### PR TITLE
Addition of MAFFT as argparse-accessible tool

### DIFF
--- a/interhost.py
+++ b/interhost.py
@@ -13,7 +13,7 @@ try :
     from itertools import zip_longest
 except ImportError :
     from itertools import izip_longest as zip_longest
-import tools.muscle, tools.snpeff
+import tools.muscle, tools.snpeff, tools.mafft
 import util.cmd, util.file, util.vcf
 from collections import OrderedDict, Sequence
 
@@ -203,6 +203,60 @@ def parser_snpEff(parser=argparse.ArgumentParser()):
     return parser
 __commands__.append(('snpEff', parser_snpEff))
 
+
+# =======================
+# ***  align_mafft  ***
+# =======================
+
+def parser_align_mafft(parser=argparse.ArgumentParser()):
+    parser.add_argument('inFastas', nargs='+',
+        help='Input FASTA files.')
+    parser.add_argument('outFile',
+        help='Output file containing alignment result (default format: FASTA)')
+    parser.add_argument('--localpair', default=None, action='store_true',
+        help='All pairwise alignments are computed with the Smith-Waterman algorithm.')
+    parser.add_argument('--globalpair', default=None, action='store_true',
+        help='All pairwise alignments are computed with the Needleman-Wunsch algorithm.')
+    parser.add_argument('--preservecase', default=None, action='store_true',
+        help='Preserve base or aa case, as well as symbols.')
+    parser.add_argument('--reorder', default=None, action='store_true',
+        help='Output is ordered aligned rather than in the order of the input (default: %(default)s).')
+    parser.add_argument('--gapOpeningPenalty', default=1.53,
+        help='Gap opening penalty (default: %(default)s).')
+    parser.add_argument('--ep',
+        help='Offset (works like gap extension penalty).')
+    parser.add_argument('--verbose', default=False, action='store_true',
+        help='Full output (default: %(default)s).')
+    parser.add_argument('--outputAsClustal', default=None, action='store_true',
+        help='Write output file in Clustal format rather than FASTA')
+    parser.add_argument('--maxiters', default = 0,
+        help='Maximum number of refinement iterations (default: %(default)s).')
+    parser.add_argument('--threads', default = 1,
+        help='Number of processing threads (default: %(default)s).')
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.attach_main(parser, main_align_mafft)
+    return parser
+
+def main_align_mafft(args):
+    ''' Run the mafft alignment on the input FASTA file.'''
+
+    tools.mafft.MafftTool().execute( 
+                inFastas           = args.inFastas, 
+                outFile           = args.outFile, 
+                localpair         = args.localpair, 
+                globalpair        = args.globalpair, 
+                preservecase      = args.preservecase, 
+                reorder           = args.reorder, 
+                gapOpeningPenalty = args.gapOpeningPenalty, 
+                offset            = args.ep, 
+                verbose           = args.verbose, 
+                outputAsClustal   = args.outputAsClustal, 
+                maxiters          = args.maxiters, 
+                threads           = args.threads
+    )
+
+    return 0
+__commands__.append(('align_mafft', parser_align_mafft))
 
 # ============================
 

--- a/interhost.py
+++ b/interhost.py
@@ -222,17 +222,17 @@ def parser_align_mafft(parser=argparse.ArgumentParser()):
         help='Preserve base or aa case, as well as symbols.')
     parser.add_argument('--reorder', default=None, action='store_true',
         help='Output is ordered aligned rather than in the order of the input (default: %(default)s).')
