### PR TITLE
Ct easy deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ test/input/TestVPhaser2/in.bam.bti
 easy-deploy/data/Snakefile
 
 easy-deploy/data/config.json
+
+easy-deploy/.vagrant/

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ nosetests.xml
 coverage.xml
 
 test/input/TestVPhaser2/in.bam.bti
+
+easy-deploy/data/Snakefile
+
+easy-deploy/data/config.json

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -2,8 +2,11 @@ Installation
 ============
 
 
-System dependencies
+Manual Installation
 -------------------
+
+System dependencies
+~~~~~~~~~~~~~~~~~~~
 
 This is known to install cleanly on most modern Linux systems with Python,
 Java, and some basic development libraries.  On Ubuntu 14.04 LTS, the
@@ -29,7 +32,7 @@ following APT packages should be installed on top of the vanilla setup::
 
 
 Python dependencies
--------------------
+~~~~~~~~~~~~~~~~~~~
 
 The **command line tools** require Python >= 2.7 or >= 3.4. Required packages
 (pysam and Biopython) are listed in requirements.txt and can be
@@ -50,7 +53,7 @@ You should either sudo pip install or use a virtualenv (recommended).
 
 
 Tool dependencies
------------------
+~~~~~~~~~~~~~~~~~
 
 A lot of effort has gone into writing auto download/compile wrappers for
 most of the bioinformatic tools we rely on here. They will auto-download
@@ -67,8 +70,8 @@ set environment variables pointing to their installed location.
  * GATK - http://www.broadinstitute.org/gatk/
  * Novoalign - http://www.novocraft.com/products/novoalign/
 
-The environment variables you will need to set are GATK_PATH and
-NOVOALIGN_PATH. These should be set to the full directory path
+The environment variables you will need to set are ``GATK_PATH`` and
+``NOVOALIGN_PATH``. These should be set to the full directory path
 that contains these tools (the jar file for GATK and the executable
 binaries for Novoalign).
 
@@ -84,3 +87,64 @@ to running any scripts.
 The version of MOSAIK we use seems to fail compile on GCC-4.9 but compiles
 fine on GCC-4.4. We have not tried intermediate versions of GCC, nor the
 latest versions of MOSAIK.
+
+Virtualized Installation (Easy Deploy)
+--------------------------------------
+
+The viral-ngs package includes a script that can be used to set up a complete virtualized 
+environment for running viral-ngs either on a local machine via VirtualBox, or on AWS EC2. 
+This is an easiesr way to get the software up and running, as it sets up most 
+dependencies automatically within an environment known to work.
+
+Requirements
+~~~~~~~~~~~~
+
+As noted above, GATK and NovoAlign cannot be installed automatically due to 
+licensing restrictions. In order to run the easy deployment script, you will
+first need to license and download these tools, and set the ``GATK_PATH`` and 
+``NOVOALIGN_PATH`` environment variables. 
+
+The easy deployment script has been tested to run on OS X 10.10 (Yosemite) and
+Ubuntu 15.04 (Vivid Vervet).
+
+
+Requirements for running on AWS EC2
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In order to deploy a virtualized viral-ngs environment to AWS EC2, you will first need
+to set up the appropriate credentials for creating EC2 instances. AWS credentials and 
+SSH keypairs are passed in as environment variables, and ``run.sh`` will prompt for 
+the values if the environment variables are not set (though the values given 
+interactively are ephemeral).
+
+The following environment variables are needed:
+
+ * ``EC2_ACCESS_KEY_ID``
+ * ``EC2_SECRET_ACCESS_KEY``
+ * ``EC2_REGION`` (ex. "us-west-2")
+ * ``EC2_KEYPAIR_NAME`` (ex. "my-ssh-keypair")
+ * ``EC2_PRIVATE_KEY_PATH`` (ex. "my-ssh-keypair.pem")
+
+ 
+Limitations
+~~~~~~~~~~~
+
+As viral-ngs does not currently build a depletion database for BMTagger or BLAST automatically, 
+it is the responsibility of the user to create a depletion database for use within the virtualized
+viral-ngs environment. It can be created within the virtual machine (VM), or uploaded
+after the fact via ``rsync``.
+
+Running Easy Deploy
+~~~~~~~~~~~~~~~~~~~
+
+Running Easy Deploy to create a virtualized viral-ngs environment is as simple as running ``easy-deploy/run.sh``. Before running this script, copy any data you wish to have in the vm to the ``easy-deploy/data`` directory on your local machine. During setup, the 
+files will be copied into the ``~/data/`` directory of virtual machine.
+
+To start, the script ``run.sh`` installs the necessary dependencies on the user's machine (ansible, vagrant, virtualbox, and virtualbox-aws). The provisioning is handled by Ansible, with Vagrant handling creation of the VMs and EC2 instances. On OSX it depends on Homebrew, and will install it if it is not present. It depends on having apt on linux. Ruby >=2.0 is required for vagrant-aws, so versions of Ubuntu older than 15.04 (notably 14.04 LTS) will need to have ruby >=2.0 installed and made default.
+
+Details on Easy Deploy
+~~~~~~~~~~~~~~~~~~~~~~
+
+Per the Vagrantfile, local VM RAM usage is set to 8GB. On EC2 it currently uses an m4.2xlarge instance with 32GB of RAM and 8 vCPUs.
+
+Ansible clones the master branch of viral-ngs from GitHub, creates a Python 3 virtual environment, and installs the viral-ngs Python dependencies. The viral-ngs tool unit tests are run to download, install, and build all of the viral-ngs tools. A ``Snakefile`` for viral-ngs is copied to the home directory of the VM (locally: ``/home/vagrant/``, on EC2: /home/ubuntu/), along with an associated ``config.json`` file. Files to contain sample names (``sample-depletion.txt``, etc.) are also created. A directory is created within the VM, ``~/data/``, to store data to be processed. This directory on the VM is synced to the ``./data/`` directory on the host machine, relative to the location of the ``easy-deploy/Vagrantfile``. On local VMs, syncing of the directory is two-way and fast. On EC2 instances, the syncing is currently one way (local->EC2) due to Vagrant limitations.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -57,7 +57,7 @@ most of the bioinformatic tools we rely on here. They will auto-download
 and install the first time they are needed by any command. If you want
 to pre-install all of the external tools, simply type this::
 
