### PR TITLE
ignore errors with os.chmod on non-unix file systems (ie, fat32)

### DIFF
--- a/tools/novoalign.py
+++ b/tools/novoalign.py
@@ -87,5 +87,8 @@ class NovoalignTool(tools.Tool) :
         cmd = [novoindex, outfname, fasta]
         log.debug(' '.join(cmd))
         subprocess.check_call(cmd)
-        mode = os.stat(outfname).st_mode & ~stat.S_IXUSR & ~stat.S_IXGRP & ~stat.S_IXOTH
-        os.chmod(outfname, mode)
+        try:
+            mode = os.stat(outfname).st_mode & ~stat.S_IXUSR & ~stat.S_IXGRP & ~stat.S_IXOTH
+            os.chmod(outfname, mode)
+        except PermissionError:
+            pass


### PR DESCRIPTION
novoindex likes to put executable nix files out on unix systems, so we follow it with a chmod, which fails on non-unix file systems. So just absorb the exception.