### PR TITLE
Irwin isnv merge

### DIFF
--- a/intrahost.py
+++ b/intrahost.py
@@ -271,7 +271,7 @@ def merge_to_vcf(refFasta, outVcf, samples, isnvs, assemblies):
                         cons_start = samp_to_cmap[s].mapBtoA(ref_sequence.id, pos, side = -1)[1]
                         cons_stop  = samp_to_cmap[s].mapBtoA(ref_sequence.id, end, side =  1)[1]
                         if cons_start == None or cons_stop == None :
-                            log.warn("dropping consensus because allele is outside "
+                            log.warning("dropping consensus because allele is outside "
                                 "consensus for %s at %s-%s." % (s, pos, end))
                             continue
                         seqIndex = Bio.SeqIO.index(samp_to_fasta[s], 'fasta')
@@ -283,7 +283,7 @@ def merge_to_vcf(refFasta, outVcf, samples, isnvs, assemblies):
                         if all(a in set(('A','C','T','G')) for a in allele):
                             consAlleles[s] = allele
                         else:
-                            log.warn("dropping unclean consensus for %s at %s-%s: %s" % (s, pos, end, allele))
+                            log.warning("dropping unclean consensus for %s at %s-%s: %s" % (s, pos, end, allele))
                     
                     # define genotypes and fractions
                     iSNVs = {}
@@ -323,7 +323,7 @@ def merge_to_vcf(refFasta, outVcf, samples, isnvs, assemblies):
                                     if a not in set(('A','C','T','G')):
                                         raise Exception()
                                     if f>0.5 and a!=consAllele[samp_offsets[s]]:
-                                        log.warn("vPhaser and assembly pipelines mismatch at %s:%d %s - consensus %s, vPhaser %s" % (ref_sequence.id, pos, s, consAllele[0], a))
+                                        log.warning("vPhaser and assembly pipelines mismatch at %s:%d %s - consensus %s, vPhaser %s" % (ref_sequence.id, pos, s, consAllele[0], a))
                                     new_allele = list(consAllele)
                                     new_allele[samp_offsets[s]] = a
                                     a = ''.join(new_allele)

--- a/intrahost.py
+++ b/intrahost.py
@@ -272,8 +272,9 @@ def merge_to_vcf(refFasta, outVcf, samples, isnvs, assemblies):
                         cons_start = samp_to_cmap[s].mapBtoA(ref_sequence.id, pos, side = -1)[1]
                         cons_stop  = samp_to_cmap[s].mapBtoA(ref_sequence.id, end, side =  1)[1]
                         if cons_start == None or cons_stop == None :
-                            raise NotImplementedError('Not yet implemented: allele is '
-                                'outside consensus for %s at %s-%s' % (s, pos, end))
+                            log.warn("dropping consensus because allele is outside "
+                                "consensus for %s at %s-%s." % (s, pos, end))
+                            continue
                         allele = str(cons[cons_start-1:cons_stop].seq).upper()
                         if s in samp_offsets:
                             samp_offsets[s] -= cons_start

--- a/intrahost.py
+++ b/intrahost.py
@@ -266,7 +266,15 @@ def merge_to_vcf(refFasta, outVcf, samples, isnvs, assemblies):
                     # find reference allele and consensus alleles
                     refAllele = str(ref_sequence[pos-1:end].seq)
                     consAlleles = {} # the full pos-to-end consensus assembly sequence for each sample
-                    samp_offsets = dict((row['sample'], row['s_pos']) for row in rows) # the isnv's index in the consAllele string for each sample
+                    samp_offsets = {} # {sample : isnv's index in its consAllele string}
+                    for row in rows :
+                        s_pos = row['s_pos']
+                        sample = row['sample']
+                        if samp_offsets.get(sample, s_pos) != s_pos :
+                            raise NotImplementedError('Sample %s has variants at 2 '
+                                'positions %s mapped to same reference position (%s)' %
+                                (sample, (s_pos, samp_offsets[sample]), pos))
+                        samp_offsets[sample] = s_pos
                     for s in samples:
                         cons_start = samp_to_cmap[s].mapBtoA(ref_sequence.id, pos, side = -1)[1]
                         cons_stop  = samp_to_cmap[s].mapBtoA(ref_sequence.id, end, side =  1)[1]

--- a/intrahost.py
+++ b/intrahost.py
@@ -268,14 +268,16 @@ def merge_to_vcf(refFasta, outVcf, samples, isnvs, assemblies):
                     consAlleles = {} # the full pos-to-end consensus assembly sequence for each sample
                     samp_offsets = dict((row['sample'], row['s_pos']) for row in rows) # the isnv's index in the consAllele string for each sample
                     for s in samples:
-                        cons = Bio.SeqIO.index(samp_to_fasta[s], 'fasta')[samp_to_cmap[s].mapBtoA(ref_sequence.id)]
                         cons_start = samp_to_cmap[s].mapBtoA(ref_sequence.id, pos, side = -1)[1]
                         cons_stop  = samp_to_cmap[s].mapBtoA(ref_sequence.id, end, side =  1)[1]
                         if cons_start == None or cons_stop == None :
                             log.warn("dropping consensus because allele is outside "
                                 "consensus for %s at %s-%s." % (s, pos, end))
                             continue
+                        seqIndex = Bio.SeqIO.index(samp_to_fasta[s], 'fasta')
+                        cons = seqIndex[samp_to_cmap[s].mapBtoA(ref_sequence.id)]
                         allele = str(cons[cons_start-1:cons_stop].seq).upper()
+                        seqIndex.close()
                         if s in samp_offsets:
                             samp_offsets[s] -= cons_start
                         if all(a in set(('A','C','T','G')) for a in allele):

--- a/test/unit/test_intrahost.py
+++ b/test/unit/test_intrahost.py
@@ -408,6 +408,21 @@ class TestVcfMerge(test.TestCaseWithTmp):
         self.assertEqual(rows[0][1], '1:0.8,0.0,0.2,0.0')
         self.assertEqual(rows[0][2], '1:0.9,0.0,0.0,0.1')
 
+    def test_2snps_within_insertion_same_sample(self):
+        # Sample assembly has insertion against reference containing two SNPs
+        # in the same sample.
+        # We don't handle this because we can't see phasing; it should be
+        #     handled by the variant caller.
+        # REF:  ATCG--GACT
+        # S1:   ATCGTTGACT
+        # isnv:     C
+        # isnv:      C 
+        merger = VcfMergeRunner([('ref1', 'ATCGGACT')])
+        merger.add_genome('s1', [('s1_1',  'ATCGTTGACT')])
+        merger.add_snp('s1', 's1_1', 5, [('T', 80, 80), ('C', 20, 20)])
+        merger.add_snp('s1', 's1_1', 6, [('T', 90, 90), ('C', 10, 10)])
+        self.assertRaises(NotImplementedError, merger.run_and_get_vcf_rows)
+
     def test_deletion_past_end_of_some_consensus(self):
         # Some sample contains a deletion beyond the end of the consensus
         # sequence of another sample with a SNP. It should skip latter rather


### PR DESCRIPTION
I'm done reviewing merge_to_vcf. Here's what I changed:
- Handle variants beyond the end of some consensus sequence by ignoring that sample for those variants. Added two tests for this case.
- The reason I had trouble with it originally was due to errors in my test. To prevent that in the future, added some consistency checks in VcfMergeRunner. We might want to put those into merge_to_vcf if we don't trust the input from vphaser.
- Raise if there are SNPs at several different positions in the same sample that map to the same reference position.
- Did some clean up including removing python3 warnings, wrapping long lines, and making comments easier for me to understand.