-  python -m unittest test.test_tools.TestToolsInstallation -v
+  python -m unittest test.unit.test_tools.TestToolsInstallation -v
 
 However, there are two tools in particular that cannot be auto-installed
 due to licensing restrictions.  You will need to download and install

--- a/easy-deploy/Vagrantfile
+++ b/easy-deploy/Vagrantfile
@@ -1,44 +1,48 @@
 Vagrant.configure("2") do |config|
-  #config.vm.provision :ansible, :playbook => 'ansible-playbook.yml'
-
-  user_name = "vagrant"
-
-  config.vm.provision "ansible" do |ansible|
-      ansible.playbook = "ansible-playbook.yml"
-      #ansible.sudo = true
-      #ansible.sudo_user = user_name
-      ansible.extra_vars = {
-        user: user_name,
-      }
-  end
-
   # This configuration is for our local box, when we use virtualbox as the provider
   config.vm.provider :virtualbox do |vb, override|
-    #override.ssh.username = "viral-ngs-user"
     vb.customize ["modifyvm", :id, "--memory", 4096]
     config.vm.hostname = "viral-ngs-vm"
-    config.vm.synced_folder "./data/", "/home/vagrant/data/", create: true
-    #config.vm.synced_folder "../", "/home/vagrant/viral-ngs/", create: true
+    
     override.vm.box = "viral-ngs-vm"
-    #override.vm.box = "ubuntu/trusty64"
     override.vm.box = "ubuntu/vivid64"
+
+    override.vm.synced_folder ".", "/vagrant", disabled: true
+    override.vm.synced_folder "./data/", "/home/vagrant/data/", create: true
+
+    override.vm.provision "ansible" do |ansible|
+        ansible.playbook = "ansible-playbook.yml"
+        ansible.extra_vars = {
+          user: "vagrant",
+        }
+    end
   end
 
   # This configuration is for our EC2 instance
   config.vm.provider :aws do |aws, override|
-    aws.access_key_id = "access key"
-    aws.secret_access_key = "secret access key"
+    aws.access_key_id = ENV["EC2_ACCESS_KEY_ID"]
+    aws.secret_access_key = ENV["EC2_SECRET_ACCESS_KEY"]
     # ubuntu AMI, see: https://cloud-images.ubuntu.com/locator/ec2/
-    # Trusty 14.04 LTS, amd64 hvm:ebs-ssd @ us-east-1
-    #aws.ami = "ami-3387fe56"
-    # Vivid 15.04, amd64 hvm:ebs-ssd @ us-east-1
-    aws.ami = "ami-f3caa396"
-    aws.keypair_name = "viral-ngs-user"
-    #aws.security_groups = ["default", "quicklaunch-1"]
+    # Vivid 15.04, amd64 hvm:ebs-ssd @ us-west-2
+    aws.ami = "ami-73b4af43"
+    aws.keypair_name = "tomkinsc-us-west-2"
+    aws.region = "us-west-2"
+    #aws.security_groups = ["sg-3a2c025f"]
 
     override.vm.box = "viral-ngs-vm"
     override.vm.box_url = "https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box"
-    override.ssh.username = "viral-ngs-user"
-    override.ssh.private_key_path = "vagrant.pem"
-  end
+    override.ssh.username = "ubuntu"
+    override.ssh.private_key_path = "tomkinsc-us-west-2.pem"
+
+    override.vm.synced_folder ".", "/ubuntu", disabled: true
+    override.vm.synced_folder "./data/", "/home/ubuntu/data/", create: true
+
+    override.vm.provision "ansible" do |ansible|
+        ansible.playbook = "ansible-playbook.yml"
+        ansible.extra_vars = {
+          user: "ubuntu",
+        }
+    end
+  end 
+
 end

--- a/easy-deploy/Vagrantfile
+++ b/easy-deploy/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure("2") do |config|
   config.vm.provider :virtualbox do |vb, override|
-    vb.customize ["modifyvm", :id, "--memory", 4096]
+    vb.customize ["modifyvm", :id, "--memory", 8192]
     config.vm.hostname = "viral-ngs-vm"
     
     override.vm.box = "viral-ngs-vm"
@@ -23,6 +23,8 @@ Vagrant.configure("2") do |config|
     # ubuntu AMI, see: https://cloud-images.ubuntu.com/locator/ec2/
     # Vivid 15.04, amd64 hvm:ebs-ssd @ us-west-2
     aws.ami = "ami-73b4af43"
+    aws.instance_type = "m4.2xlarge"
+    aws.instance_ready_timeout = 180 # default: 120
     aws.keypair_name = ENV["EC2_KEYPAIR_NAME"]
     aws.region = ENV["EC2_REGION"]
 

--- a/easy-deploy/Vagrantfile
+++ b/easy-deploy/Vagrantfile
@@ -5,8 +5,8 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "ansible" do |ansible|
       ansible.playbook = "ansible-playbook.yml"
-      ansible.sudo = true
-      ansible.sudo_user = user_name
+      #ansible.sudo = true
+      #ansible.sudo_user = user_name
       ansible.extra_vars = {
         user: user_name,
       }
@@ -15,11 +15,13 @@ Vagrant.configure("2") do |config|
   # This configuration is for our local box, when we use virtualbox as the provider
   config.vm.provider :virtualbox do |vb, override|
     #override.ssh.username = "viral-ngs-user"
+    vb.customize ["modifyvm", :id, "--memory", 4096]
     config.vm.hostname = "viral-ngs-vm"
     config.vm.synced_folder "./data/", "/home/vagrant/data/", create: true
     #config.vm.synced_folder "../", "/home/vagrant/viral-ngs/", create: true
     override.vm.box = "viral-ngs-vm"
-    override.vm.box = "ubuntu/trusty64"
+    #override.vm.box = "ubuntu/trusty64"
+    override.vm.box = "ubuntu/vivid64"
   end
 
   # This configuration is for our EC2 instance