-    parser.add_argument('--gapOpeningPenalty', default=1.53,
+    parser.add_argument('--gapOpeningPenalty', default=1.53, type=float,
         help='Gap opening penalty (default: %(default)s).')
-    parser.add_argument('--ep',
+    parser.add_argument('--ep', type=float,
         help='Offset (works like gap extension penalty).')
     parser.add_argument('--verbose', default=False, action='store_true',
         help='Full output (default: %(default)s).')
     parser.add_argument('--outputAsClustal', default=None, action='store_true',
         help='Write output file in Clustal format rather than FASTA')
-    parser.add_argument('--maxiters', default = 0,
+    parser.add_argument('--maxiters', default = 0, type=int,
         help='Maximum number of refinement iterations (default: %(default)s). Note: if "--localpair" or "--globalpair" is specified this defaults to 1000.')
-    parser.add_argument('--threads', default = -1,
+    parser.add_argument('--threads', default = -1, type=int,
         help='Number of processing threads (default: %(default)s, where -1 indicates use of all available cores).')
     util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
     util.cmd.attach_main(parser, main_align_mafft)

--- a/interhost.py
+++ b/interhost.py
@@ -213,9 +213,10 @@ def parser_align_mafft(parser=argparse.ArgumentParser()):
         help='Input FASTA files.')
     parser.add_argument('outFile',
         help='Output file containing alignment result (default format: FASTA)')
-    parser.add_argument('--localpair', default=None, action='store_true',
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--localpair', default=None, action='store_true',
         help='All pairwise alignments are computed with the Smith-Waterman algorithm.')
-    parser.add_argument('--globalpair', default=None, action='store_true',
+    group.add_argument('--globalpair', default=None, action='store_true',
         help='All pairwise alignments are computed with the Needleman-Wunsch algorithm.')
     parser.add_argument('--preservecase', default=None, action='store_true',
         help='Preserve base or aa case, as well as symbols.')
@@ -230,15 +231,18 @@ def parser_align_mafft(parser=argparse.ArgumentParser()):
     parser.add_argument('--outputAsClustal', default=None, action='store_true',
         help='Write output file in Clustal format rather than FASTA')
     parser.add_argument('--maxiters', default = 0,
-        help='Maximum number of refinement iterations (default: %(default)s).')
-    parser.add_argument('--threads', default = 1,
-        help='Number of processing threads (default: %(default)s).')
+        help='Maximum number of refinement iterations (default: %(default)s). Note: if "--localpair" or "--globalpair" is specified this defaults to 1000.')
+    parser.add_argument('--threads', default = -1,
+        help='Number of processing threads (default: %(default)s, where -1 indicates use of all available cores).')
     util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
     util.cmd.attach_main(parser, main_align_mafft)
     return parser
 
 def main_align_mafft(args):
     ''' Run the mafft alignment on the input FASTA file.'''
+
+    if int(args.threads) == 0 or int(args.threads) < -1:
+        raise argparse.ArgumentTypeError('Argument "--threads" must be non-zero. Specify "-1" to use all available cores.')
 
     tools.mafft.MafftTool().execute( 
                 inFastas           = args.inFastas, 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
+# Package source, listed here for clarity:
+--index-url https://pypi.python.org/simple/
+
 biopython==1.64
 pysam==0.8.1

--- a/tools/mafft.py
+++ b/tools/mafft.py
@@ -50,8 +50,6 @@ class MafftTool(tools.Tool):
             inputFiles.append(os.path.abspath(f))
         outFile = os.path.abspath(outFile)
 
-        print "outfile: {}".format(outFile)
-
         # if multiple fasta files are specified for input
         if len(inputFiles)>1:
             # combined specified input files into a single temp FASTA file so MAFFT can read them
@@ -68,8 +66,6 @@ class MafftTool(tools.Tool):
         # if there is only once file specified, just use it
         else:
             inputFileName = inputFiles[0]
-
-        print "BASE PATH: {}".format(os.path.dirname(self.install_and_get_path()))
 
         # change the pwd, since the shell script that comes with mafft depends on the pwd
         # being correct

--- a/tools/mafft.py
+++ b/tools/mafft.py
@@ -39,7 +39,7 @@ class MafftTool(tools.Tool):
         return tool_version
 
     def execute(self, inFastas, outFile, localpair, globalpair, preservecase, reorder, 
-                outputAsClustal, maxiters, gapOpeningPenalty=None, offset=None, threads=1, verbose=True):
+                outputAsClustal, maxiters, gapOpeningPenalty=None, offset=None, threads=-1, verbose=True):
 
         inputFileName         = ""
         tempCombinedInputFile = ""
@@ -57,9 +57,9 @@ class MafftTool(tools.Tool):
             for filePath in inputFiles:
                 tempFileSuffix += "__" + os.path.basename(filePath)
             tempCombinedInputFile = util.file.mkstempfname('__combined.{}'.format(tempFileSuffix))
-            with open(tempCombinedInputFile, "wb") as outfile:
+            with open(tempCombinedInputFile, "w") as outfile:
                 for f in inputFiles:
-                    with open(f, "rb") as infile:
+                    with open(f, "r") as infile:
                         outfile.write(infile.read())
                 #outFile.close()
             inputFileName = tempCombinedInputFile
@@ -109,7 +109,7 @@ class MafftTool(tools.Tool):
         log.debug(' '.join(toolCmd))
 
         # run the MAFFT alignment
-        with open(outFile, 'wb') as outf:
+        with open(outFile, 'w') as outf:
             subprocess.check_call(toolCmd, stdout=outf)
 
         if len(tempCombinedInputFile):

--- a/tools/mafft.py
+++ b/tools/mafft.py
@@ -1,0 +1,139 @@
+'''
+    MAFFT - Multiple alignment program for amino acid or nucleotide sequences
+    http://mafft.cbrc.jp/alignment/software/
+'''
+
+__author__ = "tomkinsc@broadinstitute.org"
+
+import logging, tools, util.file
+import os, os.path, subprocess
+
+tool_version = '7.220'
+url = 'http://mafft.cbrc.jp/alignment/software/mafft-{ver}-{os}.{ext}'
+
+log = logging.getLogger(__name__)
+
+class MafftTool(tools.Tool):
+    def __init__(self, install_methods = None):
+        if install_methods == None:
+            install_methods = []
+            mafft_os                = get_mafft_os()
+            mafft_bitdepth          = get_mafft_bitdepth()
+            mafft_archive_extension = get_mafft_archive_extension(mafft_os)
+            binaryPath = get_mafft_binary_path(mafft_os, mafft_bitdepth)
+
+            install_methods.append(
+                    tools.DownloadPackage( url.format(ver=tool_version, os=mafft_os, ext=mafft_archive_extension),
+                    '{binPath}'.format(ver=tool_version, os=mafft_os, binPath=binaryPath),
+                    verifycmd='{dir}/{binPath} --version > /dev/null 2>&1'.format(dir=util.file.get_build_path(), ver=tool_version, os=mafft_os, binPath=binaryPath)))
+
+        tools.Tool.__init__(self, install_methods = install_methods)
+
+    def version(self):
+        return tool_version
+
+    def execute(self, inFastas, outFile, localpair, globalpair, preservecase, reorder, 
+                outputAsClustal, maxiters, gapOpeningPenalty=None, offset=None, threads=1, verbose=True):
+
+        inputFileName         = ""
+        tempCombinedInputFile = ""
+
+        # get the full paths of input and output files in case the user has specified relative paths
+        inputFiles = []
+        for f in inFastas:
+            inputFiles.append(os.path.abspath(f))
+        outFile = os.path.abspath(outFile)
+
+        # if multiple fasta files are specified for input
+        if len(inputFiles)>1:
+            # combined specified input files into a single temp FASTA file so MAFFT can read them
+            tempFileSuffix = ""
+            for filePath in inputFiles:
+                tempFileSuffix += "__" + os.path.basename(filePath)
+            tempCombinedInputFile = util.file.mkstempfname('__combined.{}'.format(tempFileSuffix))
+            with open(tempCombinedInputFile, "wb") as outfile:
+                for f in inputFiles:
+                    with open(f, "rb") as infile:
+                        outfile.write(infile.read())
+                #outFile.close()
+            inputFileName = tempCombinedInputFile
+        # if there is only once file specified, just use it
+        else:
+            inputFileName = inputFiles[0]
+
+        # build the MAFFT command
+        toolCmd = [self.install_and_get_path()]
+
+        toolCmd.append("--auto")
+        toolCmd.append("--thread {}".format( max( int(threads), 1 )) )
+
+        if localpair and globalpair:
+            raise Exception("Alignment type must be either local or global, not both.")
+
+        if localpair:
+            toolCmd.append("--localpair")
+            if not maxiters:
+                maxiters = 1000
+        if globalpair:
+            toolCmd.append("--globalpair")
+            if not maxiters:
+                maxiters = 1000
+        if preservecase:
+            toolCmd.append("--preservecase")
+        if reorder:
+            toolCmd.append("--reorder")
+        if gapOpeningPenalty:
+            toolCmd.append("--op {penalty}".format(penalty=gapOpeningPenalty))
+        if offset:
+            toolCmd.append("--ep {num}".format(num=offset))
+        if not verbose:
+            toolCmd.append("--quiet")
+        if outputAsClustal:
+            toolCmd.append("--clustalout")
+        if maxiters:
+            toolCmd.append("--maxiterate {iters}".format(iters=maxiters))
+        
+        toolCmd.append(tempCombinedInputFile)
+
+        log.debug(' '.join(toolCmd))
+
+        # run the MAFFT alignment
+        with open(outFile, 'wb') as outf:
+            subprocess.check_call(toolCmd, stdout=outf)
+
+        if len(tempCombinedInputFile):
+            # remove temp FASTA file
+            os.unlink(tempCombinedInputFile)
+
+def get_mafft_os():
+    uname = os.uname()
+    if uname[0] == "Darwin":
+        return "mac"
+    if uname[0] == "Linux":
+        return "linux"
+
+def get_mafft_archive_extension(mafft_os):
+    if mafft_os == "mac":
+        return "zip"
+    elif mafft_os == "linux":
+        return "tgz"
+
+def get_mafft_bitdepth():
+    uname = os.uname()
+    if uname[4] == "x86_64":
+        return "64"
+    if uname[4] == "x86":
+        return "32"
+
+def get_mafft_binary_path(mafft_os, bitdepth):
+    mafftPath = ""
+
+    if mafft_os == "mac":
+        mafftPath += "mafft-mac/"
+    elif mafft_os == "linux":
+        mafftPath += "mafft-linux{bit}".format(bit=bitdepth) + "/"
+
+    mafftPath += "mafft.bat"
+
+    return mafftPath
+

--- a/tools/mafft.py
+++ b/tools/mafft.py
@@ -22,10 +22,15 @@ class MafftTool(tools.Tool):
             mafft_archive_extension = get_mafft_archive_extension(mafft_os)
             binaryPath = get_mafft_binary_path(mafft_os, mafft_bitdepth)
 
+            target_rel_path = '{binPath}'.format(ver=tool_version, os=mafft_os, binPath=binaryPath)
+            verify_command  = '{dir}/mafft-{ver}/{binPath} --version > /dev/null 2>&1'.format(dir=util.file.get_build_path(), ver=tool_version, os=mafft_os, binPath=binaryPath) 
+            destination_dir = '{dir}/mafft-{ver}'.format(dir=util.file.get_build_path(), ver=tool_version, os=mafft_os, binPath=binaryPath)
+
             install_methods.append(
                     tools.DownloadPackage( url.format(ver=tool_version, os=mafft_os, ext=mafft_archive_extension),
-                    '{binPath}'.format(ver=tool_version, os=mafft_os, binPath=binaryPath),
-                    verifycmd='{dir}/{binPath} --version > /dev/null 2>&1'.format(dir=util.file.get_build_path(), ver=tool_version, os=mafft_os, binPath=binaryPath)))
+                    target_rel_path=target_rel_path,
+                    destination_dir=destination_dir,
+                    verifycmd=verify_command))
 
         tools.Tool.__init__(self, install_methods = install_methods)
 
@@ -93,7 +98,7 @@ class MafftTool(tools.Tool):
         if maxiters:
             toolCmd.append("--maxiterate {iters}".format(iters=maxiters))
         
-        toolCmd.append(tempCombinedInputFile)
+        toolCmd.append(inputFileName)
 
         log.debug(' '.join(toolCmd))
 

--- a/tools/mafft.py
+++ b/tools/mafft.py
@@ -127,7 +127,7 @@ def get_mafft_bitdepth():
     uname = os.uname()
     if uname[4] == "x86_64":
         return "64"
-    if uname[4] == "x86":
+    if uname[4] in ['i386','i686',"x86"]:
         return "32"
 
 def get_mafft_binary_path(mafft_os, bitdepth):


### PR DESCRIPTION
Per issues #118 and #119: MAFFT has been added as an argparse-accessible tool to interhost.py.

The installation test [passes](https://travis-ci.org/broadinstitute/viral-ngs/builds/57679951), and the alignment has been tested for function manually on Max OSX 10.10, Ubuntu 14.04, and the Broad's RHEL and CentOS servers.