### PR TITLE
Ct update mosaik

### DIFF
--- a/tools/mosaik.py
+++ b/tools/mosaik.py
@@ -9,8 +9,8 @@ import subprocess
 import tools
 import util.file
 
-tool_version = '2.1.33'
-url = 'https://mosaik-aligner.googlecode.com/files/MOSAIK-{ver}-{os}.tar'
+commit_hash = '5c25216d3522d6a33e53875cd76a6d65001e4e67'
+url = 'https://github.com/wanpinglee/MOSAIK/archive/{commit_hash}.zip'
 
 log = logging.getLogger(__name__)
 
@@ -24,9 +24,9 @@ class MosaikTool(tools.Tool):
             else:
                 os.environ['BLD_PLATFORM'] = 'macosx'
         install_methods = []
-        destination_dir = os.path.join(util.file.get_build_path(), 'mosaik-{}'.format(tool_version))
+        destination_dir = os.path.join(util.file.get_build_path(), 'mosaik-{}'.format(commit_hash))
         install_methods.append(
-            DownloadAndBuildMosaik(url.format(ver=tool_version,
+            DownloadAndBuildMosaik(url.format(commit_hash=commit_hash,
                                               os='source'),
                                    os.path.join(destination_dir, 'bin', 'MosaikAligner'),
                                    destination_dir))
@@ -37,8 +37,8 @@ class MosaikTool(tools.Tool):
 
     def get_networkFile(self):
         # this is the directory to return
-        dir = os.path.join(util.file.get_build_path(), 'mosaik-{}'.format(tool_version),
-                           'MOSAIK-{}-source'.format(tool_version), 'networkFile')
+        dir = os.path.join(util.file.get_build_path(), 'mosaik-{}'.format(commit_hash),
+                           'MOSAIK-{}/src'.format(commit_hash), 'networkFile')
         if not os.path.isdir(dir):
             # if it doesn't exist, run just the download-unpack portion of the
             #     source installer
@@ -50,15 +50,7 @@ class MosaikTool(tools.Tool):
 class DownloadAndBuildMosaik(tools.DownloadPackage):
 
     def post_download(self):
-        mosaikDir = os.path.join(self.destination_dir, 'MOSAIK-{}-source'.format(tool_version))
-        if tool_version == "2.1.33":
-            # In this version, obsolete LDFLAGS breaks make. Remove it
-            makeFilePath = os.path.join(mosaikDir, 'Makefile')
-            os.rename(makeFilePath, makeFilePath + '.orig')
-            with open(makeFilePath + '.orig') as inf:
-                makeText = inf.read()
-            with open(makeFilePath, 'wt') as outf:
-                outf.write(makeText.replace('export LDFLAGS = -Wl', '#export LDFLAGS = -Wl'))
+        mosaikDir = os.path.join(self.destination_dir, 'MOSAIK-{}/src'.format(commit_hash))
 
         # Now we can make:
         os.system('cd "{}" && make -s'.format(mosaikDir))

--- a/tools/mosaik.py
+++ b/tools/mosaik.py
@@ -25,12 +25,11 @@ class MosaikTool(tools.Tool):
             else:
                 os.environ['BLD_PLATFORM'] = 'macosx'
         install_methods = []
-        destination_dir = os.path.join(util.file.get_build_path(), 'mosaik-{}'.format(commit_hash), 'MOSAIK-{}'.format(commit_hash))
-        print("destination_dir", destination_dir)
+        destination_dir = os.path.join(util.file.get_build_path(), 'mosaik-{}'.format(commit_hash))
         install_methods.append(
             DownloadAndBuildMosaik(url.format(commit_hash=commit_hash,
                                               os='source'),
-                                   os.path.join(destination_dir, 'bin', 'MosaikAligner'),
+                                   os.path.join(destination_dir, 'MOSAIK-{}'.format(commit_hash), 'bin', 'MosaikAligner'),
                                    destination_dir))
         tools.Tool.__init__(self, install_methods=install_methods)
 
@@ -39,8 +38,7 @@ class MosaikTool(tools.Tool):
 
     def get_networkFile(self):
         # this is the directory to return
-        dir = os.path.join(util.file.get_build_path(), 'mosaik-{}'.format(commit_hash),
-                           'MOSAIK-{}/src'.format(commit_hash), 'networkFile')
+        dir = os.path.join(util.file.get_build_path(), 'mosaik-{}'.format(commit_hash), 'MOSAIK-{}'.format(commit_hash) , 'src', 'networkFile')
         if not os.path.isdir(dir):
             # if it doesn't exist, run just the download-unpack portion of the
             #     source installer

--- a/tools/mosaik.py
+++ b/tools/mosaik.py
@@ -9,6 +9,7 @@ import subprocess
 import tools
 import util.file
 
+tool_version = '2.2.30'
 commit_hash = '5c25216d3522d6a33e53875cd76a6d65001e4e67'
 url = 'https://github.com/wanpinglee/MOSAIK/archive/{commit_hash}.zip'
 
@@ -24,7 +25,8 @@ class MosaikTool(tools.Tool):
             else:
                 os.environ['BLD_PLATFORM'] = 'macosx'
         install_methods = []
-        destination_dir = os.path.join(util.file.get_build_path(), 'mosaik-{}'.format(commit_hash))
+        destination_dir = os.path.join(util.file.get_build_path(), 'mosaik-{}'.format(commit_hash), 'MOSAIK-{}'.format(commit_hash))
+        print("destination_dir", destination_dir)
         install_methods.append(
             DownloadAndBuildMosaik(url.format(commit_hash=commit_hash,
                                               os='source'),
@@ -33,7 +35,7 @@ class MosaikTool(tools.Tool):
         tools.Tool.__init__(self, install_methods=install_methods)
 
     def version(self):
-        return tool_version
+        return commit_hash
 
     def get_networkFile(self):
         # this is the directory to return


### PR DESCRIPTION
Since Google Code is deprecated, development of MOSAIK seems to have
shifted to [GitHub](https://github.com/wanpinglee/MOSAIK). Old versions of MOSAIK were not building on Ubuntu
15.04, while the new ones from GitHub do build. The MOSAIK tool wrapper
has been updated to download from GitHub. Since the MOSAIK author is
not using tagged releases, the tool download is pinned to a commit hash rather than a version number.

The new version of MOSAIK has a few bug fixes and improvements compared to the version we were using previously (2.1.33).