@@ -28,7 +30,9 @@ Vagrant.configure("2") do |config|
     aws.secret_access_key = "secret access key"
     # ubuntu AMI, see: https://cloud-images.ubuntu.com/locator/ec2/
     # Trusty 14.04 LTS, amd64 hvm:ebs-ssd @ us-east-1
-    aws.ami = "ami-3387fe56"
+    #aws.ami = "ami-3387fe56"
+    # Vivid 15.04, amd64 hvm:ebs-ssd @ us-east-1
+    aws.ami = "ami-f3caa396"
     aws.keypair_name = "viral-ngs-user"
     #aws.security_groups = ["default", "quicklaunch-1"]
 

--- a/easy-deploy/Vagrantfile
+++ b/easy-deploy/Vagrantfile
@@ -1,0 +1,40 @@
+Vagrant.configure("2") do |config|
+  #config.vm.provision :ansible, :playbook => 'ansible-playbook.yml'
+
+  user_name = "vagrant"
+
+  config.vm.provision "ansible" do |ansible|
+      ansible.playbook = "ansible-playbook.yml"
+      ansible.sudo = true
+      ansible.sudo_user = user_name
+      ansible.extra_vars = {
+        user: user_name,
+      }
+  end
+
+  # This configuration is for our local box, when we use virtualbox as the provider
+  config.vm.provider :virtualbox do |vb, override|
+    #override.ssh.username = "viral-ngs-user"
+    config.vm.hostname = "viral-ngs-vm"
+    config.vm.synced_folder "./data/", "/home/vagrant/data/", create: true
+    #config.vm.synced_folder "../", "/home/vagrant/viral-ngs/", create: true
+    override.vm.box = "viral-ngs-vm"
+    override.vm.box = "ubuntu/trusty64"
+  end
+
+  # This configuration is for our EC2 instance
+  config.vm.provider :aws do |aws, override|
+    aws.access_key_id = "access key"
+    aws.secret_access_key = "secret access key"
+    # ubuntu AMI, see: https://cloud-images.ubuntu.com/locator/ec2/
+    # Trusty 14.04 LTS, amd64 hvm:ebs-ssd @ us-east-1
+    aws.ami = "ami-3387fe56"
+    aws.keypair_name = "viral-ngs-user"
+    #aws.security_groups = ["default", "quicklaunch-1"]
+
+    override.vm.box = "viral-ngs-vm"
+    override.vm.box_url = "https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box"
+    override.ssh.username = "viral-ngs-user"
+    override.ssh.private_key_path = "vagrant.pem"
+  end
+end

--- a/easy-deploy/Vagrantfile
+++ b/easy-deploy/Vagrantfile
@@ -1,5 +1,4 @@
 Vagrant.configure("2") do |config|
-  # This configuration is for our local box, when we use virtualbox as the provider
   config.vm.provider :virtualbox do |vb, override|
     vb.customize ["modifyvm", :id, "--memory", 4096]
     config.vm.hostname = "viral-ngs-vm"
@@ -18,24 +17,22 @@ Vagrant.configure("2") do |config|
     end
   end
 
-  # This configuration is for our EC2 instance
   config.vm.provider :aws do |aws, override|
     aws.access_key_id = ENV["EC2_ACCESS_KEY_ID"]
     aws.secret_access_key = ENV["EC2_SECRET_ACCESS_KEY"]
     # ubuntu AMI, see: https://cloud-images.ubuntu.com/locator/ec2/
     # Vivid 15.04, amd64 hvm:ebs-ssd @ us-west-2
     aws.ami = "ami-73b4af43"
-    aws.keypair_name = "tomkinsc-us-west-2"
-    aws.region = "us-west-2"
-    #aws.security_groups = ["sg-3a2c025f"]
+    aws.keypair_name = ENV["EC2_KEYPAIR_NAME"]
+    aws.region = ENV["EC2_REGION"]
 
     override.vm.box = "viral-ngs-vm"
     override.vm.box_url = "https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box"
     override.ssh.username = "ubuntu"
-    override.ssh.private_key_path = "tomkinsc-us-west-2.pem"
+    override.ssh.private_key_path = ENV["EC2_PRIVATE_KEY_PATH"]
 
-    override.vm.synced_folder ".", "/ubuntu", disabled: true
-    override.vm.synced_folder "./data/", "/home/ubuntu/data/", create: true
+    override.vm.synced_folder ".", "/vagrant", disabled: true # this disables the default Vagrant synced folder mount point
+    override.vm.synced_folder "./data/", "/home/ubuntu/data/", create: true, type: "rsync"
 
     override.vm.provision "ansible" do |ansible|
         ansible.playbook = "ansible-playbook.yml"
@@ -43,6 +40,6 @@ Vagrant.configure("2") do |config|
           user: "ubuntu",
         }
     end
-  end 
 
+  end 
 end

