### PR TITLE
Adjust verifycmd for MUSCLE

### DIFF
--- a/tools/muscle.py
+++ b/tools/muscle.py
@@ -20,12 +20,12 @@ class MuscleTool(tools.Tool) :
                 install_methods.append(
                     tools.DownloadPackage(url.format(ver=tool_version, os=muscle_os),
                         'muscle{}_{}'.format(tool_version, muscle_os),
-                        verifycmd='{}/muscle{}_{} 2> /dev/null'.format(util.file.get_build_path(), tool_version, muscle_os)))
+                        verifycmd='{}/muscle{}_{} -version 2> /dev/null'.format(util.file.get_build_path(), tool_version, muscle_os)))
             install_methods.append(
                 tools.DownloadPackage(url.format(ver=tool_version, os=muscle_os),
                     'muscle{}/src/muscle'.format(tool_version),
                     post_download_command='cd muscle{}/src; make'.format(tool_version),
-                    verifycmd='{}/muscle{}/src/muscle 2> /dev/null'.format(util.file.get_build_path(), tool_version)))
+                    verifycmd='{}/muscle{}/src/muscle -version 2> /dev/null'.format(util.file.get_build_path(), tool_version)))
         tools.Tool.__init__(self, install_methods = install_methods)
     
     def version(self) :


### PR DESCRIPTION
Without any command-line arguments, the behavior and exit code of the MUSCLE executable
depend on whether isatty(stdin). If that's not the case (as in certain unattended
environments, but evidently not Travis), it'll try to read from stdin and fail. Very
nasty to debug because it then works as expected when you try it interactively! Running
with -version is more predictable.
