### PR TITLE
Irwin download script

### DIFF
--- a/tools/bmtagger.py
+++ b/tools/bmtagger.py
@@ -1,1 +1,18 @@
-# /idi/sabeti-scratch/kandersen/bin/bmtagger/bmtagger.sh
+"tools.Tool for bmtagger.sh."
+
+import tools, util.file
+import os
+
+bmtaggerBroadUnixPath = '/idi/sabeti-scratch/kandersen/bin/bmtagger/bmtagger.sh'
+bmtaggerURL = 'ftp://ftp.ncbi.nlm.nih.gov/pub/agarwala/bmtagger/bmtagger.sh'
+#    Note that as of 2014-10-21, the version of bmtagger.sh in the mac-os directory
+#    is the same as the top level, so no need to distinguish target os.
+
+class BmtaggerTool(tools.Tool) :
+	def __init__(self, install_methods = None) :
+		if install_methods == None :
+			install_methods = []
+			install_methods.append(tools.PrexistingUnixCommand(bmtaggerBroadUnixPath,
+															   require_executability=False))
+			install_methods.append(tools.DownloadScript(bmtaggerURL, 'bmtagger.sh'))
+		tools.Tool.__init__(self, install_methods = install_methods)

--- a/tools/last.py
+++ b/tools/last.py
@@ -24,12 +24,10 @@ class DownloadAndBuildLast(tools.DownloadPackage) :
 		url = 'http://last.cbrc.jp/{}.zip'.format(self.lastWithVersion)
 		buildDir = util.file.get_build_path()
 		targetpath = os.path.join(buildDir, self.lastWithVersion, 'bin', subtoolName)
-		download_dir = tempfile.tempdir
-		unpack_dir = buildDir
+		destination_dir = buildDir
 		tools.DownloadPackage.__init__(self, url = url, targetpath = targetpath,
-									   download_dir = download_dir, unpack_dir = unpack_dir)
+									   destination_dir = destination_dir)
 	def post_download(self) :
-		self.unpack()
 		path = os.path.join(util.file.get_build_path(), self.lastWithVersion)
 		os.system('cd {}; make; make install prefix=.'.format(path))
 

--- a/tools/snpeff.py
+++ b/tools/snpeff.py
@@ -61,12 +61,11 @@ class BroadUnix(tools.PrexistingUnixCommand):
 class DownloadAndConfigJar(tools.DownloadPackage):
 	def __init__(self, url='http://downloads.sourceforge.net/project/snpeff/snpEff_v4_0_core.zip',
 		targetpath=util.file.get_build_path()+'/snpEff',
-		download_dir=tempfile.tempdir,
-		unpack_dir=util.file.get_build_path()):
+		destination_dir=util.file.get_build_path()):
 		#verifycmd='java -Xmx50M -jar %s/snpEff.jar -h -noLog &> /dev/null' % path,
 		#verifycode=65280 xxx unfortunately snpEff is not returning a meaningful code)
 		super(DownloadAndConfigJar, self).__init__(url=url, targetpath=targetpath,
-			download_dir=download_dir, unpack_dir=unpack_dir)
+			destination_dir=destination_dir)
 
 
 class SnpEffGenome:

--- a/tools/trimmomatic.py
+++ b/tools/trimmomatic.py
@@ -14,16 +14,7 @@ class TrimmomaticTool(tools.Tool) :
 		if install_methods == None :
 			install_methods = []
 			install_methods.append(tools.PrexistingUnixCommand(trimmomaticBroadUnixPath,
-															   requireExecutability=False))
-			install_methods.append(DownloadAndBuildTrimmomatic())
+															   require_executability=False))
+			install_methods.append(tools.DownloadScript(trimmomaticURL,
+														'Trimmomatic-0.32/trimmomatic-0.32.jar'))
 		tools.Tool.__init__(self, install_methods = install_methods)
-
-class DownloadAndBuildTrimmomatic(tools.DownloadPackage) :
-	def __init__(self) :
-		buildDir = util.file.get_build_path()
-		targetpath = os.path.join(buildDir, 'Trimmomatic-0.32', 'trimmomatic-0.32.jar')
-		download_dir = tempfile.tempdir
-		unpack_dir = buildDir
-		tools.DownloadPackage.__init__(self, url = trimmomaticURL, targetpath = targetpath,
-									   download_dir = download_dir, unpack_dir = unpack_dir,
-									   requireExecutability = False)


### PR DESCRIPTION
Daniel,
As I was creating tools for the various remaining commands in taxon_filter, I realized it would be nice to have a subclass of DownloadPackage that downloads stuff that doesn't require any installation except possibly unpacking. In implementing this DownloadScript class, I found some of the behaviors of DownloadPackage to be inconvenient. I changed them, but want to run the changes by you.
- I want the script to end up in the same place whether it is zipped or not, so I added a line to unpack that copies from the download_dir to the unpack_dir for files that aren't zipped or tarred.
- I renamed unpack_dir to destination_dir since it is no longer always unpacked there.
- Given this behavior, I couldn't think of any reason anyone would want a download_dir other than tempfile.gettempdir(), so I removed that argument from DownloadPackage and always use the tempdir.
- I moved the call to unpack out of post_download and put it into download.
- Unrelated to the above changes, I renamed requireExecutability to require_executability to be more consistent with your argument naming.