--- a/easy-deploy/ansible-playbook.yml
+++ b/easy-deploy/ansible-playbook.yml
@@ -1,0 +1,169 @@
+-
+  hosts: all
+  vars:
+    home_dir: "/home/{{ user }}"
+    project_dir: "{{ home_dir }}/bin"
+    venv_dir: "{{ home_dir }}/venv"
+    data_dir: "{{ home_dir }}/data"
+    licensed_tools_dir: "{{ home_dir }}/licensed_tools"
+    gatk_path: "{{ licensed_tools_dir }}/gatk"
+    novoalign_path: "{{ licensed_tools_dir }}/novoalign"
+  environment:
+    GATK_PATH: "{{ gatk_path }}"
+    NOVOALIGN_PATH: "{{ novoalign_path }}"
+    TEST_VAR: "foo"
+  sudo: yes
+  tasks:
+    - name: Install htop
+      apt: pkg=htop state=installed
+    - name: Install git
+      apt: pkg=git state=installed
+    - name: Install python-virtualenv
+      apt: pkg=python-virtualenv state=installed
+    - name: Install python3
+      apt: pkg=python3 state=installed
+    - name: Install python3-pip
+      apt: pkg=python3-pip state=installed
+    - name: Install python3-nose
+      apt: pkg=python3-nose state=installed
+    - name: Install python-software-properties
+      apt: pkg=python-software-properties state=installed
+    - name: Install openjdk-7-jdk
+      apt: pkg=openjdk-7-jdk state=installed
+    - name: Install zlib1g-dev
+      apt: pkg=zlib1g-dev state=installed
+    - name: Install unzip
+      apt: pkg=unzip state=installed
+    - name: Install libncur5-dev
+      apt: pkg=libncurses5-dev state=installed
+    - name: Install libncursesw5-dev
+      apt: pkg=libncursesw5-dev state=installed
+    - name: Install gcc-4.7 # needed to build MOSAIK
+      apt: pkg=gcc-4.7 state=installed
+
+    # these apt packages are perhaps unnecessary
+    - name: Install zlibc 
+      apt: pkg=zlibc state=installed
+    - name: Install libzip2 
+      apt: pkg=libzip2 state=installed
+
+    - name: Copying in latest viral-ngs from GitHub
+      git: 
+        repo: https://github.com/broadinstitute/viral-ngs.git
+        dest: "{{ project_dir }}"
+        version: HEAD
+        accept_hostkey: yes
+
+    - name: copy viral-ngs config.json
+      command: "cp {{ project_dir }}/pipes/config.json  {{ data_dir }}/config.json"
+      args:
+        chdir: "{{ home_dir }}"
+        creates: "{{ data_dir }}/config.json"
+
+    - name: copy viral-ngs Snakefile
+      command: "cp {{ project_dir }}/pipes/Snakefile  {{ data_dir }}/Snakefile"
+      args:
+        chdir: "{{ home_dir }}"
+        creates: "{{ data_dir }}/Snakefile"
+
+    #- name: copy viral-ngs Snakefile
+    #  command: "mkdir {{ data_dir }}/00_raw/ {{ data_dir }}/01_cleaned/ {{ data_dir }}/01_per_sample/ {{ data_dir }}/02_align_to_self/ {{ data_dir }}/02_assembly/ {{ data_dir }}/03_align_to_ref/ {{ data_dir }}/03_interhost/ {{ data_dir }}/04_intrahost/"
+
+    - name: copy gatk; REQUIRES host GATK_PATH set to licensed copy
+      copy:
+        owner: "{{ user }}" 
+        group: "{{ user }}"  
+        src: "{{ lookup('env','GATK_PATH') }}/" # trailing slash to copy contents only like rsync
+        dest: "{{ gatk_path }}"
+
+    - name: copy novoalign; REQUIRES host NOVOALIGN_PATH set to licensed copy
+      copy:
+        owner: "{{ user }}"  
+        group: "{{ user }}"  
+        src: "{{ lookup('env','NOVOALIGN_PATH') }}/" # trailing slash to copy contents only like rsync
+        dest: "{{ novoalign_path }}"
+
+    - name: Set GATK_PATH env var
+      lineinfile: 
+        dest: "/etc/environment"
+        line: "GATK_PATH={{ gatk_path }}" 
+        insertafter: 'EOF' 
+        regexp: "GATK_PATH={{ gatk_path }}" 
+        state: present
+
+    - name: Set NOVOALIGN_PATH env var
+      lineinfile: 
+        dest: "/etc/environment"
+        line: "NOVOALIGN_PATH={{ novoalign_path }}" 
+        insertafter: 'EOF' 
+        regexp: "NOVOALIGN_PATH={{ novoalign_path }}" 
+        state: present
+
+    - name: Create virtualenv
+      command: "virtualenv --python=/usr/bin/python3.4 {{ venv_dir }}"
+      args:
+        creates: "{{ venv_dir }}"
+
+    - name: Setup viral-ngs virtualenv (general)
+      pip:
+        virtualenv: "{{ venv_dir }}"
+        requirements: "{{ project_dir }}/requirements.txt"
+
+    - name: Setup viral-ngs virtualenv (Snakemake)
+      pip:
+        virtualenv: "{{ venv_dir }}"
+        requirements: "{{ project_dir }}/requirements-pipes.txt"
+
+    - name: Set owner of various files
+      file:
+        path: "{{ item }}"
+        state: directory
+        owner: "{{ user }}"  
+        group: "{{ user }}"
+        #mode: 0755
+        recurse: yes
+      with_items:
+        - "{{ home_dir }}/"
+
+    - name: Set execution bit of various files
+      file:
+        path: "{{ item }}"
+        state: directory
+        mode: 0755
+        recurse: yes
+      with_items:
+        - "{{ project_dir }}/tools/build/"
+        - "{{ gatk_path }}/"
+        - "{{ novoalign_path }}/"
+
+    - name: Copy virtualenv wrapper template  
+      template: 
+        src: "venv_exec.j2"
+        dest: "{{ venv_dir }}/exec" 
+        mode: 0755
+
+    - name: Install viral-ngs tools
+      command: "{{ venv_dir }}/exec python -m unittest test.unit.test_tools -v"
+      args:
+        chdir: "{{ project_dir }}"
+
+    - name: Set owner of various files
+      file:
+        path: "{{ item }}"
+        state: directory
+        owner: "{{ user }}"  
+        group: "{{ user }}"
+        #mode: 0755
+        recurse: yes
+      with_items:
+        - "{{ home_dir }}/"
+        - "{{ data_dir }}/"
+        - "{{ data_dir }}/00_raw/"
+        - "{{ data_dir }}/01_cleaned/"
+        - "{{ data_dir }}/01_per_sample/"
+        - "{{ data_dir }}/02_align_to_self/"
+        - "{{ data_dir }}/02_assembly/"
+        - "{{ data_dir }}/03_align_to_ref/"
+        - "{{ data_dir }}/03_interhost/"
+        - "{{ data_dir }}/04_intrahost/"
+

--- a/easy-deploy/ansible-playbook.yml
+++ b/easy-deploy/ansible-playbook.yml
@@ -14,6 +14,14 @@
     TEST_VAR: "foo"
   sudo: yes
   tasks:
+    - name: Install gcc-4.7 # needed to build MOSAIK
+      apt: pkg=gcc-4.7 state=installed
+
+    #- name: Add Ubuntu universe repository # needed for bamtools
+    #  apt_repository: 
+    #    repo: 'deb-src http://archive.canonical.com/ubuntu vivid universe' 
+    #    state: present
+
     - name: Install htop
       apt: pkg=htop state=installed
     - name: Install git
