### PR TITLE
MosaikTool: fix networkFile path calculation

### DIFF
--- a/test/unit/test_tools_mosaik.py
+++ b/test/unit/test_tools_mosaik.py
@@ -1,0 +1,22 @@
+# Unit tests for Novoalign aligner
+
+__author__ = "mlin@dnanexus.com"
+
+import unittest, os.path, shutil
+import util.file, tools.mosaik
+from test import TestCaseWithTmp
+
+class TestToolMosaik(TestCaseWithTmp) :
+
+    def setUp(self):
+        super(TestToolMosaik, self).setUp()
+        self.mosaik = tools.mosaik.MosaikTool()
+        self.mosaik.install()
+
+    def test_get_networkFile(self):
+        nndir = self.mosaik.get_networkFile()
+        assert os.path.exists(os.path.join(nndir, "2.1.26.pe.100.0065.ann"))
+
+    # TO DO: further testing of Mosaik invocations
+    # system($mosaikpath."MosaikBuild -q ".$option{fq}." -q2 ".$option{fq2}." -out $readdat -st ".$option{st}." -mfl ".$option{mfl});
+    # system($mosaikpath."MosaikAligner -in $readdat -out $output -ia $refdat -hs ".$option{hs}." -act ".$option{act}." -mm 500 -mmp ".$option{mmp}." -minp ".$option{minp}." -ms ".$option{ms}." -mms ".$option{mms}." -gop ".$option{gop}." -hgop ".$option{hgop}." -gep ".$option{gep}."$bw -m ".$option{m}." -annpe ".$option{annpe}." -annse ".$option{annse});

--- a/tools/mosaik.py
+++ b/tools/mosaik.py
@@ -32,12 +32,14 @@ class MosaikTool(tools.Tool) :
     def get_networkFile(self):
         # this is the directory to return
         dir = os.path.join(util.file.get_build_path(),
+            'mosaik-{}'.format(tool_version),
             'MOSAIK-{}-source'.format(tool_version),
             'networkFile')
         if not os.path.isdir(dir):
             # if it doesn't exist, run just the download-unpack portion of the
             #     source installer
             self.get_install_methods()[-1].download()
+        assert os.path.isdir(dir)
         return dir
 
 class DownloadAndBuildMosaik(tools.DownloadPackage) :


### PR DESCRIPTION
`MosaikTool.get_networkFile` calculates the path incorrectly, causing MosaikAligner invocations to fail with:

```
FANN Error 1: Unable to open configuration file "/home/dnanexus/viral-ngs/tools/build/MOSAIK-2.1.33-source/networkFile/2.1.26.pe.100.0065.ann" for reading.
*** glibc detected *** /home/dnanexus/viral-ngs/tools/build/mosaik-2.1.33/bin/MosaikAligner: malloc(): memory corruption: 0x00007f4edc022550 ***
======= Backtrace: =========
[0x55e6e2]
[0x560d48]
[0x56291d]
...
```

It's unclear if/how this affects the pipeline results. At least for the two samples I use for automatic tests (SRR1553416 and SRR1553554), the final assemblies and BAMs are exactly the same with or without this fix.

A more general concern is that `assembly.py order_and_orient` appears to succeed in spite of the MosaikAligner failures. That's probably because of the V-FAT scripts not checking the return value of `system()` calls which is a common perl hazard. We might want to work [autodie](http://search.cpan.org/~nthykier/autodie-2.26/lib/autodie.pm) into those; perhaps this should be a separate to do issue.

Not even gonna get into the segfault... :P