### PR TITLE
Irwin better coord mapper

### DIFF
--- a/interhost.py
+++ b/interhost.py
@@ -150,18 +150,11 @@ class CoordMapper :
                 prevToPos = toArray[insertInd - 1]
                 nextToPos = toArray[insertInd]
                 assert(prevFromPos <= fromPos < nextFromPos)
-                fromLen = nextFromPos - prevFromPos
-                toLen = nextToPos - prevToPos
-                if fromLen == toLen : # No gaps
-                    result = prevToPos + (fromPos - prevFromPos)
-                elif fromLen > toLen :
-                    result = min(prevToPos + (fromPos - prevFromPos),
-                                 nextToPos - 1)
-                elif fromPos < nextFromPos - 1 :
-                    result = prevToPos + (fromPos - prevFromPos)
+                prevPlusOffset = prevToPos + (fromPos - prevFromPos)
+                if fromPos == nextFromPos - 1 and prevPlusOffset < nextToPos - 1 :
+                    result = [prevPlusOffset, nextToPos - 1]
                 else :
-                    result = [prevToPos + (fromPos - prevFromPos),
-                              nextToPos - 1]
+                    result = min(prevPlusOffset, nextToPos - 1)
             return result
 
 # ============================

--- a/interhost.py
+++ b/interhost.py
@@ -136,7 +136,7 @@ class CoordMapper :
         def __call__(self, fromPos, fromWhich) :
             "If fromWhich is 0, map from 1st sequence to 2nd, o.w. 2nd to 1st."
             if fromPos != int(fromPos) :
-                raise TypeError, 'CoordMapper: pos %s is not an integer' % fromPos
+                raise TypeError('CoordMapper: pos %s is not an integer' % fromPos)
             fromArray = self.mapArrays[fromWhich]
             toArray = self.mapArrays[1 - fromWhich]
             if fromPos < fromArray[0] or fromPos > fromArray[-1] :

--- a/interhost.py
+++ b/interhost.py
@@ -94,7 +94,7 @@ class CoordMapper2Seqs(object) :
             - Each sequence has at least one real base.
             - A gap is never aligned to a gap.
             - A gap in one sequence is never adjacent to a gap in the other;
-                there must always be an intervening real base bewteen two gaps.
+                there must always be an intervening real base between two gaps.
     """
     """
     Implementation:

--- a/test/unit/test_interhost.py
+++ b/test/unit/test_interhost.py
@@ -5,6 +5,7 @@ __author__ = "irwin@broadinstitute.org"
 import interhost
 import test, util.file
 import unittest, shutil, argparse, os
+from interhost import CoordMapper2Seqs as Cm2s
 
 class TestCommandHelp(unittest.TestCase):
     def test_help_parser_for_each_command(self):
@@ -83,3 +84,37 @@ class TestCoordMapper(test.TestCaseWithTmp):
         with self.assertRaises(Exception):
             cm = interhost.CoordMapper(genomeA, genomeB)
 
+class TestCoordMapper2Seqs(test.TestCaseWithTmp):
+    """ For the most part, CoordMapper2Seqs is tested implicitly when
+        CoordMapper is tested. Focus here on special cases that are hard
+        or impossible to get out of the aligner.
+    """
+    def test_unequal_len(self) :
+        with self.assertRaises(AssertionError) :
+            cm2s = Cm2s('AA', 'A')
+
+    def test_no_real_bases(self) :
+        with self.assertRaises(AssertionError) :
+            cm2s = Cm2s('AA', '--')
+        with self.assertRaises(AssertionError) :
+            cm2s = Cm2s('--', 'AA')
+
+    def test_aligned_gaps(self) :
+        with self.assertRaises(AssertionError) :
+            cm2s = Cm2s('A-A', 'A-A')
+
+    def test_adjacent_gaps(self) :
+        with self.assertRaises(AssertionError) :
+            cm2s = Cm2s('AC-T', 'A-GT')
+
+    def test_one_real_base(self) :
+        cm2s = Cm2s('AC-', '-CA')
+        self.assertEqual(cm2s(2, 0), 1)
+        self.assertEqual(cm2s(1, 1), 2)
+
+    def test_exactly_two_pairs(self) :
+        cm2s = Cm2s('A--T', 'AGGT')
+        self.assertEqual([cm2s(n, 0) for n in [1, 2]], [[1, 3], 4])
+        self.assertEqual([cm2s(n, 1) for n in [1, 2, 3, 4]], [1, 1, 1, 2])
+
+    


### PR DESCRIPTION
- Rewrote mapping algorithm in CoordMapper to make it simpler and much more space efficient.
- Extracted the class that does the mapping for two already-aligned sequences into CoordMapper2Seqs. This is useful for unit testing cases that are hard or impossible to get out of the aligner. It also might be useful for situations where we already have an alignment, or where we have to adjust the alignment.
- Added unit tests for CoordMapper2Seqs, including checking that the alignment doesn't have adjacent gaps in the two sequences without an intervening aligned pair of real bases.
- Space usage is now a constant plus 8 bytes per indel. For example, a mapper from ebolavirus to Reston virus takes less than 1KB; a mapper from the 28 megabase fly chromosome 3R to mosquito uses less than 400KB.