@@ -38,16 +46,20 @@
       apt: pkg=libncurses5-dev state=installed
     - name: Install libncursesw5-dev
       apt: pkg=libncursesw5-dev state=installed
-    - name: Install gcc-4.7 # needed to build MOSAIK
-      apt: pkg=gcc-4.7 state=installed
 
     # these apt packages are perhaps unnecessary
     - name: Install zlibc 
       apt: pkg=zlibc state=installed
     - name: Install libzip2 
       apt: pkg=libzip2 state=installed
+    - name: Install libz-dev
+      apt: pkg=libz-dev state=installed
+    - name: Install bamtools
+      apt: pkg=bamtools state=installed
+    - name: Install libbamtools-dev
+      apt: pkg=libbamtools-dev state=installed
 
-    - name: Copying in latest viral-ngs from GitHub
+    - name: Cloning latest version of viral-ngs from GitHub
       git: 
         repo: https://github.com/broadinstitute/viral-ngs.git
         dest: "{{ project_dir }}"
@@ -55,19 +67,16 @@
         accept_hostkey: yes
 
     - name: copy viral-ngs config.json
-      command: "cp {{ project_dir }}/pipes/config.json  {{ data_dir }}/config.json"
+      command: "cp {{ project_dir }}/pipes/config.json  {{ home_dir }}/config.json" # {{ data_dir }}/config.json
       args:
         chdir: "{{ home_dir }}"
         creates: "{{ data_dir }}/config.json"
 
     - name: copy viral-ngs Snakefile
-      command: "cp {{ project_dir }}/pipes/Snakefile  {{ data_dir }}/Snakefile"
+      command: "cp {{ project_dir }}/pipes/Snakefile  {{ home_dir }}/Snakefile" # {{ data_dir }}/Snakefile
       args:
         chdir: "{{ home_dir }}"
         creates: "{{ data_dir }}/Snakefile"
-
-    #- name: copy viral-ngs Snakefile
-    #  command: "mkdir {{ data_dir }}/00_raw/ {{ data_dir }}/01_cleaned/ {{ data_dir }}/01_per_sample/ {{ data_dir }}/02_align_to_self/ {{ data_dir }}/02_assembly/ {{ data_dir }}/03_align_to_ref/ {{ data_dir }}/03_interhost/ {{ data_dir }}/04_intrahost/"
 
     - name: copy gatk; REQUIRES host GATK_PATH set to licensed copy
       copy:
@@ -146,6 +155,27 @@
       command: "{{ venv_dir }}/exec python -m unittest test.unit.test_tools -v"
       args:
         chdir: "{{ project_dir }}"
+
+    - name: Modify .bashrc so venv is loaded on connect
+      lineinfile: 
+        dest: "{{ home_dir }}/.bashrc"
+        line: 'test -z "$VIRTUAL_ENV" && source {{ venv_dir }}/bin/activate' 
+        insertafter: 'EOF' 
+        regexp: 'test -z "$VIRTUAL_ENV" && source {{ venv_dir }}/bin/activate'
+        state: present
+
+    - name: Create some required files
+      file:
+        path: "{{ item }}"
+        state: touch
+        owner: "{{ user }}"  
+        group: "{{ user }}"
+      with_items:
+        - "{{ home_dir }}/samples-depletion.txt"
+        - "{{ home_dir }}/samples-assembly.txt"
+        - "{{ home_dir }}/samples-runs.txt"
+        - "{{ home_dir }}/samples-assembly-failures.txt"
+        #- "{{ home_dir }}/flowcells.txt"
 
     - name: Set owner of various files
       file:

--- a/easy-deploy/data/README.txt
+++ b/easy-deploy/data/README.txt
@@ -1,0 +1,6 @@
+Place data files in this folder to make them accessible within the viral-ngs VM.
+
+Note: Due to Vagrant limitations, if the VM is running on AWS the sync is one-way only: 
+From local to AWS. You will need to move files off the AWS VM yourself.
+
+On local machines the folder sync is two-way and fast.

--- a/easy-deploy/run.sh
+++ b/easy-deploy/run.sh
@@ -42,9 +42,39 @@ function cmd_exists() {
     fi
 }
 
