### PR TITLE
added .coveragerc so code can be excluded from test coverage reports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,14 @@
+# .coveragerc to control test coverage report
+[report]
+
+exclude_lines =
+    pragma: no cover
+
+    #raise AssertionError
+    raise NotImplementedError
+
+    def __repr__
+    if self\.debug
+
+    if 0:
+    if __name__ == .__main__.:


### PR DESCRIPTION
blocks can either be commented with “#pragma: no cover”, or raise
NotImplementedError. __repr__ methods are also ignored, as is ‘if
__name__ == “__main__” ‘