+function all_commands_exist {
+    # Pass in a space-delimited string of commands
+    # to try. Returns 0 if all exist
+    #
+    # $1 array of commands to try
+
+    all_exist=true
+
+    cmds_array=($(echo $1 | tr " " "\n"))
+
+    for f in "${cmds_array[@]}"; do
+        if ! cmd_exists $f; then
+            echo "Command missing: $f"
+            if $all_exist; then
+                all_exist=false
+            fi
+        fi
+    done
+
+    if $all_exist; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 function install_with_blocking() {
+    # Use to run an install command where there isn't an easy way
+    # to see if the command already exists
+    #
     # $1 the install command to run
     # $2 description of thing to be installed
+
     if eval $1 ; then
         return 0
     else
@@ -54,6 +84,9 @@ function install_with_blocking() {
 }
 
 function use_or_install_with_checks() {
+    # Used to run an install command if a specified command does
+    # not exist
+    #
     # $1 command to check to see if it is already installed
     # $2 description of the package
     # $3 command to install it    
@@ -90,7 +123,6 @@ function clean_up {
 }
 trap clean_up SIGHUP SIGINT SIGTERM
 
-#echo $'viral-ngs easy deployment script\n'
 echo $' +-----------------------------------------------------------+ '
 echo $' |       _   _ _           _        _   _ _____  _____       | '
 echo $' |      | | | (_)         | |      | \ | |  __ \/  ___|      | '
@@ -111,31 +143,72 @@ echo $' |                  |___/             |_|            |___/   | '
 echo $' |                                                           | '
 echo $' +-----------------------------------------------------------+ '
 
+relevant_commands=('ansible vagrant VirtualBox')
 
-if ! cmd_exists "vagrant" || ! cmd_exists "VirtualBox"; then
+if ! all_commands_exist $relevant_commands; then
     if $(ask "Install local dependencies for running viral-ngs?" Y); then
         echo "Setting up dependencies..."
+
+        if [ -z "$GATK_PATH" ]; then 
+            echo "Prior to setting up everything, you must license and download GATK ( https://www.broadinstitute.org/gatk/download/ )." 
+            echo "Once downloaded, extract the archive and set the environment variable GATK_PATH to the directory path"
+            echo "containing 'GenomeAnalysisTK.jar'"
+            echo "  ex. 'export GATK_PATH=/path/to/gatk'"
+            echo "       Note: add the export line to .bashrc or .bash_profile for persistence across sessions."
+            exit 1;
+        else
+            echo "GATK_PATH is set to '$GATK_PATH'"
+            echo "Continuing..."
+        fi
+
+        if [ -z "$NOVOALIGN_PATH" ]; then 
+            echo "Prior to setting up everything, you must license and download NovoAlign ( http://www.novocraft.com/products/novoalign/ )." 
+            echo "Once downloaded, extract the archive and set the environment variable NOVOALIGN_PATH to the directory path"
+            echo "containing 'novoalign'"
+            echo "  ex. 'export NOVOALIGN_PATH=/path/to/novoalign'"
+            echo "       Note: add the export line to .bashrc or .bash_profile for persistence across sessions."
+            exit 1;
+        else
+            echo "NOVOALIGN_PATH is set to '$NOVOALIGN_PATH'"
+            echo "Continuing..."
+        fi
 
         if [ "$(uname)" == "Darwin" ]; then
             echo "Platform: Mac"
 
             if use_or_install_with_checks "brew" "Homebrew package mananger" 'ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" ' 1 ; then
                 echo "Homebrew found, installing cask..."
+                use_or_install_with_checks 'ansible' "Ansible deploy and config manager" 'brew install ansible' 1
                 if use_or_install_with_checks 'brew-cask' "Homebrew cask" 'brew install caskroom/cask/brew-cask' 1 ; then
-                    install_with_blocking 'brew cask install virtualbox'
-                    install_with_blocking 'brew cask install vagrant'
-                    install_with_blocking 'brew cask install vagrant-manager'
-                fi        
+                    #install_with_blocking 'brew cask install virtualbox'
+                    use_or_install_with_checks 'VirtualBox' "VirtualBox VM manager" 'brew cask install virtualbox' 1
+                    #install_with_blocking 'brew cask install vagrant'
+                    use_or_install_with_checks 'vagrant' "Vagrant VM provisioning tool" 'brew cask install vagrant' 1
+                    install_with_blocking 'brew cask install vagrant-manager' 'vagrant-manager'
+                fi          
+                # if the version of ruby is not 2.0 ( OSX < 10.10 )
+                if ! echo $(ruby -e 'print RUBY_VERSION') | grep "2."; then
+                    echo "Ruby is not at version 2.x. Installing 2.0 from Homebrew..."
+                    install_with_blocking "brew install ruby20" "Ruby 2.0"
+                fi
+                install_with_blocking "vagrant plugin install vagrant-aws" 'vagrant-aws'
             fi
 
         elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
             echo "Platform: Linux"
 
-            if [ $(python -mplatform | grep Ubuntu) ]; then
+            if cmd_exists "apt-get"; then
                 use_or_install_with_checks "VirtualBox" "VirtualBox VM manager" 'sudo apt-get -y install virtualbox virtualbox-dkms' 1
-                use_or_install_with_checks "vagrant" "Vagrant VM environment manager" 'sudo apt-get -y install vagrant' 1
+                use_or_install_with_checks "ansible" "Ansible deploy and config manager" 'sudo apt-get -y install ansible' 1
+                use_or_install_with_checks "vagrant" "Vagrant VM provisioning tool" 'sudo apt-get -y install vagrant' 1
+
+                if ! echo $(ruby -e 'print RUBY_VERSION') | grep "2."; then
+                    echo "Please update your system ruby to >2.0 and re-run this script"
+                else
+                    install_with_blocking '$(vagrant plugin install vagrant-aws)' 'vagrant-aws'
+                fi
             else
-                echo "This script is intended to be used with Ubuntu. If you are using a different Linux distro, please set up the environment manually."
+                echo "This script is intended to be used on a system with apt. If you are using a Linux distro without apt, please set up the environment manually."
                 exit 1
             fi
 
@@ -147,30 +220,66 @@ if ! cmd_exists "vagrant" || ! cmd_exists "VirtualBox"; then
         echo "Aborting."
         exit 1
     fi
-    install_with_blocking "vagrant plugin install vagrant-aws"
-else
+fi
+
+if all_commands_exist $relevant_commands; then
     echo $'Dependencies for building the viral-ngs environment are SATISFIED.\n'
     echo $'Next you have an opportunity to choose whether you would like to provision'
     echo $'the viral-ngs environment LOCALLY or on AWS EC2.'
     echo $'In either case, you will be directed to an ssh session on a VM where'
     echo $'you can work with viral-ngs.\n'
 
-    if $(ask "Run viral-ngs LOCALLY?" Y); then
-        vagrant up --provider=virtualbox
-        vagrant box update
-        vagrant ssh
-        vagrant suspend
-        if [[ $? ]]; then
-            echo $'\nThe Viral-NGS virtual machine has been suspended. Next time you run this'
-            echo $'script, you will be connected exactly where you left off.\n'
-            exit 0
-        else
-            echo $'The Vial-NGS virtual machine did not close cleanly.'
-            exit 1
-        fi
-    elif $(ask "Run viral-ngs on AWS?" Y); then
-        vagrant up --provider=aws
-        vagrant ssh
-        exit 0
+    # Ask the question
+    read -p "Run viral-ngs locally or on AWS EC2? [LOCAL/aws] " REPLY
+    
+    # Default?
+    if [ -z "$REPLY" ]; then
+        REPLY="local"
     fi
+    
+    # Check if the reply is valid
+    case "$REPLY" in
+        L*|l*) # could also be explicit LOCAL|local)
+            echo "Running locally..."; 
+            vagrant up --provider=virtualbox
+            vagrant box update
+            vagrant ssh
+            vagrant suspend
+            if [[ $? ]]; then
+                echo $'\nThe Viral-NGS virtual machine has been suspended. Next time you run this'
+                echo $'script, you will be connected exactly where you left off.\n'
+                exit 0
+            else
+                echo $'The Vial-NGS virtual machine did not close cleanly.'
+                exit 1
+            fi
+            ;;
+        A*|a*) 
+            echo "AWS support not yet implemented."
+            exit 1
+
+            echo "Running on AWS...";
+
+            if ! echo $(ruby -e 'print RUBY_VERSION') | grep "2."; then
+                echo "Running viral-ngs on AWS needs ruby >2.0"
+                exit 1
+            else
+                if ! $(vagrant plugin list | grep aws); then
+                    install_with_blocking "vagrant plugin install vagrant-aws" 'vagrant-aws'
+                fi
+            fi
+
+            vagrant up --provider=aws
+            vagrant ssh
+            vagrant suspend
+            if [[ $? ]]; then
+                echo $'\nThe Viral-NGS virtual machine has been suspended. Next time you run this'
+                echo $'script, you will be connected exactly where you left off.\n'
+                exit 0
+            else
+                echo $'The Vial-NGS virtual machine did not close cleanly.'
+                exit 1
+            fi
+            ;;
+    esac
 fi

--- a/easy-deploy/run.sh
+++ b/easy-deploy/run.sh
@@ -255,31 +255,35 @@ if all_commands_exist $relevant_commands; then
             fi
             ;;
         A*|a*) 
-            echo "AWS support not yet implemented."
-            exit 1
-
             echo "Running on AWS...";
 
             if ! echo $(ruby -e 'print RUBY_VERSION') | grep "2."; then
                 echo "Running viral-ngs on AWS needs ruby >2.0"
                 exit 1
             else
-                if ! $(vagrant plugin list | grep aws); then
+                if ! echo $(vagrant plugin list) | grep "aws"; then
                     install_with_blocking "vagrant plugin install vagrant-aws" 'vagrant-aws'
                 fi
             fi
 
+            if [ -z "$EC2_ACCESS_KEY_ID" ] && [ -z "$EC2_SECRET_ACCESS_KEY" ]; then 
+                echo "Prior to deploying to EC2 you must obtain AWS IAM credentials permitting instance creation." 
+                echo "You must then set the environment variables:"
+                echo "    EC2_ACCESS_KEY_ID"
+                echo "    EC2_SECRET_ACCESS_KEY"
+                exit 1;
+            else
+                echo "EC2_ACCESS_KEY_ID is set, and EC2_SECRET_ACCESS_KEY is set"
+                echo "Continuing..."
+            fi
+
+            # ask for private key, if not set (store in env)
+            # ask for EC2 credentials, if not set (store in env)
+            # ask "Have you copied any data you would like to work on in this session to data/ ?" --> continue after the prompt
+            #
+
             vagrant up --provider=aws
             vagrant ssh
-            vagrant suspend
-            if [[ $? ]]; then
-                echo $'\nThe Viral-NGS virtual machine has been suspended. Next time you run this'
-                echo $'script, you will be connected exactly where you left off.\n'
-                exit 0
-            else
-                echo $'The Vial-NGS virtual machine did not close cleanly.'
-                exit 1
-            fi
             ;;
     esac
 fi

--- a/easy-deploy/run.sh
+++ b/easy-deploy/run.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+
+# 2015 Christopher Tomkins-Tinch
+# Broad Institute of MIT and Harvard
+
+function ask() {
+    while true; do
+ 
+        if [ "${2:-}" = "Y" ]; then
+            prompt="Y/n"
+            default=Y
+        elif [ "${2:-}" = "N" ]; then
+            prompt="y/N"
+            default=N
+        else
+            prompt="y/n"
+            default=
+        fi
+ 
+        # Ask the question
+        read -p "$1 [$prompt] " REPLY
+ 
+        # Default?
+        if [ -z "$REPLY" ]; then
+            REPLY=$default
+        fi
+ 
+        # Check if the reply is valid
+        case "$REPLY" in
+            Y*|y*) echo " "; return 0 ;;
+            N*|n*) echo " "; return 1 ;;
+        esac
+ 
+    done
+}
+
+function cmd_exists() {
+    if hash $@ 2> /dev/null ; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+function install_with_blocking() {
+    # $1 the install command to run
+    # $2 description of thing to be installed
+    if eval $1 ; then
+        return 0
+    else
+        echo "Install of $2 seems to have been unsuccessful"
+        exit 1
+    fi
+}
+
+function use_or_install_with_checks() {
+    # $1 command to check to see if it is already installed
+    # $2 description of the package
+    # $3 command to install it    
+    # $4 unattended if 1
+
+    if ! cmd_exists $1  ; then
+        if [[ $4 == 1 ]] || $(ask "Install $2?" Y); then
+            echo "Installing $2..."
+            echo "$3"
+            eval $3
+            if cmd_exists $1  ; then
+                return 0
+            else
+                echo "Attempt to install $2 failed. Please check error messages and logs."
+                exit 1
+            fi
+        else
+            echo "Aborting. Please install $2 manually."
+            exit 1
+        fi
+    else
+        echo "$2 found. Continuing..."
+        return 0
+    fi
+}
+
+# in the event that the script is sent a kill signal
+# suspend the vm cleanly
+function clean_up {
+    if cmd_exists "vagrant"; then
+        vagrant suspend
+    fi
+    exit $1
+}
+trap clean_up SIGHUP SIGINT SIGTERM
+
+#echo $'viral-ngs easy deployment script\n'
+echo $' +-----------------------------------------------------------+ '
+echo $' |       _   _ _           _        _   _ _____  _____       | '
+echo $' |      | | | (_)         | |      | \ | |  __ \/  ___|      | '
+echo $' |      | | | |_ _ __ __ _| |______|  \| | |  \/\ `--.       | '
+echo $' |      | | | | | \'__/ _` | |______| . ` | | __  `--. \      | '
+echo $' |      \ \_/ / | | | (_| | |      | |\  | |_\ \/\__/ /      | '
+echo $' |       \___/|_|_|  \__,_|_|      \_| \_/\____/\____/       | '
+echo $' |                                                           | '
+echo $' |                                                           | '
+echo $' |   _____                  ______           _               | '
+echo $' |  |  ___|                 |  _  \         | |              | '
+echo $' |  | |__  __ _ ___ _   _   | | | |___ _ __ | | ___  _   _   | '
+echo $' |  |  __|/ _` / __| | | |  | | | / _ \ \'_ \| |/ _ \| | | |  | '
+echo $' |  | |__| (_| \__ \ |_| |  | |/ /  __/ |_) | | (_) | |_| |  | '
+echo $' |  \____/\__,_|___/\__, |  |___/ \___| .__/|_|\___/ \__, |  | '
+echo $' |                   __/ |            | |             __/ |  | '
+echo $' |                  |___/             |_|            |___/   | '
+echo $' |                                                           | '
+echo $' +-----------------------------------------------------------+ '
+
+
+if ! cmd_exists "vagrant" || ! cmd_exists "VirtualBox"; then
+    if $(ask "Install local dependencies for running viral-ngs?" Y); then
+        echo "Setting up dependencies..."
+
+        if [ "$(uname)" == "Darwin" ]; then
+            echo "Platform: Mac"
+
+            if use_or_install_with_checks "brew" "Homebrew package mananger" 'ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" ' 1 ; then
+                echo "Homebrew found, installing cask..."
+                if use_or_install_with_checks 'brew-cask' "Homebrew cask" 'brew install caskroom/cask/brew-cask' 1 ; then
+                    install_with_blocking 'brew cask install virtualbox'
+                    install_with_blocking 'brew cask install vagrant'
+                    install_with_blocking 'brew cask install vagrant-manager'
+                fi        
+            fi
+
+        elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+            echo "Platform: Linux"
+
+            if [ $(python -mplatform | grep Ubuntu) ]; then
+                use_or_install_with_checks "VirtualBox" "VirtualBox VM manager" 'sudo apt-get -y install virtualbox virtualbox-dkms' 1
+                use_or_install_with_checks "vagrant" "Vagrant VM environment manager" 'sudo apt-get -y install vagrant' 1
+            else
+                echo "This script is intended to be used with Ubuntu. If you are using a different Linux distro, please set up the environment manually."
+                exit 1
+            fi
+
+        elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
+            echo "Platform: Windows. Not currently supported."
+            exit 1
+        fi
+    else
+        echo "Aborting."
+        exit 1
+    fi
+    install_with_blocking "vagrant plugin install vagrant-aws"
+else
+    echo $'Dependencies for building the viral-ngs environment are SATISFIED.\n'
+    echo $'Next you have an opportunity to choose whether you would like to provision'
+    echo $'the viral-ngs environment LOCALLY or on AWS EC2.'
+    echo $'In either case, you will be directed to an ssh session on a VM where'
+    echo $'you can work with viral-ngs.\n'
+
+    if $(ask "Run viral-ngs LOCALLY?" Y); then
+        vagrant up --provider=virtualbox
+        vagrant box update
+        vagrant ssh
+        vagrant suspend
+        if [[ $? ]]; then
+            echo $'\nThe Viral-NGS virtual machine has been suspended. Next time you run this'
+            echo $'script, you will be connected exactly where you left off.\n'
+            exit 0
+        else
+            echo $'The Vial-NGS virtual machine did not close cleanly.'
+            exit 1
+        fi
+    elif $(ask "Run viral-ngs on AWS?" Y); then
+        vagrant up --provider=aws
+        vagrant ssh
+        exit 0
+    fi
+fi

--- a/easy-deploy/venv_exec.j2
+++ b/easy-deploy/venv_exec.j2
@@ -1,4 +1,3 @@
 #!/bin/bash
 source {{ venv_dir }}/bin/activate
-export CXX=/usr/bin/gcc-4.7
 $@

--- a/easy-deploy/venv_exec.j2
+++ b/easy-deploy/venv_exec.j2
@@ -1,0 +1,4 @@
+#!/bin/bash
+source {{ venv_dir }}/bin/activate
+export CXX=/usr/bin/gcc-4.7
+$@


### PR DESCRIPTION
This adds files to easily create a virtualized environment for running viral-ngs. The environment can be either local (via VirtualBox), or cloud-based (via Amazon EC2). It is tested to work on host machines based on OS X 10.10 (Yosemite) and Ubuntu 15.04 (Vivid Vervet). Currently the pipeline can execute within the VM up to the point where the depletion databases are needed. Per the Vagrantfile, local VM RAM usage is set to 8GB. On EC2 it currently uses an m4.2xlarge instance with 32GB of RAM and 8 vCPUs.

The `run.sh` script sets up everything, and drops the user into a shell on the VM. 

To start, the script `run.sh` installs the necessary dependencies on the user's machine (ansible, vagrant, virtualbox, and virtualbox-aws). The provisioning is handled by Ansible, with Vagrant handling creation of the VMs and EC2 instances. On OSX it depends on Homebrew, and will install it if it is not present.  It depends on having apt on linux, so it's Debian/Ubuntu only for now. Ruby >=2.0 is required for [vagrant-aws](https://github.com/mitchellh/vagrant-aws), so versions of Ubuntu older than 15.04 (notably 14.04 LTS) would need to have ruby >=2.0 installed and made default (this is currently left as an exercise to the user).

Ansible clones the master branch of viral-ngs from GitHub, creates a Python 3 virtual environment, and installs the viral-ngs Python dependencies. The viral-ngs tool unit tests are run to download, install, and build all of the viral-ngs tools. A `Snakefile` for viral-ngs is copied to the home directory of the VM (locally: `/home/vagrant/`, on EC2: `/home/ubuntu/`), along with the associated `config.json` file. Files to contain sample names (`sample-depletion.txt`, etc.) are also created. A directory is created within the VM, `~/data/`, to store data to be processed. This directory on the VM is synced to the `./data/` directory on the host machine, relative to the location of the `east-deploy/Vagrantfile`. On local VMs, syncing of the directory is two-way and fast. On EC2 instances, the syncing is currently one way (local->EC2) due to Vagrant limitations. 

AWS credentials and SSH keypairs are passed in as environment variables, and the `run.sh` will prompt for the values if the environment variables are not set (though the values given interactively are ephemeral).