### PR TITLE
refactor config file, add LSF data_dir check

### DIFF
--- a/assembly.py
+++ b/assembly.py
@@ -127,7 +127,7 @@ def parser_trim_rmdup_subsamp(parser=argparse.ArgumentParser()):
                         default=100000,
                         type=int,
                         help='Subsample reads to no more than this many pairs. (default %(default)s)')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, trim_rmdup_subsamp_reads, split_args=True)
     return parser
 
@@ -169,7 +169,7 @@ def parser_assemble_trinity(parser=argparse.ArgumentParser()):
                         default=tools.trinity.TrinityTool.jvmMemDefault,
                         help='JVM virtual memory size (default: %(default)s)')
     parser.add_argument('--threads', default=1, help='Number of threads (default: %(default)s)')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, assemble_trinity, split_args=True)
     return parser
 
@@ -253,7 +253,7 @@ def parser_order_and_orient(parser=argparse.ArgumentParser()):
     parser.add_argument('--inReads',
                         default=None,
                         help='Input reads in unaligned BAM format. These can be used to improve the merge process.')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, order_and_orient, split_args=True)
     return parser
 
@@ -362,7 +362,7 @@ def parser_impute_from_reference(parser=argparse.ArgumentParser()):
                         type=int,
                         default=0,
                         help="length of ends to be replaced with reference (default: %(default)s)")
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, impute_from_reference, split_args=True)
     return parser
 
@@ -477,7 +477,7 @@ def parser_refine_assembly(parser=argparse.ArgumentParser()):
                         default=tools.gatk.GATKTool.jvmMemDefault,
                         help='JVM virtual memory size (default: %(default)s)')
     parser.add_argument('--threads', default=1, help='Number of threads (default: %(default)s)')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, refine_assembly, split_args=True)
     return parser
 
@@ -582,7 +582,7 @@ def parser_modify_contig(parser=argparse.ArgumentParser()):
                         default=False,
                         action="store_true",
                         dest="call_reference_ambiguous")
-    util.cmd.common_args(parser, (('tmpDir', None), ('loglevel', None), ('version', None)))
+    util.cmd.common_args(parser, (('tmp_dir', None), ('loglevel', None), ('version', None)))
     util.cmd.attach_main(parser, main_modify_contig)
     return parser
 

--- a/docs/pipeuse.rst
+++ b/docs/pipeuse.rst
@@ -156,8 +156,8 @@ docs <ftp://ftp.ncbi.nih.gov/pub/agarwala/bmtagger/README.bmtagger.txt>`__.
 
 ::
 
-    "bmTaggerDbDir":  "/path/to/depletion_databases",
-    "bmTaggerDbs_remove": [
+    "bm_tagger_db_dir":  "/path/to/depletion_databases",
+    "bm_tagger_dbs_remove": [
         "hg19",
         "GRCh37.68_ncRNA-GRCh37.68_transcripts-HS_rRNA_mitRNA",
         "metagenomics_contaminants_v3"
@@ -174,8 +174,8 @@ from the University of Oxford.
 
 ::
 
-    "blastDbDir":     "/path/to/depletion_databases",
-    "blastDb_remove": "metag_v3.ncRNA.mRNA.mitRNA.consensus",
+    "blast_db_dir":     "/path/to/depletion_databases",
+    "blast_db_remove": "metag_v3.ncRNA.mRNA.mitRNA.consensus",
 
 An array of the `NCBI GenBank
 CoreNucleotide <http://www.ncbi.nlm.nih.gov/nuccore/>`__ accessions for
@@ -202,13 +202,13 @@ contaminents from reads:
 
 ::
 
-    "trim_clipDb":    "/path/to/depletion_databases/contaminants.fasta",
+    "trim_clip_db":    "/path/to/depletion_databases/contaminants.fasta",
 
 A FASTA file containing spike-ins to be reported:
 
 ::
 
-    "spikeinsDb":     "/path/to/references/ercc_spike-ins.fasta",
+    "spikeins_db":     "/path/to/references/ercc_spike-ins.fasta",
 
 Modifying the ``Snakefile``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/pipeuse.rst
+++ b/docs/pipeuse.rst
@@ -193,7 +193,6 @@ to represent the full reference genome file used downstream.
 ::
 
     "accessions_for_ref_genome_build": ["KJ660346.2"],
-    "ref_genome_file_prefix": "ebov",
 
 An optional file containing a list of accessions may be specified for 
 filtering reads via `LAST <http://last.cbrc.jp/doc/lastal.txt>`__. This is 

--- a/docs/pipeuse.rst
+++ b/docs/pipeuse.rst
@@ -149,12 +149,6 @@ API <http://www.ncbi.nlm.nih.gov/books/NBK25501/>`__:
 
     "email_point_of_contact_for_ncbi" : "someone@example.com"
 
-The number of chomosomes (or segments) in the reference organism:
-
-::
-
-    "number_of_chromosomes": 2,
-
 The path to the depletion databases to be used by BMTagger, along with
 the file prefixes of the specific databases to use. The process for
 creating BMTagger depletion databases is described in the `NIH BMTagger

--- a/docs/pipeuse.rst
+++ b/docs/pipeuse.rst
@@ -156,8 +156,8 @@ docs <ftp://ftp.ncbi.nih.gov/pub/agarwala/bmtagger/README.bmtagger.txt>`__.
 
 ::
 
-    "bm_tagger_db_dir":  "/path/to/depletion_databases",
-    "bm_tagger_dbs_remove": [
+    "bmtagger_db_dir":  "/path/to/depletion_databases",
+    "bmtagger_dbs_remove": [
         "hg19",
         "GRCh37.68_ncRNA-GRCh37.68_transcripts-HS_rRNA_mitRNA",
         "metagenomics_contaminants_v3"

--- a/illumina.py
+++ b/illumina.py
@@ -66,7 +66,7 @@ def parser_illumina_demux(parser=argparse.ArgumentParser()):
     parser.add_argument('--JVMmemory',
                         help='JVM virtual memory size (default: %(default)s)',
                         default=tools.picard.IlluminaBasecallsToSamTool.jvmMemDefault)
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, main_illumina_demux)
     return parser
 
@@ -573,7 +573,7 @@ def parser_miseq_fastq_to_bam(parser=argparse.ArgumentParser()):
     parser.add_argument('--JVMmemory',
                         default=tools.picard.FastqToSamTool.jvmMemDefault,
                         help='JVM virtual memory size (default: %(default)s)')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, miseq_fastq_to_bam, split_args=True)
     return parser
 
@@ -597,7 +597,7 @@ def parser_extract_fc_metadata(parser=argparse.ArgumentParser()):
     parser.add_argument('flowcell', help='Illumina directory (possibly tarball)')
     parser.add_argument('outRunInfo', help='Output RunInfo.xml file.')
     parser.add_argument('outSampleSheet', help='Output SampleSheet.csv file.')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, extract_fc_metadata, split_args=True)
     return parser
 __commands__.append(('extract_fc_metadata', parser_extract_fc_metadata))

--- a/interhost.py
+++ b/interhost.py
@@ -331,7 +331,7 @@ def parser_snpEff(parser=argparse.ArgumentParser()):
         NCBI requires you to specify your email address with each request.
         In case of excessive usage of the E-utilities, NCBI will attempt to contact
         a user at the email address provided before blocking access.""")
-    util.cmd.common_args(parser, (('tmpDir', None), ('loglevel', None), ('version', None)))
+    util.cmd.common_args(parser, (('tmp_dir', None), ('loglevel', None), ('version', None)))
     util.cmd.attach_main(parser, tools.snpeff.SnpEff().annotate_vcf, split_args=True)
     return parser
 
@@ -393,7 +393,7 @@ def parser_align_mafft(parser):
 
     parser.add_argument('outFile', help='Output file containing alignment result (default format: FASTA)')
 
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, main_align_mafft)
     return parser
 
@@ -448,7 +448,7 @@ def parser_multichr_mafft(parser):
         sample names in the order of their sequence
         positions in the output.""")
 
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, multichr_mafft)
     return parser
 

--- a/ncbi.py
+++ b/ncbi.py
@@ -123,7 +123,7 @@ def parser_tbl_transfer(parser=argparse.ArgumentParser()):
         False: drop all features that are completely or partly out of bounds
         True:  drop all features completely out of bounds
                but truncate any features that are partly out of bounds''')
-    util.cmd.common_args(parser, (('tmpDir', None), ('loglevel', None), ('version', None)))
+    util.cmd.common_args(parser, (('tmp_dir', None), ('loglevel', None), ('version', None)))
     util.cmd.attach_main(parser, tbl_transfer, split_args=True)
     return parser
 
@@ -225,7 +225,7 @@ def parser_tbl_transfer_prealigned(parser=argparse.ArgumentParser()):
         False: drop all features that are completely or partly out of bounds
         True:  drop all features completely out of bounds
                but truncate any features that are partly out of bounds''')
-    util.cmd.common_args(parser, (('tmpDir', None), ('loglevel', None), ('version', None)))
+    util.cmd.common_args(parser, (('tmp_dir', None), ('loglevel', None), ('version', None)))
     util.cmd.attach_main(parser, tbl_transfer_prealigned, split_args=True)
     return parser
 
@@ -321,7 +321,7 @@ def parser_fetch_reference_common(parser=argparse.ArgumentParser()):
 def parser_fetch_fastas(parser):
     parser = parser_fetch_reference_common(parser)
 
-    util.cmd.common_args(parser, (('tmpDir', None), ('loglevel', None), ('version', None)))
+    util.cmd.common_args(parser, (('tmp_dir', None), ('loglevel', None), ('version', None)))
     util.cmd.attach_main(parser, fetch_fastas, split_args=True)
     return parser
 
@@ -332,7 +332,7 @@ __commands__.append(('fetch_fastas', parser_fetch_fastas))
 def parser_fetch_feature_tables(parser):
     parser = parser_fetch_reference_common(parser)
 
-    util.cmd.common_args(parser, (('tmpDir', None), ('loglevel', None), ('version', None)))
+    util.cmd.common_args(parser, (('tmp_dir', None), ('loglevel', None), ('version', None)))
     util.cmd.attach_main(parser, fetch_feature_tables, split_args=True)
     return parser
 
@@ -343,7 +343,7 @@ __commands__.append(('fetch_feature_tables', parser_fetch_feature_tables))
 def parser_fetch_genbank_records(parser):
     parser = parser_fetch_reference_common(parser)
 
-    util.cmd.common_args(parser, (('tmpDir', None), ('loglevel', None), ('version', None)))
+    util.cmd.common_args(parser, (('tmp_dir', None), ('loglevel', None), ('version', None)))
     util.cmd.attach_main(parser, fetch_genbank_records, split_args=True)
     return parser
 
@@ -448,7 +448,7 @@ def parser_prep_genbank_files(parser=argparse.ArgumentParser()):
         have at least two columns named sample and aln2self_cov_median.  All other
         columns are ignored. Rows referring to samples not in this submission are
         ignored.''')
-    util.cmd.common_args(parser, (('tmpDir', None), ('loglevel', None), ('version', None)))
+    util.cmd.common_args(parser, (('tmp_dir', None), ('loglevel', None), ('version', None)))
     util.cmd.attach_main(parser, prep_genbank_files, split_args=True)
     return parser
 

--- a/pipes/Broad_LSF/cluster-submitter.py
+++ b/pipes/Broad_LSF/cluster-submitter.py
@@ -5,6 +5,7 @@ import re
 from snakemake.utils import read_job_properties
 
 LOGDIR = sys.argv[-2]
+DATADIR = sys.argv[-3]
 jobscript = sys.argv[-1]
 mo = re.match(r'(\S+)/snakejob\.\S+\.(\d+)\.sh', jobscript)
 assert mo
@@ -15,7 +16,10 @@ props = read_job_properties(jobscript)
 jobname = "{rule}-{jobid}".format(rule=props["rule"], jobid=sm_jobid)
 if props["params"].get("logid"):
     jobname = "{rule}-{id}".format(rule=props["rule"], id=props["params"]["logid"])
-cmdline = "bsub -P {proj_name} -J {jobname} -r ".format(proj_name='viral_ngs', jobname=jobname)
+
+# -E is a pre-exec command, that reschedules the job if the command fails
+#   in this case, if the data dir is unavailable (as may be the case for a hot-mounted file path)
+cmdline = 'bsub -P {proj_name} -J {jobname} -r -E "ls {datadir}" '.format(proj_name='viral_ngs', jobname=jobname, datadir=DATADIR)
 
 # log file output
 if "-N" not in props["params"].get("LSF", ""):
@@ -30,7 +34,7 @@ if mem:
 cmdline += props["params"].get("LSF", "") + " "
 
 # figure out job dependencies
-dependencies = set(sys.argv[1:-2])
+dependencies = set(sys.argv[1:-3])
 if dependencies:
     cmdline += "-w '{}' ".format(" && ".join(dependencies))
 

--- a/pipes/Broad_LSF/lsf-report.py
+++ b/pipes/Broad_LSF/lsf-report.py
@@ -73,14 +73,14 @@ def read_all_logfiles(dirname):
 def parser_report():
     parser = argparse.ArgumentParser(
         description="Read a directory full of LSF log files and produce a tabular report.")
-    parser.add_argument("logDir", help="Input directory of LSF log files")
+    parser.add_argument("log_dir", help="Input directory of LSF log files")
     parser.add_argument("outFile", help="Output report file")
     return parser
 
 
 def main_report(args):
     with open(args.outFile, 'wt') as outf:
-        for row in read_all_logfiles(args.logDir):
+        for row in read_all_logfiles(args.log_dir):
             outf.write('\t'.join(row) + '\n')
     return 0
 

--- a/pipes/Broad_LSF/run-pipe.sh
+++ b/pipes/Broad_LSF/run-pipe.sh
@@ -22,6 +22,5 @@ snakemake --timestamp --rerun-incomplete --keep-going --nolock \
 	--config mode=LSF job_profiler="$BINDIR/pipes/Broad_LSF/lsf-report.py" \
 	--directory . \
 	--jobscript "$BINDIR/pipes/Broad_LSF/jobscript.sh" \
-	--cluster $BINDIR'/pipes/Broad_LSF/cluster-submitter.py {dependencies}' $DATADIR \
-    '{config[logDir]}' \
+	--cluster $BINDIR"/pipes/Broad_LSF/cluster-submitter.py {dependencies} $DATADIR {config[logDir]}" \
 	"$@"

--- a/pipes/Broad_LSF/run-pipe.sh
+++ b/pipes/Broad_LSF/run-pipe.sh
@@ -8,9 +8,9 @@ reuse -q Python-3.4
 reuse -q Perl-5.10
 
 # load config dirs from config.json
-VENVDIR=`python -c 'import json;f=open("config.json");print(json.load(f)["venvDir"]);f.close()'`
-BINDIR=`python -c 'import json;f=open("config.json");print(json.load(f)["binDir"]);f.close()'`
-DATADIR=`python -c 'import json; import os; f=open("config.json");print(os.path.realpath(json.load(f)["dataDir"]));f.close()'`
+VENVDIR=`python -c 'import json;f=open("config.json");print(json.load(f)["venv_dir"]);f.close()'`
+BINDIR=`python -c 'import json;f=open("config.json");print(json.load(f)["bin_dir"]);f.close()'`
+DATADIR=`python -c 'import json; import os; f=open("config.json");print(os.path.realpath(json.load(f)["data_dir"]));f.close()'`
 
 # load Python virtual environment
 source "$VENVDIR/bin/activate"
@@ -22,5 +22,5 @@ snakemake --timestamp --rerun-incomplete --keep-going --nolock \
 	--config mode=LSF job_profiler="$BINDIR/pipes/Broad_LSF/lsf-report.py" \
 	--directory . \
 	--jobscript "$BINDIR/pipes/Broad_LSF/jobscript.sh" \
-	--cluster $BINDIR"/pipes/Broad_LSF/cluster-submitter.py {dependencies} $DATADIR {config[logDir]}" \
+	--cluster $BINDIR"/pipes/Broad_LSF/cluster-submitter.py {dependencies} $DATADIR {config[log_dir]}" \
 	"$@"

--- a/pipes/Broad_LSF/run-pipe.sh
+++ b/pipes/Broad_LSF/run-pipe.sh
@@ -10,6 +10,7 @@ reuse -q Perl-5.10
 # load config dirs from config.json
 VENVDIR=`python -c 'import json;f=open("config.json");print(json.load(f)["venvDir"]);f.close()'`
 BINDIR=`python -c 'import json;f=open("config.json");print(json.load(f)["binDir"]);f.close()'`
+DATADIR=`python -c 'import json; import os; f=open("config.json");print(os.path.realpath(json.load(f)["dataDir"]));f.close()'`
 
 # load Python virtual environment
 source "$VENVDIR/bin/activate"
@@ -21,5 +22,6 @@ snakemake --timestamp --rerun-incomplete --keep-going --nolock \
 	--config mode=LSF job_profiler="$BINDIR/pipes/Broad_LSF/lsf-report.py" \
 	--directory . \
 	--jobscript "$BINDIR/pipes/Broad_LSF/jobscript.sh" \
-	--cluster $BINDIR'/pipes/Broad_LSF/cluster-submitter.py {dependencies} {config[logDir]}' \
+	--cluster $BINDIR'/pipes/Broad_LSF/cluster-submitter.py {dependencies}' $DATADIR \
+    '{config[logDir]}' \
 	"$@"

--- a/pipes/Broad_UGER/jobscript.sh
+++ b/pipes/Broad_UGER/jobscript.sh
@@ -2,9 +2,9 @@
 # properties = {properties}
 # this is identical to the default jobscript with the exception of the exit code
 
-BINDIR=`python -c 'import json; import os; f=open("config.json");print(os.path.realpath(json.load(f)["binDir"]));f.close()'`
-DATADIR=`python -c 'import json; import os; f=open("config.json");print(os.path.realpath(json.load(f)["dataDir"]));f.close()'`
-VENVDIR=`python -c 'import json; import os; f=open("config.json");print(os.path.realpath(json.load(f)["venvDir"]));f.close()'`
+BINDIR=`python -c 'import json; import os; f=open("config.json");print(os.path.realpath(json.load(f)["bin_dir"]));f.close()'`
+DATADIR=`python -c 'import json; import os; f=open("config.json");print(os.path.realpath(json.load(f)["data_dir"]));f.close()'`
+VENVDIR=`python -c 'import json; import os; f=open("config.json");print(os.path.realpath(json.load(f)["venv_dir"]));f.close()'`
 
 source "$BINDIR/pipes/Broad_UGER/setup_dotkits.sh"
 

--- a/pipes/Broad_UGER/run-pipe.sh
+++ b/pipes/Broad_UGER/run-pipe.sh
@@ -2,8 +2,8 @@
 # Wrappers around Snakemake for use on the Broad LSF cluster
 
 # load config dirs from config.json
-VENVDIR=`python -c 'import json; import os; f=open("config.json");print(os.path.realpath(json.load(f)["venvDir"]));f.close()'`
-BINDIR=`python -c 'import json; import os; f=open("config.json");print(os.path.realpath(json.load(f)["binDir"]));f.close()'`
+VENVDIR=`python -c 'import json; import os; f=open("config.json");print(os.path.realpath(json.load(f)["venv_dir"]));f.close()'`
+BINDIR=`python -c 'import json; import os; f=open("config.json");print(os.path.realpath(json.load(f)["bin_dir"]));f.close()'`
 
 source "$BINDIR/pipes/Broad_UGER/setup_dotkits.sh"
 
@@ -17,5 +17,5 @@ snakemake --timestamp --rerun-incomplete --keep-going --nolock \
     --config mode=UGER \
     --directory . \
     --jobscript "$BINDIR/pipes/Broad_UGER/jobscript.sh" \
-    --cluster $BINDIR'/pipes/Broad_UGER/cluster-submitter.py {dependencies} {config[logDir]}' \
+    --cluster $BINDIR'/pipes/Broad_UGER/cluster-submitter.py {dependencies} {config[log_dir]}' \
     "$@"

--- a/pipes/Snakefile
+++ b/pipes/Snakefile
@@ -12,7 +12,7 @@ __author__ = 'Daniel Park <dpark@broadinstitute.org>'
 import os
 
 configfile: "config.json"
-pipesDir = os.path.join(os.path.expanduser(config['binDir']), 'pipes', 'rules')
+pipesDir = os.path.join(os.path.expanduser(config['bin_dir']), 'pipes', 'rules')
 
 include: os.path.join(pipesDir, 'common.rules')
 set_env_vars()
@@ -28,25 +28,25 @@ include: os.path.join(pipesDir, 'reports.rules')
 rule all:
     input:
         # create final assemblies for all samples
-        expand("{dataDir}/{subdir}/{sample}.fasta",
-            dataDir=config["dataDir"], subdir=config["subdirs"]["assembly"],
+        expand("{data_dir}/{subdir}/{sample}.fasta",
+            data_dir=config["data_dir"], subdir=config["subdirs"]["assembly"],
             sample=read_samples_file(config["samples_assembly"])),
         # create BAMs of aligned reads to own consensus and to common ref
-        expand("{dataDir}/{subdir}/{sample}.bam",
-            dataDir=config["dataDir"], subdir=config["subdirs"]["align_self"],
+        expand("{data_dir}/{subdir}/{sample}.bam",
+            data_dir=config["data_dir"], subdir=config["subdirs"]["align_self"],
             sample=read_samples_file(config["samples_assembly"])),
         # intrahost variant calling
-        config["dataDir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.vcf.gz',
+        config["data_dir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.vcf.gz',
         # create summary reports
-        config["reportsDir"]+'/summary.fastqc.txt',
-        config["reportsDir"]+'/summary.spike_count.txt'
+        config["reports_dir"]+'/summary.fastqc.txt',
+        config["reports_dir"]+'/summary.spike_count.txt'
     params: LSF="-N"
     run:
             if "job_profiler" in config:
                 print("running report on all job runs")
-                shell("{config[job_profiler]} {config[logDir]} {config[reportsDir]}/summary.job_stats.txt")
+                shell("{config[job_profiler]} {config[log_dir]} {config[reports_dir]}/summary.job_stats.txt")
             print("echo all done!")
 
 rule clean:
     params: LSF="-N"
-    shell: "rm -rf {config[tmpDir]}/* .snakemake/tmp.*"
+    shell: "rm -rf {config[tmp_dir]}/* .snakemake/tmp.*"

--- a/pipes/config.json
+++ b/pipes/config.json
@@ -5,17 +5,17 @@
   "accessions_file_for_lastal_db_build": "",
 
 
-  "bmTaggerDbDir":  "/idi/sabeti-scratch/kandersen/references/depletion_databases",
-  "bmTaggerDbs_remove": [
+  "bm_tagger_db_dir":  "/idi/sabeti-scratch/kandersen/references/depletion_databases",
+  "bm_tagger_dbs_remove": [
     "hg19",
     "GRCh37.68_ncRNA-GRCh37.68_transcripts-HS_rRNA_mitRNA",
     "metagenomics_contaminants_v3"],
 
-  "blastDbDir":     "/idi/sabeti-scratch/kandersen/references/depletion_databases",
-  "blastDb_remove": "metag_v3.ncRNA.mRNA.mitRNA.consensus",
+  "blast_db_dir":     "/idi/sabeti-scratch/kandersen/references/depletion_databases",
+  "blast_db_remove": "metag_v3.ncRNA.mRNA.mitRNA.consensus",
 
-  "trim_clipDb":    "/idi/sabeti-scratch/kandersen/references/depletion_databases/contaminants.fasta",
-  "spikeinsDb":     "/idi/sabeti-scratch/kandersen/references/other/ercc_spike-ins.fasta",
+  "trim_clip_db":    "/idi/sabeti-scratch/kandersen/references/depletion_databases/contaminants.fasta",
+  "spikeins_db":     "/idi/sabeti-scratch/kandersen/references/other/ercc_spike-ins.fasta",
 
   "env_vars": {
     "GATK_PATH":       "/humgen/gsa-hpprojects/GATK/bin/GenomeAnalysisTK-3.3-0-g37228af",
@@ -33,15 +33,16 @@
   },
 
 
-  "dataDir":    "data",
-  "tmpDir":     "tmp",
-  "logDir":     "log",
-  "reportsDir": "reports",
-  "binDir":     "bin",
-  "venvDir":    "venv",
   "project":    "viral_ngs",
-  "ref_genome":     "ref_genome",
-  "lastal_refDb":   "lastal_db",
+
+  "data_dir":    "data",
+  "tmp_dir":     "tmp",
+  "log_dir":     "log",
+  "reports_dir": "reports",
+  "bin_dir":     "bin",
+  "venv_dir":    "venv",
+  "ref_genome_dir":     "ref_genome",
+  "lastal_ref_db_dir":   "lastal_db",
 
   "seqruns_demux":     "flowcells.txt",
   "samples_depletion": "samples-depletion.txt",

--- a/pipes/config.json
+++ b/pipes/config.json
@@ -5,8 +5,8 @@
   "accessions_file_for_lastal_db_build": "",
 
 
-  "bm_tagger_db_dir":  "/idi/sabeti-scratch/kandersen/references/depletion_databases",
-  "bm_tagger_dbs_remove": [
+  "bmtagger_db_dir":  "/idi/sabeti-scratch/kandersen/references/depletion_databases",
+  "bmtagger_dbs_remove": [
     "hg19",
     "GRCh37.68_ncRNA-GRCh37.68_transcripts-HS_rRNA_mitRNA",
     "metagenomics_contaminants_v3"],

--- a/pipes/config.json
+++ b/pipes/config.json
@@ -1,7 +1,6 @@
 {
   
   "email_point_of_contact_for_ncbi" : "someone@example.com",
-  "number_of_chromosomes": 1,
   "accessions_for_ref_genome_build": ["KJ660346.2"],
   "accessions_file_for_lastal_db_build": "",
 

--- a/pipes/config.json
+++ b/pipes/config.json
@@ -4,7 +4,6 @@
   "number_of_chromosomes": 1,
   "accessions_for_ref_genome_build": ["KJ660346.2"],
   "accessions_file_for_lastal_db_build": "",
-  "ref_genome_file_prefix": "ebov",
 
 
   "bmTaggerDbDir":  "/idi/sabeti-scratch/kandersen/references/depletion_databases",

--- a/pipes/ref_assisted/Snakefile
+++ b/pipes/ref_assisted/Snakefile
@@ -63,8 +63,8 @@ def make_run_hash(fname, length=6):
 
 rule all:
     input:
-        expand("{dataDir}/{sample}.fasta",
-            dataDir=config["dataDir"],
+        expand("{data_dir}/{sample}.fasta",
+            data_dir=config["data_dir"],
             sample=get_sample_list(config["samples"]))
 
 ##############################################
@@ -88,7 +88,7 @@ rule bams_from_fastq:
             run_date = get_file_date(input[0])
             info = get_sample_info(wildcards.sample, config["samples"])
             hash = make_run_hash(config["samples"])
-            shell("{config[binDir]}/read_utils.py fastq_to_bam {input} {output} " \
+            shell("{config[bin_dir]}/read_utils.py fastq_to_bam {input} {output} " \
                 + "--sampleName {wildcards.sample} --picardOptions " \
                 + "SEQUENCING_CENTER={params.center} " \
                 + "RUN_DATE={run_date} " \
@@ -106,10 +106,10 @@ rule ref_guided_consensus:
     resources: mem=4
     params: LSF='-W 4:00',
             logid="{sample}",
-            refGenome=os.path.expanduser(os.path.join(config["ref_genome"],"reference"+".fasta")),
+            refGenome=os.path.expanduser(os.path.join(config["ref_genome_dir"],"reference"+".fasta")),
             novoalign_options=config["refine_options"]["novoalign"],
             min_coverage=config["refine_options"]["min_coverage"]
-    shell:  "{config[binDir]}/assembly.py refine_assembly " \
+    shell:  "{config[bin_dir]}/assembly.py refine_assembly " \
                 + "{params.refGenome} {input} {output[2]} " \
                 + "--outBam {output[0]} " \
                 + "--outVcf {output[1]} " \

--- a/pipes/ref_assisted/Snakefile
+++ b/pipes/ref_assisted/Snakefile
@@ -106,7 +106,7 @@ rule ref_guided_consensus:
     resources: mem=4
     params: LSF='-W 4:00',
             logid="{sample}",
-            refGenome=os.path.expanduser(os.path.join(config["ref_genome"],config["ref_genome_file_prefix"]+".fasta")),
+            refGenome=os.path.expanduser(os.path.join(config["ref_genome"],"reference"+".fasta")),
             novoalign_options=config["refine_options"]["novoalign"],
             min_coverage=config["refine_options"]["min_coverage"]
     shell:  "{config[binDir]}/assembly.py refine_assembly " \

--- a/pipes/ref_assisted/config.json
+++ b/pipes/ref_assisted/config.json
@@ -10,11 +10,11 @@
   "fastqs_gzipped":  false,
   "n_cores":         4,
   "max_ram":         16,
-  "ref_genome":      "~/resources/ref_genome/genome.fasta",
+  "ref_genome_dir":      "~/resources/ref_genome/genome.fasta",
 
-  "dataDir":         "data",
-  "logDir":          "log",
-  "binDir":          "~/viral-ngs",
-  "venvDir":         "~/venv",
+  "data_dir":         "data",
+  "log_dir":          "log",
+  "bin_dir":          "~/viral-ngs",
+  "venv_dir":         "~/venv",
   "project":         "viral_ngs"
 }

--- a/pipes/ref_assisted/ref_assisted
+++ b/pipes/ref_assisted/ref_assisted
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # load config dirs from config.json
-BIN_DIR=`python -c 'import json,os.path;f=open("config.json");print(os.path.expanduser(json.load(f)["binDir"]));f.close()'`
+BIN_DIR=`python -c 'import json,os.path;f=open("config.json");print(os.path.expanduser(json.load(f)["bin_dir"]));f.close()'`
 N_CORES=`python -c 'import json;f=open("config.json");print(json.load(f)["n_cores"]);f.close()'`
 MAX_RAM=`python -c 'import json;f=open("config.json");print(json.load(f)["max_ram"]);f.close()'`
 

--- a/pipes/rules/assembly.rules
+++ b/pipes/rules/assembly.rules
@@ -13,19 +13,19 @@ import os, os.path, time, shutil
 rule all_assemble:
     input:
         # create final assemblies for all samples
-        expand("{dataDir}/{subdir}/{sample}.fasta",
-            dataDir=config["dataDir"], subdir=config["subdirs"]["assembly"],
+        expand("{data_dir}/{subdir}/{sample}.fasta",
+            data_dir=config["data_dir"], subdir=config["subdirs"]["assembly"],
             sample=read_samples_file(config["samples_assembly"])),
         # create BAMs of aligned reads to own consensus
-        expand("{dataDir}/{subdir}/{sample}.bam",
-            dataDir=config["dataDir"], subdir=config["subdirs"]["align_self"],
+        expand("{data_dir}/{subdir}/{sample}.bam",
+            data_dir=config["data_dir"], subdir=config["subdirs"]["align_self"],
             sample=read_samples_file(config["samples_assembly"]))
     params: LSF="-N"
 
 rule all_assemble_failures:
     input:
-        expand("{dataDir}/{subdir}/{sample}.fasta",
-            dataDir=config["dataDir"], subdir=config["subdirs"]["assembly"],
+        expand("{data_dir}/{subdir}/{sample}.fasta",
+            data_dir=config["data_dir"], subdir=config["subdirs"]["assembly"],
             sample=read_samples_file(config.get("samples_assembly_failures")))
     params: LSF="-N"
 
@@ -36,8 +36,8 @@ rule assemble_trinity:
         First trim reads with trimmomatic, rmdup with prinseq,
         and random subsample to no more than 100k reads.
     '''
-    input:  config["dataDir"]+'/'+config["subdirs"]["per_sample"]+'/{sample}.taxfilt.bam'
-    output: config["tmpDir"] +'/'+config["subdirs"]["assembly"]+'/{sample}.assembly1-trinity.fasta'
+    input:  config["data_dir"]+'/'+config["subdirs"]["per_sample"]+'/{sample}.taxfilt.bam'
+    output: config["tmp_dir"] +'/'+config["subdirs"]["assembly"]+'/{sample}.assembly1-trinity.fasta'
     resources: 
             mem=4,
             cores=int(config.get("number_of_threads", 1))
@@ -45,14 +45,14 @@ rule assemble_trinity:
             UGER=config.get('UGER_queues', {}).get('short', '-q short'),
             n_reads=str(config["trinity_n_reads"]),
             logid="{sample}",
-            clipDb=config["trim_clipDb"],
-            subsamp_bam=config["tmpDir"]+'/'+config["subdirs"]["assembly"]+'/{sample}.subsamp.bam',
+            clipDb=config["trim_clip_db"],
+            subsamp_bam=config["tmp_dir"]+'/'+config["subdirs"]["assembly"]+'/{sample}.subsamp.bam',
             numThreads=str(config.get("number_of_threads", 1))
     run:
             makedirs(expand("{dir}/{subdir}",
-                dir=[config["dataDir"],config["tmpDir"]],
+                dir=[config["data_dir"],config["tmp_dir"]],
                 subdir=config["subdirs"]["assembly"]))
-            shell("{config[binDir]}/assembly.py assemble_trinity {input} {params.clipDb} {output} --n_reads={params.n_reads} --outReads {params.subsamp_bam} --threads {params.numThreads}")
+            shell("{config[bin_dir]}/assembly.py assemble_trinity {input} {params.clipDb} {output} --n_reads={params.n_reads} --outReads {params.subsamp_bam} --threads {params.numThreads}")
 
 rule orient_and_impute:
     ''' This step cleans up the Trinity assembly with a known reference genome.
@@ -77,13 +77,13 @@ rule orient_and_impute:
             multi-chromosome genomes.
     '''
     input:  
-        config["tmpDir"]+'/'+config["subdirs"]["assembly"]+'/{sample}.assembly1-trinity.fasta',
-        expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name="reference" )
-    output: config["tmpDir"]+'/'+config["subdirs"]["assembly"]+'/{sample}.assembly3-modify.fasta'
+        config["tmp_dir"]+'/'+config["subdirs"]["assembly"]+'/{sample}.assembly1-trinity.fasta',
+        expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome_dir"], ref_name="reference" )
+    output: config["tmp_dir"]+'/'+config["subdirs"]["assembly"]+'/{sample}.assembly3-modify.fasta'
     resources: mem=3
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             UGER=config.get('UGER_queues', {}).get('short', '-q short'),
-            refGenome=os.path.join(config["ref_genome"],"reference"+".fasta"),
+            refGenome=os.path.join(config["ref_genome_dir"],"reference"+".fasta"),
             # length should be defined as a fraction/percentage cutoff, relative to 
             # reference length for a given sequence. float is in the config.json file
             length = str(config["assembly_min_length_fraction_of_reference"]),
@@ -91,11 +91,11 @@ rule orient_and_impute:
             renamed_prefix="",
             replace_length="55",
             logid="{sample}",
-            vfat_fasta=config["tmpDir"]+'/'+config["subdirs"]["assembly"]+'/{sample}.assembly2-vfat.fasta',
-            subsamp_bam=config["tmpDir"]+'/'+config["subdirs"]["assembly"]+'/{sample}.subsamp.bam'
+            vfat_fasta=config["tmp_dir"]+'/'+config["subdirs"]["assembly"]+'/{sample}.assembly2-vfat.fasta',
+            subsamp_bam=config["tmp_dir"]+'/'+config["subdirs"]["assembly"]+'/{sample}.subsamp.bam'
     run:
-            shell("{config[binDir]}/assembly.py order_and_orient {input[0]} {params.refGenome} {params.vfat_fasta} --inReads {params.subsamp_bam}")
-            shell("{config[binDir]}/assembly.py impute_from_reference {params.vfat_fasta} {params.refGenome} {output} --newName {params.renamed_prefix}{wildcards.sample} --replaceLength {params.replace_length} --minLengthFraction {params.length} --minUnambig {params.min_unambig}")
+            shell("{config[bin_dir]}/assembly.py order_and_orient {input[0]} {params.refGenome} {params.vfat_fasta} --inReads {params.subsamp_bam}")
+            shell("{config[bin_dir]}/assembly.py impute_from_reference {params.vfat_fasta} {params.refGenome} {output} --newName {params.renamed_prefix}{wildcards.sample} --replaceLength {params.replace_length} --minLengthFraction {params.length} --minUnambig {params.min_unambig}")
 
 rule refine_assembly_1:
     ''' This a first pass refinement step where we take the VFAT assembly,
@@ -109,10 +109,10 @@ rule refine_assembly_1:
         IndelRealigner (in order to call indels).
         Output FASTA file is indexed for Picard, Samtools, and Novoalign.
     '''
-    input:  config["tmpDir"] +'/'+config["subdirs"]["assembly"]+'/{sample}.assembly3-modify.fasta',
-            config["dataDir"]+'/'+config["subdirs"]["per_sample"]+'/{sample}.cleaned.bam'
-    output: config["tmpDir"] +'/'+config["subdirs"]["assembly"]+'/{sample}.assembly4-refined.fasta',
-            config["tmpDir"] +'/'+config["subdirs"]["assembly"]+'/{sample}.assembly3.vcf.gz'
+    input:  config["tmp_dir"] +'/'+config["subdirs"]["assembly"]+'/{sample}.assembly3-modify.fasta',
+            config["data_dir"]+'/'+config["subdirs"]["per_sample"]+'/{sample}.cleaned.bam'
+    output: config["tmp_dir"] +'/'+config["subdirs"]["assembly"]+'/{sample}.assembly4-refined.fasta',
+            config["tmp_dir"] +'/'+config["subdirs"]["assembly"]+'/{sample}.assembly3.vcf.gz'
     resources: 
             mem=7,
             cores=int(config.get("number_of_threads", 1))
@@ -122,7 +122,7 @@ rule refine_assembly_1:
             novoalign_options = "-r Random -l 30 -g 40 -x 20 -t 502",
             min_coverage = "2",
             numThreads=str(config.get("number_of_threads", 1))
-    shell:  "{config[binDir]}/assembly.py refine_assembly {input} {output[0]} --outVcf {output[1]} --min_coverage {params.min_coverage} --novo_params '{params.novoalign_options}' --threads {params.numThreads}"
+    shell:  "{config[bin_dir]}/assembly.py refine_assembly {input} {output[0]} --outVcf {output[1]} --min_coverage {params.min_coverage} --novo_params '{params.novoalign_options}' --threads {params.numThreads}"
 
 rule refine_assembly_2:
     ''' This a second pass refinement step very similar to the first.
@@ -133,10 +133,10 @@ rule refine_assembly_2:
         The output of this step is the final assembly for this sample.
         Final FASTA file is indexed for Picard, Samtools, and Novoalign.
     '''
-    input:  config["tmpDir"] +'/'+config["subdirs"]["assembly"]+'/{sample}.assembly4-refined.fasta',
-            config["dataDir"]+'/'+config["subdirs"]["per_sample"]+'/{sample}.cleaned.bam'
-    output: config["dataDir"]+'/'+config["subdirs"]["assembly"]+'/{sample}.fasta',
-            config["tmpDir"] +'/'+config["subdirs"]["assembly"]+'/{sample}.assembly4.vcf.gz'
+    input:  config["tmp_dir"] +'/'+config["subdirs"]["assembly"]+'/{sample}.assembly4-refined.fasta',
+            config["data_dir"]+'/'+config["subdirs"]["per_sample"]+'/{sample}.cleaned.bam'
+    output: config["data_dir"]+'/'+config["subdirs"]["assembly"]+'/{sample}.fasta',
+            config["tmp_dir"] +'/'+config["subdirs"]["assembly"]+'/{sample}.assembly4.vcf.gz'
     resources: 
             mem=7,
             cores=int(config.get("number_of_threads", 1))
@@ -146,7 +146,7 @@ rule refine_assembly_2:
             novoalign_options = "-r Random -l 40 -g 40 -x 20 -t 100",
             min_coverage = "3",
             numThreads=str(config.get("number_of_threads", 1))
-    shell:  "{config[binDir]}/assembly.py refine_assembly {input} {output[0]} --outVcf {output[1]} --min_coverage {params.min_coverage} --novo_params '{params.novoalign_options}' --threads {params.numThreads}"
+    shell:  "{config[bin_dir]}/assembly.py refine_assembly {input} {output[0]} --outVcf {output[1]} --min_coverage {params.min_coverage} --novo_params '{params.novoalign_options}' --threads {params.numThreads}"
 
 rule map_reads_to_self:
     ''' After the final assembly is produced, we also produce BAM files with all reads
@@ -155,10 +155,10 @@ rule map_reads_to_self:
             {sample}.mapped.bam - only mapped reads, duplicates removed by Picard,
                                   realigned with GATK IndelRealigner
     '''
-    input:  config["dataDir"]+'/'+config["subdirs"]["per_sample"]+'/{sample}.cleaned.bam',
-            config["dataDir"]+'/'+config["subdirs"]["assembly"]+'/{sample}.fasta'
-    output: config["dataDir"]+'/'+config["subdirs"]["align_self"]+'/{sample}.bam',
-            config["dataDir"]+'/'+config["subdirs"]["align_self"]+'/{sample}.mapped.bam'
+    input:  config["data_dir"]+'/'+config["subdirs"]["per_sample"]+'/{sample}.cleaned.bam',
+            config["data_dir"]+'/'+config["subdirs"]["assembly"]+'/{sample}.fasta'
+    output: config["data_dir"]+'/'+config["subdirs"]["align_self"]+'/{sample}.bam',
+            config["data_dir"]+'/'+config["subdirs"]["align_self"]+'/{sample}.mapped.bam'
     resources: 
             mem=4,
             cores=int(config.get("number_of_threads", 1))
@@ -168,6 +168,6 @@ rule map_reads_to_self:
             novoalign_options = "-r Random -l 40 -g 40 -x 20 -t 100 -k -c 3",
             numThreads=str(config.get("number_of_threads", 1))
     run:
-            makedirs([os.path.join(config["dataDir"], config["subdirs"]["align_self"]),
-                os.path.join(config["reportsDir"], "assembly")])
-            shell("{config[binDir]}/read_utils.py align_and_fix {input} --outBamAll {output[0]} --outBamFiltered {output[1]} --novoalign_options '{params.novoalign_options}' --threads {params.numThreads}")
+            makedirs([os.path.join(config["data_dir"], config["subdirs"]["align_self"]),
+                os.path.join(config["reports_dir"], "assembly")])
+            shell("{config[bin_dir]}/read_utils.py align_and_fix {input} --outBamAll {output[0]} --outBamFiltered {output[1]} --novoalign_options '{params.novoalign_options}' --threads {params.numThreads}")

--- a/pipes/rules/assembly.rules
+++ b/pipes/rules/assembly.rules
@@ -78,12 +78,12 @@ rule orient_and_impute:
     '''
     input:  
         config["tmpDir"]+'/'+config["subdirs"]["assembly"]+'/{sample}.assembly1-trinity.fasta',
-        expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name=config["ref_genome_file_prefix"] )
+        expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name="reference" )
     output: config["tmpDir"]+'/'+config["subdirs"]["assembly"]+'/{sample}.assembly3-modify.fasta'
     resources: mem=3
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             UGER=config.get('UGER_queues', {}).get('short', '-q short'),
-            refGenome=os.path.join(config["ref_genome"],config["ref_genome_file_prefix"]+".fasta"),
+            refGenome=os.path.join(config["ref_genome"],"reference"+".fasta"),
             # length should be defined as a fraction/percentage cutoff, relative to 
             # reference length for a given sequence. float is in the config.json file
             length = str(config["assembly_min_length_fraction_of_reference"]),

--- a/pipes/rules/demux.rules
+++ b/pipes/rules/demux.rules
@@ -43,7 +43,7 @@ def get_run_id(well):
     return run_id
 
 def get_bam_path(lane, well):
-    return os.path.join(config['tmpDir'], config['subdirs']['demux'],
+    return os.path.join(config['tmp_dir'], config['subdirs']['demux'],
         'bams_per_lane', lane['flowcell'] + '.' + lane['lane'],
         get_run_id(well) + ".bam")
 
@@ -59,7 +59,7 @@ def get_all_runs(runfile):
 rule all_demux_basecalls:
     input:  
             expand("{dir}/{flowlane}/{lib}.bam",
-                dir = os.path.join(config['tmpDir'], config['subdirs']['demux'], 'bams_per_lane'),
+                dir = os.path.join(config['tmp_dir'], config['subdirs']['demux'], 'bams_per_lane'),
                 flowlane = get_all_lanes(config.get('seqruns_demux','')),
                 lib = 'Unmatched')
     params: LSF="-N"
@@ -67,17 +67,17 @@ rule all_demux_basecalls:
 rule all_demux:
     input:
             expand("{dir}/{run}.bam",
-                dir = os.path.join(config['dataDir'], config['subdirs']['source']),
+                dir = os.path.join(config['data_dir'], config['subdirs']['source']),
                 run=get_all_runs(config.get('seqruns_demux','')))
     params: LSF="-N"
 
 
 rule illumina_demux:
     input:  config.get('seqruns_demux','DNE')
-    output: config['tmpDir']+'/'+config['subdirs']['demux']+'/bams_per_lane/{flowcell}.{lane}/Unmatched.bam',
-            config['reportsDir']+'/barcodes/barcodes-metrics-{flowcell}.{lane}.txt'
+    output: config['tmp_dir']+'/'+config['subdirs']['demux']+'/bams_per_lane/{flowcell}.{lane}/Unmatched.bam',
+            config['reports_dir']+'/barcodes/barcodes-metrics-{flowcell}.{lane}.txt'
             #expand("{dir}/{{flowcell}}.{{lane}}/{sample}.bam",
-            #    dir = config['tmpDir']+'/'+config['subdirs']['demux']+'/bams_per_lane/',
+            #    dir = config['tmp_dir']+'/'+config['subdirs']['demux']+'/bams_per_lane/',
             #    sample = get_all_demux_outs(config.get('seqruns_demux','DNE'), flowcell, lane),
             #    )
     resources: mem=80
@@ -94,7 +94,7 @@ rule illumina_demux:
             for opt in ('minimum_base_quality', 'max_mismatches', 'min_mismatch_delta', 'max_no_calls', 'read_structure', 'minimum_quality', 'run_start_date'):
                 if lane.get(opt):
                     opts += ' --%s=%s' % (opt, lane[opt])
-            shell("{config[binDir]}/illumina.py illumina_demux {lane[bustard_dir]} {wildcards.lane} {outdir} --sampleSheet={lane[barcode_file]} --sequencing_center={params.center} --outMetrics={output[1]} --flowcell={wildcards.flowcell} {opts}")
+            shell("{config[bin_dir]}/illumina.py illumina_demux {lane[bustard_dir]} {wildcards.lane} {outdir} --sampleSheet={lane[barcode_file]} --sequencing_center={params.center} --outMetrics={output[1]} --flowcell={wildcards.flowcell} {opts}")
 
 
 def demux_move_bams_inputs(wildcards):
@@ -105,25 +105,25 @@ def demux_move_bams_inputs(wildcards):
     return "unreachable-{}-{}-{}-{}".format(wildcards.sample, wildcards.library, wildcards.flowcell, wildcards.lane)
 rule move_bams_demux:
     input:  demux_move_bams_inputs
-    output: config['dataDir']+'/'+config['subdirs']['source']+'/{sample}.l{library}.{flowcell}.{lane}.bam'
+    output: config['data_dir']+'/'+config['subdirs']['source']+'/{sample}.l{library}.{flowcell}.{lane}.bam'
     params: logid="{sample}.l{library}.{flowcell}.{lane}"
     run:
-            makedirs(os.path.join(config['dataDir'], config['subdirs']['source']))
+            makedirs(os.path.join(config['data_dir'], config['subdirs']['source']))
             shutil.move(input[0], output[0])
 
 rule bams_from_fastq:
-    input:  os.path.join(config['dataDir'],config['subdirs']['source'],'{sample}_L001_R1_001.fastq.gz'),
-            os.path.join(config['dataDir'],config['subdirs']['source'],'{sample}_L001_R2_001.fastq.gz'),
-            os.path.join(config['dataDir'],config['subdirs']['source'],'SampleSheet.csv'),
-            os.path.join(config['dataDir'],config['subdirs']['source'],'RunInfo.xml')
-    output: os.path.join(config['dataDir'],config['subdirs']['source'],'{sample}.bam')
+    input:  os.path.join(config['data_dir'],config['subdirs']['source'],'{sample}_L001_R1_001.fastq.gz'),
+            os.path.join(config['data_dir'],config['subdirs']['source'],'{sample}_L001_R2_001.fastq.gz'),
+            os.path.join(config['data_dir'],config['subdirs']['source'],'SampleSheet.csv'),
+            os.path.join(config['data_dir'],config['subdirs']['source'],'RunInfo.xml')
+    output: os.path.join(config['data_dir'],config['subdirs']['source'],'{sample}.bam')
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             UGER=config.get('UGER_queues', {}).get('short', '-q short'),
             logid="{sample}",
             center=config["seq_center"]
     run:
-            makedirs(os.path.join(config['dataDir'], config['subdirs']['source']))
-            shell("{config[binDir]}/illumina.py miseq_fastq_to_bam {output} {input[2]} {input[0]} --inFastq2 {input[1]} --runInfo {input[3]} --sequencing_center {params.center}")
+            makedirs(os.path.join(config['data_dir'], config['subdirs']['source']))
+            shell("{config[bin_dir]}/illumina.py miseq_fastq_to_bam {output} {input[2]} {input[0]} --inFastq2 {input[1]} --runInfo {input[3]} --sequencing_center {params.center}")
 
 ruleorder: move_bams_demux > bams_from_fastq
 

--- a/pipes/rules/hs_deplete.rules
+++ b/pipes/rules/hs_deplete.rules
@@ -13,8 +13,8 @@ import os
 
 rule all_deplete:
     input:
-        expand("{dataDir}/{subdir}/{sample}.{adjective}.bam",
-            dataDir=config["dataDir"],
+        expand("{data_dir}/{subdir}/{sample}.{adjective}.bam",
+            data_dir=config["data_dir"],
             subdir=config["subdirs"]["per_sample"],
             adjective=['cleaned','taxfilt'],
             sample=read_samples_file(config["samples_depletion"])),
@@ -23,22 +23,22 @@ rule all_deplete:
 rule depletion:
     ''' Runs a full human read depletion pipeline and removes PCR duplicates
     '''
-    input:  config["dataDir"]+'/'+config["subdirs"]["source"]+'/{sample}.bam'
-    output: config["tmpDir"] +'/'+config["subdirs"]["depletion"]+'/{sample}.bmtagger_depleted.bam',
-            config["tmpDir"] +'/'+config["subdirs"]["depletion"]+'/{sample}.rmdup.bam',
-            config["dataDir"]+'/'+config["subdirs"]["depletion"]+'/{sample}.cleaned.bam'
+    input:  config["data_dir"]+'/'+config["subdirs"]["source"]+'/{sample}.bam'
+    output: config["tmp_dir"] +'/'+config["subdirs"]["depletion"]+'/{sample}.bmtagger_depleted.bam',
+            config["tmp_dir"] +'/'+config["subdirs"]["depletion"]+'/{sample}.rmdup.bam',
+            config["data_dir"]+'/'+config["subdirs"]["depletion"]+'/{sample}.cleaned.bam'
     resources: mem=15
     params: LSF=config.get('LSF_queues', {}).get('long', '-q forest'),
             UGER=config.get('UGER_queues', {}).get('long', '-q long'),
-            bmtaggerDbs = expand("{dbdir}/{db}", dbdir=config["bmTaggerDbDir"], db=config["bmTaggerDbs_remove"]),
-            blastDbs = expand("{dbdir}/{db}", dbdir=config["blastDbDir"], db=config["blastDb_remove"]),
-            revert_bam = config["tmpDir"] +'/'+config["subdirs"]["depletion"]+'/{sample}.raw.bam',
+            bmtaggerDbs = expand("{dbdir}/{db}", dbdir=config["bm_tagger_db_dir"], db=config["bm_tagger_dbs_remove"]),
+            blastDbs = expand("{dbdir}/{db}", dbdir=config["blast_db_dir"], db=config["blast_db_remove"]),
+            revert_bam = config["tmp_dir"] +'/'+config["subdirs"]["depletion"]+'/{sample}.raw.bam',
             logid="{sample}"
     run:
             makedirs(expand("{dir}/{subdir}",
-                dir=[config["dataDir"],config["tmpDir"]],
+                dir=[config["data_dir"],config["tmp_dir"]],
                 subdir=config["subdirs"]["depletion"]))
-            shell("{config[binDir]}/taxon_filter.py deplete_human {input} {params.revert_bam} {output} --bmtaggerDbs {params.bmtaggerDbs} --blastDbs {params.blastDbs} --JVMmemory 15g")
+            shell("{config[bin_dir]}/taxon_filter.py deplete_human {input} {params.revert_bam} {output} --bmtaggerDbs {params.bmtaggerDbs} --blastDbs {params.blastDbs} --JVMmemory 15g")
             os.unlink(params.revert_bam)
 
 rule filter_to_taxon:
@@ -46,34 +46,34 @@ rule filter_to_taxon:
         level or greater for the virus of interest).
     '''
     input:  
-        config["dataDir"]+'/'+config["subdirs"]["depletion"]+'/{sample}.cleaned.bam',
-        expand('{lastal_refDb}/lastal.bck', lastal_refDb=config["lastal_refDb"]),
-        expand('{lastal_refDb}/lastal.des', lastal_refDb=config["lastal_refDb"]),
-        expand('{lastal_refDb}/lastal.prj', lastal_refDb=config["lastal_refDb"]),
-        expand('{lastal_refDb}/lastal.sds', lastal_refDb=config["lastal_refDb"]),
-        expand('{lastal_refDb}/lastal.ssp', lastal_refDb=config["lastal_refDb"]),
-        expand('{lastal_refDb}/lastal.suf', lastal_refDb=config["lastal_refDb"]),
-        expand('{lastal_refDb}/lastal.tis', lastal_refDb=config["lastal_refDb"])
-    output: config["dataDir"]+'/'+config["subdirs"]["depletion"]+'/{sample}.taxfilt.bam'
+        config["data_dir"]+'/'+config["subdirs"]["depletion"]+'/{sample}.cleaned.bam',
+        expand('{lastal_ref_db_dir}/lastal.bck', lastal_ref_db_dir=config["lastal_ref_db_dir"]),
+        expand('{lastal_ref_db_dir}/lastal.des', lastal_ref_db_dir=config["lastal_ref_db_dir"]),
+        expand('{lastal_ref_db_dir}/lastal.prj', lastal_ref_db_dir=config["lastal_ref_db_dir"]),
+        expand('{lastal_ref_db_dir}/lastal.sds', lastal_ref_db_dir=config["lastal_ref_db_dir"]),
+        expand('{lastal_ref_db_dir}/lastal.ssp', lastal_ref_db_dir=config["lastal_ref_db_dir"]),
+        expand('{lastal_ref_db_dir}/lastal.suf', lastal_ref_db_dir=config["lastal_ref_db_dir"]),
+        expand('{lastal_ref_db_dir}/lastal.tis', lastal_ref_db_dir=config["lastal_ref_db_dir"])
+    output: config["data_dir"]+'/'+config["subdirs"]["depletion"]+'/{sample}.taxfilt.bam'
     resources: mem=3
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             UGER=config.get('UGER_queues', {}).get('short', '-q short'),
-            lastalDb=os.path.join(config["lastal_refDb"], "lastal"),
+            lastalDb=os.path.join(config["lastal_ref_db_dir"], "lastal"),
             logid="{sample}"
-    shell:  "{config[binDir]}/taxon_filter.py filter_lastal_bam {input[0]} {params.lastalDb} {output}"
+    shell:  "{config[bin_dir]}/taxon_filter.py filter_lastal_bam {input[0]} {params.lastalDb} {output}"
 
 def merge_one_per_sample_inputs(wildcards):
     if 'seqruns_demux' not in config or not os.path.isfile(config['seqruns_demux']):
-        return config["dataDir"]+'/'+config["subdirs"]["depletion"] +'/'+ wildcards.sample + '.' + wildcards.adjective + '.bam'
+        return config["data_dir"]+'/'+config["subdirs"]["depletion"] +'/'+ wildcards.sample + '.' + wildcards.adjective + '.bam'
     runs = set()
     for lane in read_tab_file(config['seqruns_demux']):
         for well in read_tab_file(lane['barcode_file']):
             if well['sample'] == wildcards.sample:
               if wildcards.adjective=='raw':
-                 runs.add(os.path.join(config["dataDir"], config["subdirs"]["source"],
+                 runs.add(os.path.join(config["data_dir"], config["subdirs"]["source"],
                     get_run_id(well) +'.'+ lane['flowcell'] +'.'+ lane['lane'] + '.bam'))
               else:
-                 runs.add(os.path.join(config["dataDir"], config["subdirs"]["depletion"],
+                 runs.add(os.path.join(config["data_dir"], config["subdirs"]["depletion"],
                     get_run_id(well) +'.'+ lane['flowcell'] +'.'+ lane['lane'] +'.'+ wildcards.adjective + '.bam'))
     return sorted(runs)
 rule merge_one_per_sample:
@@ -85,17 +85,17 @@ rule merge_one_per_sample:
         the rmdup step on a per-library basis after merging.
     '''
     input:  merge_one_per_sample_inputs
-    output: config["dataDir"]+'/'+config["subdirs"]["per_sample"] +'/{sample}.{adjective,raw|cleaned|taxfilt}.bam'
+    output: config["data_dir"]+'/'+config["subdirs"]["per_sample"] +'/{sample}.{adjective,raw|cleaned|taxfilt}.bam'
     resources: mem=7
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             UGER=config.get('UGER_queues', {}).get('short', '-q short'),
             logid="{sample}-{adjective}",
-            tmpf_bam=config["tmpDir"]+'/'+config["subdirs"]["depletion"] +'/{sample}.{adjective}.bam'
+            tmpf_bam=config["tmp_dir"]+'/'+config["subdirs"]["depletion"] +'/{sample}.{adjective}.bam'
     run:
-            makedirs(config["dataDir"]+'/'+config["subdirs"]["per_sample"])
+            makedirs(config["data_dir"]+'/'+config["subdirs"]["per_sample"])
             if wildcards.adjective == 'raw':
-                shell("{config[binDir]}/read_utils.py merge_bams {input} {output} --picardOptions SORT_ORDER=queryname")
+                shell("{config[bin_dir]}/read_utils.py merge_bams {input} {output} --picardOptions SORT_ORDER=queryname")
             else:
-                shell("{config[binDir]}/read_utils.py merge_bams {input} {params.tmpf_bam} --picardOptions SORT_ORDER=queryname")
-                shell("{config[binDir]}/read_utils.py rmdup_mvicuna_bam {params.tmpf_bam} {output} --JVMmemory 8g")
+                shell("{config[bin_dir]}/read_utils.py merge_bams {input} {params.tmpf_bam} --picardOptions SORT_ORDER=queryname")
+                shell("{config[bin_dir]}/read_utils.py rmdup_mvicuna_bam {params.tmpf_bam} {output} --JVMmemory 8g")
 

--- a/pipes/rules/hs_deplete.rules
+++ b/pipes/rules/hs_deplete.rules
@@ -30,7 +30,7 @@ rule depletion:
     resources: mem=15
     params: LSF=config.get('LSF_queues', {}).get('long', '-q forest'),
             UGER=config.get('UGER_queues', {}).get('long', '-q long'),
-            bmtaggerDbs = expand("{dbdir}/{db}", dbdir=config["bm_tagger_db_dir"], db=config["bm_tagger_dbs_remove"]),
+            bmtaggerDbs = expand("{dbdir}/{db}", dbdir=config["bmtagger_db_dir"], db=config["bmtagger_dbs_remove"]),
             blastDbs = expand("{dbdir}/{db}", dbdir=config["blast_db_dir"], db=config["blast_db_remove"]),
             revert_bam = config["tmp_dir"] +'/'+config["subdirs"]["depletion"]+'/{sample}.raw.bam',
             logid="{sample}"

--- a/pipes/rules/interhost.rules
+++ b/pipes/rules/interhost.rules
@@ -27,53 +27,53 @@ def update_timestamps(files):
 
 rule all_ref_guided:
     input:
-            os.path.join(config["dataDir"], config["subdirs"]["interhost"], 'ref_guided.fasta'),
-            os.path.join(config["dataDir"], config["subdirs"]["interhost"], 'ref_guided.vcf.gz')
+            os.path.join(config["data_dir"], config["subdirs"]["interhost"], 'ref_guided.fasta'),
+            os.path.join(config["data_dir"], config["subdirs"]["interhost"], 'ref_guided.vcf.gz')
 
 rule ref_guided_consensus:
     input:  
-            config["dataDir"]+'/'+config["subdirs"]["source"]+'/{sample}.bam',
-            expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name="reference" )
-    output: config["dataDir"]+'/'+config["subdirs"]["align_ref"]+'/{sample}.realigned.bam',
-            config["dataDir"]+'/'+config["subdirs"]["align_ref"]+'/{sample}.vcf.gz',
-            config["dataDir"]+'/'+config["subdirs"]["align_ref"]+'/{sample}.fasta'
+            config["data_dir"]+'/'+config["subdirs"]["source"]+'/{sample}.bam',
+            expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome_dir"], ref_name="reference" )
+    output: config["data_dir"]+'/'+config["subdirs"]["align_ref"]+'/{sample}.realigned.bam',
+            config["data_dir"]+'/'+config["subdirs"]["align_ref"]+'/{sample}.vcf.gz',
+            config["data_dir"]+'/'+config["subdirs"]["align_ref"]+'/{sample}.fasta'
     resources: 
             mem=4,
             cores=int(config.get("number_of_threads", 1))
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             UGER=config.get('UGER_queues', {}).get('short', '-q short'),
             logid="{sample}",
-            refGenome=os.path.join(config["ref_genome"],"reference"+".fasta"),
+            refGenome=os.path.join(config["ref_genome_dir"],"reference"+".fasta"),
             novoalign_options="-r Random -l 30 -g 40 -x 20 -t 502",
             min_coverage="3",
             numThreads=str(config.get("number_of_threads", 1))
     run:
             makedirs(expand("{dir}/{subdir}",
-                dir=[config["dataDir"]],
+                dir=[config["data_dir"]],
                 subdir=[config["subdirs"]["align_ref"], config["subdirs"]["interhost"]]))
-            shell("{config[binDir]}/assembly.py refine_assembly {params.refGenome} {input} {output[2]} --outBam {output[0]} --outVcf {output[1]} --min_coverage {params.min_coverage} --novo_params '{params.novoalign_options}' --keep_all_reads --chr_names {wildcards.sample} --threads {params.numThreads}")
+            shell("{config[bin_dir]}/assembly.py refine_assembly {params.refGenome} {input} {output[2]} --outBam {output[0]} --outVcf {output[1]} --min_coverage {params.min_coverage} --novo_params '{params.novoalign_options}' --keep_all_reads --chr_names {wildcards.sample} --threads {params.numThreads}")
 
 rule ref_guided_diversity:
     input:  
-            expand("{dataDir}/{subdir}/{sample}.{ext}",
-                dataDir=config["dataDir"],
+            expand("{data_dir}/{subdir}/{sample}.{ext}",
+                data_dir=config["data_dir"],
                 subdir=config["subdirs"]["align_ref"],
                 ext = ['fasta', 'vcf.gz'],
                 sample=read_samples_file(config["samples_per_run"])),
-            expand( '{refDir}/'+'/{ref_name}.fasta', refDir=config["ref_genome"], ref_name="reference" )
+            expand( '{refDir}/'+'/{ref_name}.fasta', refDir=config["ref_genome_dir"], ref_name="reference" )
     output: 
-            os.path.join(config["dataDir"], config["subdirs"]["interhost"], 'ref_guided.fasta'),
-            os.path.join(config["dataDir"], config["subdirs"]["interhost"], 'ref_guided.vcf.gz')
+            os.path.join(config["data_dir"], config["subdirs"]["interhost"], 'ref_guided.fasta'),
+            os.path.join(config["data_dir"], config["subdirs"]["interhost"], 'ref_guided.vcf.gz')
     resources: mem=8
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             UGER=config.get('UGER_queues', {}).get('short', '-q short'),
             logid="all",
-            refGenome=os.path.join(config["ref_genome"],"reference"+".fasta"),
-            inFastas = expand("{dataDir}/{subdir}/{sample}.fasta",
-                dataDir=config["dataDir"], subdir=config["subdirs"]["align_ref"],
+            refGenome=os.path.join(config["ref_genome_dir"],"reference"+".fasta"),
+            inFastas = expand("{data_dir}/{subdir}/{sample}.fasta",
+                data_dir=config["data_dir"], subdir=config["subdirs"]["align_ref"],
                 sample=read_samples_file(config["samples_per_run"])),
-            inVcfs = expand("{dataDir}/{subdir}/{sample}.vcf.gz",
-                dataDir=config["dataDir"], subdir=config["subdirs"]["align_ref"],
+            inVcfs = expand("{data_dir}/{subdir}/{sample}.vcf.gz",
+                data_dir=config["data_dir"], subdir=config["subdirs"]["align_ref"],
                 sample=read_samples_file(config["samples_per_run"]))
     run:
             update_timestamps(input)
@@ -82,15 +82,15 @@ rule ref_guided_diversity:
 
 rule multi_align_mafft:
     input:
-        expand("{dataDir}/{subdir}/{sample}.fasta",
-                dataDir=config["dataDir"],
+        expand("{data_dir}/{subdir}/{sample}.fasta",
+                data_dir=config["data_dir"],
                 subdir=config["subdirs"]["assembly"],
                 sample=read_samples_file(config["samples_assembly"])),
-        expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name="reference" )
+        expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome_dir"], ref_name="reference" )
     output:
-        config["dataDir"]+'/'+config["subdirs"]["multialign_ref"] + "/sampleNameList.txt",
-        expand("{dataDir}/{subdir}/aligned_{chrom}.fasta",
-                dataDir=config["dataDir"],
+        config["data_dir"]+'/'+config["subdirs"]["multialign_ref"] + "/sampleNameList.txt",
+        expand("{data_dir}/{subdir}/aligned_{chrom}.fasta",
+                data_dir=config["data_dir"],
                 subdir=config["subdirs"]["multialign_ref"],
                 chrom=range(1, len(config["accessions_for_ref_genome_build"])+1))        
     resources: 
@@ -99,35 +99,35 @@ rule multi_align_mafft:
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             UGER=config.get('UGER_queues', {}).get('short', '-q short'),
             logid="all",
-            refGenome=os.path.join(config["ref_genome"],"reference"+".fasta"),
+            refGenome=os.path.join(config["ref_genome_dir"],"reference"+".fasta"),
             snpEff_ref=config["accessions_for_ref_genome_build"],
             samples=read_samples_file(config["samples_assembly"]),
             ep=str(config["mafft_ep"]),
             maxiters=str(config["mafft_maxiters"]),
             numThreads=str(config.get("number_of_threads", 1))
     run:
-        shell("{config[binDir]}/interhost.py multichr_mafft {params.refGenome} "
-                + " ".join(["{config[dataDir]}/{config[subdirs][assembly]}/" + s + ".fasta" for s in params.samples])
-                + " {config[dataDir]}/{config[subdirs][multialign_ref]}"
+        shell("{config[bin_dir]}/interhost.py multichr_mafft {params.refGenome} "
+                + " ".join(["{config[data_dir]}/{config[subdirs][assembly]}/" + s + ".fasta" for s in params.samples])
+                + " {config[data_dir]}/{config[subdirs][multialign_ref]}"
                 + " --ep {params.ep} --maxiters {params.maxiters} --preservecase"
                 + " --localpair --outFilePrefix aligned --sampleNameListFile {output[0]} --threads {params.numThreads}")
 
 '''
 rule multi_align_mafft:
-    input:  config["dataDir"]+'/'+config["subdirs"]["assembly"]+'/{sample}.fasta'
-        expand("{dataDir}/{subdir}/{sample}.fasta",
-            dataDir=config["dataDir"], subdir=config["subdirs"]["assembly"],
+    input:  config["data_dir"]+'/'+config["subdirs"]["assembly"]+'/{sample}.fasta'
+        expand("{data_dir}/{subdir}/{sample}.fasta",
+            data_dir=config["data_dir"], subdir=config["subdirs"]["assembly"],
             sample=read_samples_file(config["samples_assembly"])),
-    output: config["dataDir"]+'/'+config["subdirs"]["interhost"]+'/{sample}.pruned.phy'
+    output: config["data_dir"]+'/'+config["subdirs"]["interhost"]+'/{sample}.pruned.phy'
     resources: mem=3
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             logid="all",
-            tmpf_mafft=config["tmpDir"]+'/'+config["subdirs"]["interhost"]+'/{sample}.mafft.fasta',
-            log_trimal=config["tmpDir"]+'/'+config["subdirs"]["interhost"]+'/{sample}.log.trimal.html'
+            tmpf_mafft=config["tmp_dir"]+'/'+config["subdirs"]["interhost"]+'/{sample}.mafft.fasta',
+            log_trimal=config["tmp_dir"]+'/'+config["subdirs"]["interhost"]+'/{sample}.log.trimal.html'
     # TODO: replace with python wrapper
     run:
-            makedirs(os.path.join(config["dataDir"], config["subdirs"]["interhost"]),
-                os.path.join(config["tmpDir"], config["subdirs"]["interhost"]))
+            makedirs(os.path.join(config["data_dir"], config["subdirs"]["interhost"]),
+                os.path.join(config["tmp_dir"], config["subdirs"]["interhost"]))
             shell("/idi/sabeti-scratch/kandersen/bin/mafft/core/mafft --localpair --maxiterate 1000 --reorder --ep 0.123 --preservecase --thread 4 {input} > {params.tmpf_mafft}")
             shell("/idi/sabeti-scratch/kandersen/bin/trimal/trimal -phylip -automated1 -in {params.tmpf_mafft} -out {output} -htmlout {params.log_trimal} -colnumbering")
             update_timestamps(input)

--- a/pipes/rules/interhost.rules
+++ b/pipes/rules/interhost.rules
@@ -33,7 +33,7 @@ rule all_ref_guided:
 rule ref_guided_consensus:
     input:  
             config["dataDir"]+'/'+config["subdirs"]["source"]+'/{sample}.bam',
-            expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name=config["ref_genome_file_prefix"] )
+            expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name="reference" )
     output: config["dataDir"]+'/'+config["subdirs"]["align_ref"]+'/{sample}.realigned.bam',
             config["dataDir"]+'/'+config["subdirs"]["align_ref"]+'/{sample}.vcf.gz',
             config["dataDir"]+'/'+config["subdirs"]["align_ref"]+'/{sample}.fasta'
@@ -43,7 +43,7 @@ rule ref_guided_consensus:
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             UGER=config.get('UGER_queues', {}).get('short', '-q short'),
             logid="{sample}",
-            refGenome=os.path.join(config["ref_genome"],config["ref_genome_file_prefix"]+".fasta"),
+            refGenome=os.path.join(config["ref_genome"],"reference"+".fasta"),
             novoalign_options="-r Random -l 30 -g 40 -x 20 -t 502",
             min_coverage="3",
             numThreads=str(config.get("number_of_threads", 1))
@@ -60,7 +60,7 @@ rule ref_guided_diversity:
                 subdir=config["subdirs"]["align_ref"],
                 ext = ['fasta', 'vcf.gz'],
                 sample=read_samples_file(config["samples_per_run"])),
-            expand( '{refDir}/'+'/{ref_name}.fasta', refDir=config["ref_genome"], ref_name=config["ref_genome_file_prefix"] )
+            expand( '{refDir}/'+'/{ref_name}.fasta', refDir=config["ref_genome"], ref_name="reference" )
     output: 
             os.path.join(config["dataDir"], config["subdirs"]["interhost"], 'ref_guided.fasta'),
             os.path.join(config["dataDir"], config["subdirs"]["interhost"], 'ref_guided.vcf.gz')
@@ -68,7 +68,7 @@ rule ref_guided_diversity:
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             UGER=config.get('UGER_queues', {}).get('short', '-q short'),
             logid="all",
-            refGenome=os.path.join(config["ref_genome"],config["ref_genome_file_prefix"]+".fasta"),
+            refGenome=os.path.join(config["ref_genome"],"reference"+".fasta"),
             inFastas = expand("{dataDir}/{subdir}/{sample}.fasta",
                 dataDir=config["dataDir"], subdir=config["subdirs"]["align_ref"],
                 sample=read_samples_file(config["samples_per_run"])),
@@ -86,20 +86,20 @@ rule multi_align_mafft:
                 dataDir=config["dataDir"],
                 subdir=config["subdirs"]["assembly"],
                 sample=read_samples_file(config["samples_assembly"])),
-        expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name=config["ref_genome_file_prefix"] )
+        expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name="reference" )
     output:
         config["dataDir"]+'/'+config["subdirs"]["multialign_ref"] + "/sampleNameList.txt",
         expand("{dataDir}/{subdir}/aligned_{chrom}.fasta",
                 dataDir=config["dataDir"],
                 subdir=config["subdirs"]["multialign_ref"],
-                chrom=range(1, config["number_of_chromosomes"]+1))        
+                chrom=range(1, len(config["accessions_for_ref_genome_build"])+1))        
     resources: 
             mem=8,
             cores=int(config.get("number_of_threads", 1))
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             UGER=config.get('UGER_queues', {}).get('short', '-q short'),
             logid="all",
-            refGenome=os.path.join(config["ref_genome"],config["ref_genome_file_prefix"]+".fasta"),
+            refGenome=os.path.join(config["ref_genome"],"reference"+".fasta"),
             snpEff_ref=config["accessions_for_ref_genome_build"],
             samples=read_samples_file(config["samples_assembly"]),
             ep=str(config["mafft_ep"]),

--- a/pipes/rules/intrahost.rules
+++ b/pipes/rules/intrahost.rules
@@ -38,8 +38,8 @@ rule isnvs_vcf:
             expand("{dataDir}/{subdir}/aligned_{chrom}.fasta",
                 dataDir=config["dataDir"],
                 subdir=config["subdirs"]["multialign_ref"],
-                chrom=range(1, config["number_of_chromosomes"]+1)),
-            expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name=config["ref_genome_file_prefix"] ),
+                chrom=range(1, len(config["accessions_for_ref_genome_build"])+1)),
+            expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name="reference" ),
             config["dataDir"]+'/'+config["subdirs"]["multialign_ref"] + "/sampleNameList.txt"
     output:
             config["dataDir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.vcf.gz',
@@ -51,7 +51,7 @@ rule isnvs_vcf:
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             UGER=config.get('UGER_queues', {}).get('short', '-q short'),
             logid="all",
-            refGenome=os.path.join(config["ref_genome"],config["ref_genome_file_prefix"]+".fasta"),
+            refGenome=os.path.join(config["ref_genome"],"reference"+".fasta"),
             snpEff_ref=config["accessions_for_ref_genome_build"],
             samples=read_samples_file(config["samples_assembly"]),
             emailAddress=config["email_point_of_contact_for_ncbi"]
@@ -59,7 +59,7 @@ rule isnvs_vcf:
             shell("{config[binDir]}/intrahost.py merge_to_vcf {params.refGenome} {output[0]}"
                 + " --samples {params.samples}"
                 + " --isnvs " + " ".join(["{config[dataDir]}/{config[subdirs][intrahost]}/vphaser2."+s+".txt.gz" for s in params.samples])
-                + " --alignments " + " ".join(["{config[dataDir]}/{config[subdirs][multialign_ref]}/aligned_" + str(n) + ".fasta" for n in range(1, config["number_of_chromosomes"]+1)])
+                + " --alignments " + " ".join(["{config[dataDir]}/{config[subdirs][multialign_ref]}/aligned_" + str(n) + ".fasta" for n in range(1, len(config["accessions_for_ref_genome_build"])+1)])
                 + " --strip_chr_version"
                 + " --parse_accession" # the vcf chr column must match a chr known to snpEff; we have an option to parse out only the accession
                 )
@@ -75,8 +75,8 @@ rule isnvs_vcf_filtered:
             expand("{dataDir}/{subdir}/aligned_{chrom}.fasta",
                 dataDir=config["dataDir"],
                 subdir=config["subdirs"]["multialign_ref"],
-                chrom=range(1, config["number_of_chromosomes"]+1)),
-            expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name=config["ref_genome_file_prefix"] )
+                chrom=range(1, len(config["accessions_for_ref_genome_build"])+1)),
+            expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name="reference" )
     output:
             config["dataDir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.filtered.vcf.gz',
             config["dataDir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.filtered.annot.vcf.gz',
@@ -85,7 +85,7 @@ rule isnvs_vcf_filtered:
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             UGER=config.get('UGER_queues', {}).get('short', '-q short'),
             logid="all",
-            refGenome=os.path.join(config["ref_genome"],config["ref_genome_file_prefix"]+".fasta"),
+            refGenome=os.path.join(config["ref_genome"],"reference"+".fasta"),
             snpEff_ref=config["accessions_for_ref_genome_build"],
             samples=read_samples_file(config["samples_assembly"]),
             emailAddress=config["email_point_of_contact_for_ncbi"]
@@ -93,7 +93,7 @@ rule isnvs_vcf_filtered:
             shell("{config[binDir]}/intrahost.py merge_to_vcf {params.refGenome} {output[0]}"
                 + " --samples {params.samples}"
                 + " --isnvs " + " ".join(["{config[dataDir]}/{config[subdirs][intrahost]}/vphaser2."+s+".txt.gz" for s in params.samples])
-                + " --alignments " + " ".join(["{config[dataDir]}/{config[subdirs][multialign_ref]}/aligned_" + str(n) + ".fasta" for n in range(1, config["number_of_chromosomes"]+1)])
+                + " --alignments " + " ".join(["{config[dataDir]}/{config[subdirs][multialign_ref]}/aligned_" + str(n) + ".fasta" for n in range(1, len(config["accessions_for_ref_genome_build"])+1)])
                 + " --strip_chr_version"
                 + "--parse_accession" # the vcf chr column must match a chr known to snpEff; we have an option to parse out only the accession
                 )

--- a/pipes/rules/intrahost.rules
+++ b/pipes/rules/intrahost.rules
@@ -10,14 +10,14 @@ import os, os.path, time
 
 rule all_intrahost:
     input:
-            config["dataDir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.vcf.gz',
-            config["dataDir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.filtered.vcf.gz'
+            config["data_dir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.vcf.gz',
+            config["data_dir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.filtered.vcf.gz'
 
 rule isnvs_per_sample:
     input:
-            config["dataDir"]+'/'+config["subdirs"]["align_self"]+'/{sample}.mapped.bam',
-            config["dataDir"]+'/'+config["subdirs"]["assembly"]  +'/{sample}.fasta',
-    output: config["dataDir"]+'/'+config["subdirs"]["intrahost"] +'/vphaser2.{sample}.txt.gz'
+            config["data_dir"]+'/'+config["subdirs"]["align_self"]+'/{sample}.mapped.bam',
+            config["data_dir"]+'/'+config["subdirs"]["assembly"]  +'/{sample}.fasta',
+    output: config["data_dir"]+'/'+config["subdirs"]["intrahost"] +'/vphaser2.{sample}.txt.gz'
     resources: 
             mem=7,
             cores=int(config.get("number_of_threads", 1))
@@ -26,77 +26,77 @@ rule isnvs_per_sample:
             logid="{sample}",
             numThreads=str(config.get("number_of_threads", 1))
     run:
-            makedirs(config["dataDir"]+'/'+config["subdirs"]["intrahost"])
-            shell("{config[binDir]}/intrahost.py vphaser_one_sample {input} {output} --vphaserNumThreads {params.numThreads} --removeDoublyMappedReads")
+            makedirs(config["data_dir"]+'/'+config["subdirs"]["intrahost"])
+            shell("{config[bin_dir]}/intrahost.py vphaser_one_sample {input} {output} --vphaserNumThreads {params.numThreads} --removeDoublyMappedReads")
             
 rule isnvs_vcf:
     input:
-            expand("{dataDir}/{subdir}/vphaser2.{sample}.txt.gz",
-                dataDir=config["dataDir"],
+            expand("{data_dir}/{subdir}/vphaser2.{sample}.txt.gz",
+                data_dir=config["data_dir"],
                 subdir=config["subdirs"]["intrahost"],
                 sample=read_samples_file(config["samples_assembly"])),
-            expand("{dataDir}/{subdir}/aligned_{chrom}.fasta",
-                dataDir=config["dataDir"],
+            expand("{data_dir}/{subdir}/aligned_{chrom}.fasta",
+                data_dir=config["data_dir"],
                 subdir=config["subdirs"]["multialign_ref"],
                 chrom=range(1, len(config["accessions_for_ref_genome_build"])+1)),
-            expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name="reference" ),
-            config["dataDir"]+'/'+config["subdirs"]["multialign_ref"] + "/sampleNameList.txt"
+            expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome_dir"], ref_name="reference" ),
+            config["data_dir"]+'/'+config["subdirs"]["multialign_ref"] + "/sampleNameList.txt"
     output:
-            config["dataDir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.vcf.gz',
-            config["dataDir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.vcf.gz.tbi',
-            config["dataDir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.annot.vcf.gz',
-            config["dataDir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.annot.txt.gz',
-            config["dataDir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.annot.vcf.gz.tbi'
+            config["data_dir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.vcf.gz',
+            config["data_dir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.vcf.gz.tbi',
+            config["data_dir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.annot.vcf.gz',
+            config["data_dir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.annot.txt.gz',
+            config["data_dir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.annot.vcf.gz.tbi'
     resources: mem=4
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             UGER=config.get('UGER_queues', {}).get('short', '-q short'),
             logid="all",
-            refGenome=os.path.join(config["ref_genome"],"reference"+".fasta"),
+            refGenome=os.path.join(config["ref_genome_dir"],"reference"+".fasta"),
             snpEff_ref=config["accessions_for_ref_genome_build"],
             samples=read_samples_file(config["samples_assembly"]),
             emailAddress=config["email_point_of_contact_for_ncbi"]
     run:
-            shell("{config[binDir]}/intrahost.py merge_to_vcf {params.refGenome} {output[0]}"
+            shell("{config[bin_dir]}/intrahost.py merge_to_vcf {params.refGenome} {output[0]}"
                 + " --samples {params.samples}"
-                + " --isnvs " + " ".join(["{config[dataDir]}/{config[subdirs][intrahost]}/vphaser2."+s+".txt.gz" for s in params.samples])
-                + " --alignments " + " ".join(["{config[dataDir]}/{config[subdirs][multialign_ref]}/aligned_" + str(n) + ".fasta" for n in range(1, len(config["accessions_for_ref_genome_build"])+1)])
+                + " --isnvs " + " ".join(["{config[data_dir]}/{config[subdirs][intrahost]}/vphaser2."+s+".txt.gz" for s in params.samples])
+                + " --alignments " + " ".join(["{config[data_dir]}/{config[subdirs][multialign_ref]}/aligned_" + str(n) + ".fasta" for n in range(1, len(config["accessions_for_ref_genome_build"])+1)])
                 + " --strip_chr_version"
                 + " --parse_accession" # the vcf chr column must match a chr known to snpEff; we have an option to parse out only the accession
                 )
-            shell("{config[binDir]}/interhost.py snpEff {output[0]} {params.snpEff_ref} {output[2]} {params.emailAddress}")
-            shell("{config[binDir]}/intrahost.py iSNV_table {output[2]} {output[3]}")
+            shell("{config[bin_dir]}/interhost.py snpEff {output[0]} {params.snpEff_ref} {output[2]} {params.emailAddress}")
+            shell("{config[bin_dir]}/intrahost.py iSNV_table {output[2]} {output[3]}")
             
 rule isnvs_vcf_filtered:
     input:
-            expand("{dataDir}/{subdir}/vphaser2.{sample}.txt.gz",
-                dataDir=config["dataDir"],
+            expand("{data_dir}/{subdir}/vphaser2.{sample}.txt.gz",
+                data_dir=config["data_dir"],
                 subdir=config["subdirs"]["intrahost"],
                 sample=read_samples_file(config["samples_assembly"])),
-            expand("{dataDir}/{subdir}/aligned_{chrom}.fasta",
-                dataDir=config["dataDir"],
+            expand("{data_dir}/{subdir}/aligned_{chrom}.fasta",
+                data_dir=config["data_dir"],
                 subdir=config["subdirs"]["multialign_ref"],
                 chrom=range(1, len(config["accessions_for_ref_genome_build"])+1)),
-            expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name="reference" )
+            expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome_dir"], ref_name="reference" )
     output:
-            config["dataDir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.filtered.vcf.gz',
-            config["dataDir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.filtered.annot.vcf.gz',
-            config["dataDir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.filtered.annot.txt.gz'
+            config["data_dir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.filtered.vcf.gz',
+            config["data_dir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.filtered.annot.vcf.gz',
+            config["data_dir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.filtered.annot.txt.gz'
     resources: mem=4
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             UGER=config.get('UGER_queues', {}).get('short', '-q short'),
             logid="all",
-            refGenome=os.path.join(config["ref_genome"],"reference"+".fasta"),
+            refGenome=os.path.join(config["ref_genome_dir"],"reference"+".fasta"),
             snpEff_ref=config["accessions_for_ref_genome_build"],
             samples=read_samples_file(config["samples_assembly"]),
             emailAddress=config["email_point_of_contact_for_ncbi"]
     run:
-            shell("{config[binDir]}/intrahost.py merge_to_vcf {params.refGenome} {output[0]}"
+            shell("{config[bin_dir]}/intrahost.py merge_to_vcf {params.refGenome} {output[0]}"
                 + " --samples {params.samples}"
-                + " --isnvs " + " ".join(["{config[dataDir]}/{config[subdirs][intrahost]}/vphaser2."+s+".txt.gz" for s in params.samples])
-                + " --alignments " + " ".join(["{config[dataDir]}/{config[subdirs][multialign_ref]}/aligned_" + str(n) + ".fasta" for n in range(1, len(config["accessions_for_ref_genome_build"])+1)])
+                + " --isnvs " + " ".join(["{config[data_dir]}/{config[subdirs][intrahost]}/vphaser2."+s+".txt.gz" for s in params.samples])
+                + " --alignments " + " ".join(["{config[data_dir]}/{config[subdirs][multialign_ref]}/aligned_" + str(n) + ".fasta" for n in range(1, len(config["accessions_for_ref_genome_build"])+1)])
                 + " --strip_chr_version"
                 + "--parse_accession" # the vcf chr column must match a chr known to snpEff; we have an option to parse out only the accession
                 )
-            shell("{config[binDir]}/interhost.py snpEff {output[0]} {params.snpEff_ref} {output[1]} {params.emailAddress}")
-            shell("{config[binDir]}/intrahost.py iSNV_table {output[1]} {output[2]}")
+            shell("{config[bin_dir]}/interhost.py snpEff {output[0]} {params.snpEff_ref} {output[1]} {params.emailAddress}")
+            shell("{config[bin_dir]}/intrahost.py iSNV_table {output[1]} {output[2]}")
 

--- a/pipes/rules/ncbi.rules
+++ b/pipes/rules/ncbi.rules
@@ -22,14 +22,14 @@ rule all_annot:
 
 rule download_reference_genome:
     output:
-        expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name=config["ref_genome_file_prefix"] ),
+        expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name="reference" ),
         expand( '{refDir}/'+'{feature_tbl_name}.tbl', refDir=config["ref_genome"], feature_tbl_name=config["accessions_for_ref_genome_build"] )
     params:
         emailAddress=config["email_point_of_contact_for_ncbi"],
         accessionsList=config["accessions_for_ref_genome_build"]
     run:
         makedirs( expand( "{dir}", dir=[config["ref_genome"]] ) )
-        shell("{config[binDir]}/ncbi.py fetch_fastas {params.emailAddress} {config[ref_genome]} {params.accessionsList} --combinedFilePrefix {config[ref_genome_file_prefix]} --removeSeparateFiles --forceOverwrite")
+        shell("{config[binDir]}/ncbi.py fetch_fastas {params.emailAddress} {config[ref_genome]} {params.accessionsList} --combinedFilePrefix reference --removeSeparateFiles --forceOverwrite")
         shell("{config[binDir]}/ncbi.py fetch_feature_tables {params.emailAddress} {config[ref_genome]} {params.accessionsList} --forceOverwrite")
 
 rule download_lastal_sources:
@@ -67,7 +67,7 @@ rule annot_transfer:
                     subdir=config["subdirs"]["multialign_ref"],
                     chrom=range(1, config["number_of_chromosomes"]+1)),
                 expand( '{refDir}/'+'{feature_tbl_name}.tbl', refDir=config["ref_genome"], feature_tbl_name=config["accessions_for_ref_genome_build"] ),
-                expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name=config["ref_genome_file_prefix"] )
+                expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name="reference" )
     output:     
                 #config["dataDir"]+'/'+config["subdirs"]["annot"]   +'/{sample}.tbl'#,
                 expand("{dataDir}/{subdir}/{samp}-{chrom}.tbl",
@@ -80,7 +80,7 @@ rule annot_transfer:
     params:     LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
                 UGER=config.get('UGER_queues', {}).get('short', '-q short'),
                 #logid="{samp}",
-                refGenome=expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name=config["ref_genome_file_prefix"] ),
+                refGenome=expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name="reference" ),
                 refAnnot=expand( '{refDir}/'+'{feature_tbl_name}.tbl', refDir=config["ref_genome"], feature_tbl_name=config["accessions_for_ref_genome_build"] ),
                 outputDir=config["dataDir"]+'/'+config["subdirs"]["annot"]
     run:      

--- a/pipes/rules/ncbi.rules
+++ b/pipes/rules/ncbi.rules
@@ -12,99 +12,99 @@ localrules: download_reference_genome, download_lastal_sources, build_lastal_db
 
 rule all_annot:
     input:
-        config["dataDir"]+'/'+config["subdirs"]["annot"]+'/errorsummary.val'#,
-        #expand("{dataDir}/{subdir}/{samp}-{chrom}.tbl",
-        #            dataDir=config["dataDir"],
+        config["data_dir"]+'/'+config["subdirs"]["annot"]+'/errorsummary.val'#,
+        #expand("{data_dir}/{subdir}/{samp}-{chrom}.tbl",
+        #            data_dir=config["data_dir"],
         #            subdir=config["subdirs"]["annot"],
         #            samp=read_samples_file(config["samples_assembly"]),
         #            chrom=range(1, len(config["accessions_for_ref_genome_build"])+1))
-        #config["dataDir"]+'/'+config["subdirs"]["annot"]   +'/{sample}.tbl'
+        #config["data_dir"]+'/'+config["subdirs"]["annot"]   +'/{sample}.tbl'
 
 rule download_reference_genome:
     output:
-        expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name="reference" ),
-        expand( '{refDir}/'+'{feature_tbl_name}.tbl', refDir=config["ref_genome"], feature_tbl_name=config["accessions_for_ref_genome_build"] )
+        expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome_dir"], ref_name="reference" ),
+        expand( '{refDir}/'+'{feature_tbl_name}.tbl', refDir=config["ref_genome_dir"], feature_tbl_name=config["accessions_for_ref_genome_build"] )
     params:
         emailAddress=config["email_point_of_contact_for_ncbi"],
         accessionsList=config["accessions_for_ref_genome_build"]
     run:
-        makedirs( expand( "{dir}", dir=[config["ref_genome"]] ) )
-        shell("{config[binDir]}/ncbi.py fetch_fastas {params.emailAddress} {config[ref_genome]} {params.accessionsList} --combinedFilePrefix reference --removeSeparateFiles --forceOverwrite")
-        shell("{config[binDir]}/ncbi.py fetch_feature_tables {params.emailAddress} {config[ref_genome]} {params.accessionsList} --forceOverwrite")
+        makedirs( expand( "{dir}", dir=[config["ref_genome_dir"]] ) )
+        shell("{config[bin_dir]}/ncbi.py fetch_fastas {params.emailAddress} {config[ref_genome_dir]} {params.accessionsList} --combinedFilePrefix reference --removeSeparateFiles --forceOverwrite")
+        shell("{config[bin_dir]}/ncbi.py fetch_feature_tables {params.emailAddress} {config[ref_genome_dir]} {params.accessionsList} --forceOverwrite")
 
 rule download_lastal_sources:
     output:
-        expand( '{lastalDb}/'+'lastal.fasta', lastalDb=config["lastal_refDb"] )
+        expand( '{lastalDb}/'+'lastal.fasta', lastalDb=config["lastal_ref_db_dir"] )
     params:
         accessionsList=read_accessions_file(config["accessions_file_for_lastal_db_build"]) if "accessions_file_for_lastal_db_build" in config and len(config["accessions_file_for_lastal_db_build"])>0 else config["accessions_for_ref_genome_build"],
         emailAddress=config["email_point_of_contact_for_ncbi"]
     run:
-        makedirs( expand( "{dir}", dir=[config["lastal_refDb"]] ) )
-        shell("{config[binDir]}/ncbi.py fetch_fastas {params.emailAddress} {config[lastal_refDb]} {params.accessionsList} --combinedFilePrefix lastal --removeSeparateFiles --forceOverwrite --chunkSize 300")
+        makedirs( expand( "{dir}", dir=[config["lastal_ref_db_dir"]] ) )
+        shell("{config[bin_dir]}/ncbi.py fetch_fastas {params.emailAddress} {config[lastal_ref_db_dir]} {params.accessionsList} --combinedFilePrefix lastal --removeSeparateFiles --forceOverwrite --chunkSize 300")
 
 
 rule build_lastal_db:
     input:
-        expand( '{lastalDb}/'+'lastal.fasta', lastalDb=config["lastal_refDb"] )
+        expand( '{lastalDb}/'+'lastal.fasta', lastalDb=config["lastal_ref_db_dir"] )
     output:
-        expand('{lastal_refDb}/lastal.bck', lastal_refDb=config["lastal_refDb"]),
-        expand('{lastal_refDb}/lastal.des', lastal_refDb=config["lastal_refDb"]),
-        expand('{lastal_refDb}/lastal.prj', lastal_refDb=config["lastal_refDb"]),
-        expand('{lastal_refDb}/lastal.sds', lastal_refDb=config["lastal_refDb"]),
-        expand('{lastal_refDb}/lastal.ssp', lastal_refDb=config["lastal_refDb"]),
-        expand('{lastal_refDb}/lastal.suf', lastal_refDb=config["lastal_refDb"]),
-        expand('{lastal_refDb}/lastal.tis', lastal_refDb=config["lastal_refDb"])
+        expand('{lastal_ref_db_dir}/lastal.bck', lastal_ref_db_dir=config["lastal_ref_db_dir"]),
+        expand('{lastal_ref_db_dir}/lastal.des', lastal_ref_db_dir=config["lastal_ref_db_dir"]),
+        expand('{lastal_ref_db_dir}/lastal.prj', lastal_ref_db_dir=config["lastal_ref_db_dir"]),
+        expand('{lastal_ref_db_dir}/lastal.sds', lastal_ref_db_dir=config["lastal_ref_db_dir"]),
+        expand('{lastal_ref_db_dir}/lastal.ssp', lastal_ref_db_dir=config["lastal_ref_db_dir"]),
+        expand('{lastal_ref_db_dir}/lastal.suf', lastal_ref_db_dir=config["lastal_ref_db_dir"]),
+        expand('{lastal_ref_db_dir}/lastal.tis', lastal_ref_db_dir=config["lastal_ref_db_dir"])
     params:
         UGER=config.get('UGER_queues', {}).get('short', '-q short'),
         emailAddress=config["email_point_of_contact_for_ncbi"]
     run:
-        shell("{config[binDir]}/taxon_filter.py lastal_build_db {input[0]} {config[lastal_refDb]}")
+        shell("{config[bin_dir]}/taxon_filter.py lastal_build_db {input[0]} {config[lastal_ref_db_dir]}")
 
 rule annot_transfer:
     input:      
-                expand("{dataDir}/{subdir}/aligned_{chrom}.fasta",
-                    dataDir=config["dataDir"],
+                expand("{data_dir}/{subdir}/aligned_{chrom}.fasta",
+                    data_dir=config["data_dir"],
                     subdir=config["subdirs"]["multialign_ref"],
                     chrom=range(1, len(config["accessions_for_ref_genome_build"])+1)),
-                expand( '{refDir}/'+'{feature_tbl_name}.tbl', refDir=config["ref_genome"], feature_tbl_name=config["accessions_for_ref_genome_build"] ),
-                expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name="reference" )
+                expand( '{refDir}/'+'{feature_tbl_name}.tbl', refDir=config["ref_genome_dir"], feature_tbl_name=config["accessions_for_ref_genome_build"] ),
+                expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome_dir"], ref_name="reference" )
     output:     
-                #config["dataDir"]+'/'+config["subdirs"]["annot"]   +'/{sample}.tbl'#,
-                expand("{dataDir}/{subdir}/{samp}-{chrom}.tbl",
-                    dataDir=config["dataDir"],
+                #config["data_dir"]+'/'+config["subdirs"]["annot"]   +'/{sample}.tbl'#,
+                expand("{data_dir}/{subdir}/{samp}-{chrom}.tbl",
+                    data_dir=config["data_dir"],
                     subdir=config["subdirs"]["annot"],
                     samp=read_samples_file(config["samples_assembly"]),
                     chrom=range(1, len(config["accessions_for_ref_genome_build"])+1))
-                #config["dataDir"]+'/'+config["subdirs"]["annot"]   +'/{sample}.fasta'
+                #config["data_dir"]+'/'+config["subdirs"]["annot"]   +'/{sample}.fasta'
     resources:  mem=4
     params:     LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
                 UGER=config.get('UGER_queues', {}).get('short', '-q short'),
                 #logid="{samp}",
-                refGenome=expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name="reference" ),
-                refAnnot=expand( '{refDir}/'+'{feature_tbl_name}.tbl', refDir=config["ref_genome"], feature_tbl_name=config["accessions_for_ref_genome_build"] ),
-                outputDir=config["dataDir"]+'/'+config["subdirs"]["annot"]
+                refGenome=expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome_dir"], ref_name="reference" ),
+                refAnnot=expand( '{refDir}/'+'{feature_tbl_name}.tbl', refDir=config["ref_genome_dir"], feature_tbl_name=config["accessions_for_ref_genome_build"] ),
+                outputDir=config["data_dir"]+'/'+config["subdirs"]["annot"]
     run:      
-        for alignmentFile in expand("{dataDir}/{subdir}/aligned_{chrom}.fasta",
-                                        dataDir=config["dataDir"],
+        for alignmentFile in expand("{data_dir}/{subdir}/aligned_{chrom}.fasta",
+                                        data_dir=config["data_dir"],
                                         subdir=config["subdirs"]["multialign_ref"],
                                         chrom=range(1, len(config["accessions_for_ref_genome_build"])+1)):
-            shell("{config[binDir]}/ncbi.py tbl_transfer_prealigned " + alignmentFile + " {params.refGenome} {params.refAnnot} {params.outputDir} --oob_clip")
+            shell("{config[bin_dir]}/ncbi.py tbl_transfer_prealigned " + alignmentFile + " {params.refGenome} {params.refAnnot} {params.outputDir} --oob_clip")
 
 rule prepare_genbank:
     input:
-                config["reportsDir"]+"/summary.assembly.txt",
-                expand("{dataDir}/{subdir}/{samp}-{chrom}.tbl",
-                    dataDir=config["dataDir"],
+                config["reports_dir"]+"/summary.assembly.txt",
+                expand("{data_dir}/{subdir}/{samp}-{chrom}.tbl",
+                    data_dir=config["data_dir"],
                     subdir=config["subdirs"]["annot"],
                     samp=read_samples_file(config["samples_assembly"]),
                     chrom=range(1, len(config["accessions_for_ref_genome_build"])+1))
     output:
-                config["dataDir"]+'/'+config["subdirs"]["annot"]+'/errorsummary.val'
+                config["data_dir"]+'/'+config["subdirs"]["annot"]+'/errorsummary.val'
     params:
                 LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
                 UGER=config.get('UGER_queues', {}).get('short', '-q short'),
                 fasta_files=expand("{dir}/{subdir}/{sample}.fasta",
-                    dir=[config["dataDir"]], subdir=[config["subdirs"]["assembly"]],
+                    dir=[config["data_dir"]], subdir=[config["subdirs"]["assembly"]],
                     sample=read_samples_file(config["samples_assembly"])),
                 genbank_template=config.get('genbank',{}).get('author_template', ''),
                 genbank_source_table=config.get('genbank',{}).get('source_modifier_table', ''),
@@ -113,11 +113,11 @@ rule prepare_genbank:
                 comment=config.get('genbank',{}).get('comment', ''),
                 logid="all"
     shell:
-                ' '.join(["{config[binDir]}/ncbi.py prep_genbank_files",
+                ' '.join(["{config[bin_dir]}/ncbi.py prep_genbank_files",
                     "{params.genbank_template} {params.fasta_files}",
-                    "{config[dataDir]}/{config[subdirs][annot]}",
+                    "{config[data_dir]}/{config[subdirs][annot]}",
                     "--master_source_table {params.genbank_source_table}",
                     "--sequencing_tech '{params.seq_tech}'",
                     "--biosample_map {params.biosample_map}",
-                    "--coverage_table {config[reportsDir]}/summary.assembly.txt",
+                    "--coverage_table {config[reports_dir]}/summary.assembly.txt",
                     "--comment '{params.comment}'"])

--- a/pipes/rules/ncbi.rules
+++ b/pipes/rules/ncbi.rules
@@ -17,7 +17,7 @@ rule all_annot:
         #            dataDir=config["dataDir"],
         #            subdir=config["subdirs"]["annot"],
         #            samp=read_samples_file(config["samples_assembly"]),
-        #            chrom=range(1, config["number_of_chromosomes"]+1))
+        #            chrom=range(1, len(config["accessions_for_ref_genome_build"])+1))
         #config["dataDir"]+'/'+config["subdirs"]["annot"]   +'/{sample}.tbl'
 
 rule download_reference_genome:
@@ -65,7 +65,7 @@ rule annot_transfer:
                 expand("{dataDir}/{subdir}/aligned_{chrom}.fasta",
                     dataDir=config["dataDir"],
                     subdir=config["subdirs"]["multialign_ref"],
-                    chrom=range(1, config["number_of_chromosomes"]+1)),
+                    chrom=range(1, len(config["accessions_for_ref_genome_build"])+1)),
                 expand( '{refDir}/'+'{feature_tbl_name}.tbl', refDir=config["ref_genome"], feature_tbl_name=config["accessions_for_ref_genome_build"] ),
                 expand( '{refDir}/'+'{ref_name}.fasta', refDir=config["ref_genome"], ref_name="reference" )
     output:     
@@ -74,7 +74,7 @@ rule annot_transfer:
                     dataDir=config["dataDir"],
                     subdir=config["subdirs"]["annot"],
                     samp=read_samples_file(config["samples_assembly"]),
-                    chrom=range(1, config["number_of_chromosomes"]+1))
+                    chrom=range(1, len(config["accessions_for_ref_genome_build"])+1))
                 #config["dataDir"]+'/'+config["subdirs"]["annot"]   +'/{sample}.fasta'
     resources:  mem=4
     params:     LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
@@ -87,7 +87,7 @@ rule annot_transfer:
         for alignmentFile in expand("{dataDir}/{subdir}/aligned_{chrom}.fasta",
                                         dataDir=config["dataDir"],
                                         subdir=config["subdirs"]["multialign_ref"],
-                                        chrom=range(1, config["number_of_chromosomes"]+1)):
+                                        chrom=range(1, len(config["accessions_for_ref_genome_build"])+1)):
             shell("{config[binDir]}/ncbi.py tbl_transfer_prealigned " + alignmentFile + " {params.refGenome} {params.refAnnot} {params.outputDir} --oob_clip")
 
 rule prepare_genbank:
@@ -97,7 +97,7 @@ rule prepare_genbank:
                     dataDir=config["dataDir"],
                     subdir=config["subdirs"]["annot"],
                     samp=read_samples_file(config["samples_assembly"]),
-                    chrom=range(1, config["number_of_chromosomes"]+1))
+                    chrom=range(1, len(config["accessions_for_ref_genome_build"])+1))
     output:
                 config["dataDir"]+'/'+config["subdirs"]["annot"]+'/errorsummary.val'
     params:

--- a/pipes/rules/reports.rules
+++ b/pipes/rules/reports.rules
@@ -10,25 +10,25 @@ import os, os.path, gzip, shutil
 
 rule all_reports:
     input:
-        config["reportsDir"]+'/summary.fastqc.txt',
-        config["reportsDir"]+'/summary.spike_count.txt'
+        config["reports_dir"]+'/summary.fastqc.txt',
+        config["reports_dir"]+'/summary.spike_count.txt'
     params: LSF="-N"
 
 
 #-----------FASTQC---------------------
 
 rule fastqc_report:
-    input:  config["dataDir"]+'/'+config["subdirs"]["align_self"]+'/{sample}.bam'
-    output: config["reportsDir"]+'/fastqc/{sample}_fastqc'
+    input:  config["data_dir"]+'/'+config["subdirs"]["align_self"]+'/{sample}.bam'
+    output: config["reports_dir"]+'/fastqc/{sample}_fastqc'
     resources: mem=3
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             UGER=config.get('UGER_queues', {}).get('short', '-q short'),
             logid="{sample}"
     run:
-            makedirs(config["reportsDir"])
+            makedirs(config["reports_dir"])
             shutil.rmtree(output[0], ignore_errors=True)
-            makedirs(os.path.join(config["reportsDir"], 'fastqc'))
-            shell("/idi/sabeti-scratch/kandersen/bin/fastqc/fastqc -f bam {input} -o {config[reportsDir]}/fastqc")
+            makedirs(os.path.join(config["reports_dir"], 'fastqc'))
+            shell("/idi/sabeti-scratch/kandersen/bin/fastqc/fastqc -f bam {input} -o {config[reports_dir]}/fastqc")
             os.unlink(output[0]+'.zip')
 
 rule consolidate_fastqc:
@@ -37,25 +37,25 @@ rule consolidate_fastqc:
                 sample=read_samples_file(config["samples_assembly"]))
     output: '{dir}/summary.fastqc.txt'
     params: logid="all"
-    shell:  "{config[binDir]}/reports.py consolidate_fastqc {input} {output}"
+    shell:  "{config[bin_dir]}/reports.py consolidate_fastqc {input} {output}"
 
 
 #-----------SPIKE-INS------------------
 
 rule spikein_report:
-    input:  config["dataDir"]+'/'+config["subdirs"]["depletion"]+'/{sample}.cleaned.bam'
-    output: config["reportsDir"]+'/spike_count/{sample}.spike_count.txt'
+    input:  config["data_dir"]+'/'+config["subdirs"]["depletion"]+'/{sample}.cleaned.bam'
+    output: config["reports_dir"]+'/spike_count/{sample}.spike_count.txt'
     resources: mem=3
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             UGER=config.get('UGER_queues', {}).get('short', '-q short'),
             logid="{sample}",
-            spike_in_fasta=config["spikeinsDb"],
+            spike_in_fasta=config["spikeins_db"],
             novoalign_options="-r Random",
-            tmpf_spike_bam=config["tmpDir"]+'/'+config["subdirs"]["depletion"]+'/{sample}.cleaned.aligned_to_spikes.bam'
+            tmpf_spike_bam=config["tmp_dir"]+'/'+config["subdirs"]["depletion"]+'/{sample}.cleaned.aligned_to_spikes.bam'
     run:
-            makedirs(os.path.join(config["reportsDir"], 'spike_count'))
-            makedirs(os.path.join(config["tmpDir"], config["subdirs"]["depletion"]))
-            shell("{config[binDir]}/read_utils.py novoalign {input} {params.spike_in_fasta} {params.tmpf_spike_bam} --options '{params.novoalign_options}'")
+            makedirs(os.path.join(config["reports_dir"], 'spike_count'))
+            makedirs(os.path.join(config["tmp_dir"], config["subdirs"]["depletion"]))
+            shell("{config[bin_dir]}/read_utils.py novoalign {input} {params.spike_in_fasta} {params.tmpf_spike_bam} --options '{params.novoalign_options}'")
             shell("/idi/sabeti-scratch/kandersen/bin/scripts/CountAlignmentsByDescriptionLine -bam {params.tmpf_spike_bam} > {output}")
             os.unlink(params.tmpf_spike_bam)
             os.unlink(params.tmpf_spike_bam[:-1] + 'i')
@@ -65,5 +65,5 @@ rule consolidate_spike_count:
                 sample=read_samples_file(config["samples_per_run"]))
     output: '{dir}/summary.spike_count.txt'
     params: logid="all"
-    shell:  "{config[binDir]}/reports.py consolidate_spike_count {wildcards.dir}/spike_count {output}"
+    shell:  "{config[bin_dir]}/reports.py consolidate_spike_count {wildcards.dir}/spike_count {output}"
 

--- a/pipes/rules/reports_only
+++ b/pipes/rules/reports_only
@@ -37,25 +37,25 @@ def cat_files_with_header(inFiles, outFile):
 
 rule all_assembly_reports:
     input:
-            expand("{reportsDir}/assembly/{sample}.txt",
-                reportsDir=config["reportsDir"],
+            expand("{reports_dir}/assembly/{sample}.txt",
+                reports_dir=config["reports_dir"],
                 sample=read_file(config["samples_depletion"]))
     output:
-            config["reportsDir"]+"/summary.assembly.txt"
+            config["reports_dir"]+"/summary.assembly.txt"
     params: LSF="-N"
     run:
             cat_files_with_header(input, output[0])
         
 
 rule assembly_report:
-    output: config["reportsDir"]+'/assembly/{sample}.txt'
+    output: config["reports_dir"]+'/assembly/{sample}.txt'
     resources: mem=2
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             logid="{sample}"
-    shell:  "{config[binDir]}/reports.py assembly_stats {wildcards.sample} {output}" \
-            " --assembly_dir {config[dataDir]}/{config[subdirs][assembly]}" \
-            " --assembly_tmp {config[tmpDir]}/{config[subdirs][assembly]}" \
-            " --align_dir {config[dataDir]}/{config[subdirs][align_self]}" \
-            " --reads_dir {config[dataDir]}/{config[subdirs][per_sample]}" \
-            " --raw_reads_dir {config[dataDir]}/{config[subdirs][source]}"
+    shell:  "{config[bin_dir]}/reports.py assembly_stats {wildcards.sample} {output}" \
+            " --assembly_dir {config[data_dir]}/{config[subdirs][assembly]}" \
+            " --assembly_tmp {config[tmp_dir]}/{config[subdirs][assembly]}" \
+            " --align_dir {config[data_dir]}/{config[subdirs][align_self]}" \
+            " --reads_dir {config[data_dir]}/{config[subdirs][per_sample]}" \
+            " --raw_reads_dir {config[data_dir]}/{config[subdirs][source]}"
 

--- a/read_utils.py
+++ b/read_utils.py
@@ -57,7 +57,7 @@ def parser_purge_unmated(parser=argparse.ArgumentParser()):
     parser.add_argument("--regex",
                         help="Perl regular expression to parse paired read IDs (default: %(default)s)",
                         default='^@(\S+)/[1|2]$')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, purge_unmated, split_args=True)
     return parser
 
@@ -88,7 +88,7 @@ def fastq_to_fasta(inFastq, outFasta):
 def parser_fastq_to_fasta(parser=argparse.ArgumentParser()):
     parser.add_argument('inFastq', help='Input fastq file.')
     parser.add_argument('outFasta', help='Output fasta file.')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, fastq_to_fasta, split_args=True)
     return parser
 
@@ -129,7 +129,7 @@ def parser_index_fasta_picard(parser=argparse.ArgumentParser()):
                         default=[],
                         nargs='*',
                         help='Optional arguments to Picard\'s CreateSequenceDictionary, OPTIONNAME=value ...')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, main_index_fasta_picard)
     return parser
 
@@ -167,7 +167,7 @@ def parser_mkdup_picard(parser=argparse.ArgumentParser()):
                         default=[],
                         nargs='*',
                         help='Optional arguments to Picard\'s MarkDuplicates, OPTIONNAME=value ...')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, main_mkdup_picard)
     return parser
 
@@ -203,7 +203,7 @@ def parser_revert_bam_picard(parser=argparse.ArgumentParser()):
                         default=[],
                         nargs='*',
                         help='Optional arguments to Picard\'s RevertSam, OPTIONNAME=value ...')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, main_revert_bam_picard)
     return parser
 
@@ -231,7 +231,7 @@ def parser_picard(parser=argparse.ArgumentParser()):
                         default=[],
                         nargs='*',
                         help='Optional arguments to Picard, OPTIONNAME=value ...')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, main_picard)
     return parser
 
@@ -273,7 +273,7 @@ def parser_sort_bam(parser=argparse.ArgumentParser()):
                         default=[],
                         nargs='*',
                         help='Optional arguments to Picard\'s SortSam, OPTIONNAME=value ...')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, main_sort_bam)
     return parser
 
@@ -311,7 +311,7 @@ def parser_merge_bams(parser=argparse.ArgumentParser()):
                         default=[],
                         nargs='*',
                         help='Optional arguments to Picard\'s MergeSamFiles, OPTIONNAME=value ...')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, main_merge_bams)
     return parser
 
@@ -348,7 +348,7 @@ def parser_filter_bam(parser=argparse.ArgumentParser()):
                         default=[],
                         nargs='*',
                         help='Optional arguments to Picard\'s FilterSamReads, OPTIONNAME=value ...')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, main_filter_bam)
     return parser
 
@@ -401,7 +401,7 @@ def parser_bam_to_fastq(parser=argparse.ArgumentParser()):
                         default=[],
                         nargs='*',
                         help='Optional arguments to Picard\'s SamToFastq, OPTIONNAME=value ...')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, bam_to_fastq, split_args=True)
     return parser
 
@@ -462,7 +462,7 @@ def parser_fastq_to_bam(parser=argparse.ArgumentParser()):
                         help='''Optional arguments to Picard\'s FastqToSam,
                 OPTIONNAME=value ...  Note that header-related options will be
                 overwritten by HEADER if present.''')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, fastq_to_bam, split_args=True)
     return parser
 
@@ -606,7 +606,7 @@ def split_bam(inBam, outBams):
 def parser_split_bam(parser=argparse.ArgumentParser()):
     parser.add_argument('inBam', help='Input BAM file.')
     parser.add_argument('outBams', nargs='+', help='Output BAM files')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, split_bam, split_args=True)
     return parser
 
@@ -623,7 +623,7 @@ def parser_reheader_bam(parser=argparse.ArgumentParser()):
     parser.add_argument('inBam', help='Input reads, BAM format.')
     parser.add_argument('rgMap', help='Tabular file containing three columns: field, old, new.')
     parser.add_argument('outBam', help='Output reads, BAM format.')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, main_reheader_bam)
     return parser
 
@@ -658,7 +658,7 @@ __commands__.append(('reheader_bam', parser_reheader_bam))
 
 def parser_reheader_bams(parser=argparse.ArgumentParser()):
     parser.add_argument('rgMap', help='Tabular file containing three columns: field, old, new.')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, main_reheader_bams)
     return parser
 def main_reheader_bams(args):
@@ -777,7 +777,7 @@ def parser_rmdup_mvicuna_bam(parser=argparse.ArgumentParser()):
     parser.add_argument('--JVMmemory',
                         default=tools.picard.FilterSamReadsTool.jvmMemDefault,
                         help='JVM virtual memory size (default: %(default)s)')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, rmdup_mvicuna_bam, split_args=True)
     return parser
 
@@ -791,7 +791,7 @@ def parser_dup_remove_mvicuna(parser=argparse.ArgumentParser()):
     parser.add_argument('pairedOutFastq1', help='Output fastq file; 1st end of paired-end reads.')
     parser.add_argument('pairedOutFastq2', help='Output fastq file; 2nd end of paired-end reads.')
     parser.add_argument('--unpairedOutFastq', default=None, help='File name of output unpaired reads')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, main_dup_remove_mvicuna)
     return parser
 
@@ -829,7 +829,7 @@ def parser_rmdup_prinseq_fastq(parser=argparse.ArgumentParser()):
     parser.add_argument('inFastq2', help='Input fastq file; 2nd end of paired-end reads.')
     parser.add_argument('outFastq1', help='Output fastq file; 1st end of paired-end reads.')
     parser.add_argument('outFastq2', help='Output fastq file; 2nd end of paired-end reads.')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, main_rmdup_prinseq_fastq)
     return parser
 
@@ -859,7 +859,7 @@ def filter_bam_mapped_only(inBam, outBam):
 def parser_filter_bam_mapped_only(parser=argparse.ArgumentParser()):
     parser.add_argument('inBam', help='Input aligned reads, BAM format.')
     parser.add_argument('outBam', help='Output sorted indexed reads, filtered to aligned-only, BAM format.')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, filter_bam_mapped_only, split_args=True)
     return parser
 
@@ -880,7 +880,7 @@ def parser_novoalign(parser=argparse.ArgumentParser()):
     parser.add_argument('--JVMmemory',
                         default=tools.picard.SortSamTool.jvmMemDefault,
                         help='JVM virtual memory size (default: %(default)s)')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, main_novoalign)
     return parser
 
@@ -924,7 +924,7 @@ def parser_gatk_ug(parser=argparse.ArgumentParser()):
     parser.add_argument('--JVMmemory',
                         default=tools.gatk.GATKTool.jvmMemDefault,
                         help='JVM virtual memory size (default: %(default)s)')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, main_gatk_ug)
     return parser
 
@@ -949,7 +949,7 @@ def parser_gatk_realign(parser=argparse.ArgumentParser()):
     parser.add_argument('--JVMmemory',
                         default=tools.gatk.GATKTool.jvmMemDefault,
                         help='JVM virtual memory size (default: %(default)s)')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, main_gatk_realign)
     parser.add_argument('--threads', default=1, help='Number of threads (default: %(default)s)')
     return parser
@@ -1023,7 +1023,7 @@ def parser_align_and_fix(parser=argparse.ArgumentParser()):
     parser.add_argument('--novoalign_options', default='-r Random', help='Novoalign options (default: %(default)s)')
     parser.add_argument('--JVMmemory', default='4g', help='JVM virtual memory size (default: %(default)s)')
     parser.add_argument('--threads', default=1, help='Number of threads (default: %(default)s)')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, align_and_fix, split_args=True)
     return parser
 

--- a/taxon_filter.py
+++ b/taxon_filter.py
@@ -60,7 +60,7 @@ def parser_deplete_human(parser=argparse.ArgumentParser()):
     parser.add_argument('--JVMmemory',
                         default=tools.picard.FilterSamReadsTool.jvmMemDefault,
                         help='JVM virtual memory size for Picard FilterSamReads (default: %(default)s)')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, main_deplete_human)
     return parser
 
@@ -115,7 +115,7 @@ def parser_trim_trimmomatic(parser=argparse.ArgumentParser()):
     parser.add_argument("pairedOutFastq1", help="Paired output 1")
     parser.add_argument("pairedOutFastq2", help="Paired output 2")
     parser.add_argument("clipFasta", help="Fasta file with adapters, PCR sequences, etc. to clip off")
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, trimmomatic, split_args=True)
     return parser
 
@@ -211,7 +211,7 @@ def parser_filter_lastal_bam(parser=argparse.ArgumentParser()):
     parser.add_argument('--JVMmemory',
                         default=tools.picard.FilterSamReadsTool.jvmMemDefault,
                         help='JVM virtual memory size (default: %(default)s)')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, filter_lastal_bam, split_args=True)
     return parser
 
@@ -266,7 +266,7 @@ def parser_filter_lastal(parser=argparse.ArgumentParser()):
     parser.add_argument("inFastq", help="Input fastq file")
     parser.add_argument("refDb", help="Reference database to retain from input")
     parser.add_argument("outFastq", help="Output fastq file")
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, filter_lastal, split_args=True)
     return parser
 
@@ -463,7 +463,7 @@ def parser_partition_bmtagger(parser=argparse.ArgumentParser()):
              ''')
     parser.add_argument('--outMatch', nargs=2, help='Filenames for fastq output of matching reads.')
     parser.add_argument('--outNoMatch', nargs=2, help='Filenames for fastq output of unmatched reads.')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, main_partition_bmtagger)
     return parser
 
@@ -502,7 +502,7 @@ def parser_deplete_bam_bmtagger(parser=argparse.ArgumentParser()):
     parser.add_argument('--JVMmemory',
                         default=tools.picard.FilterSamReadsTool.jvmMemDefault,
                         help='JVM virtual memory size (default: %(default)s)')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, main_deplete_bam_bmtagger)
     return parser
 
@@ -594,7 +594,7 @@ def parser_deplete_blastn(parser=argparse.ArgumentParser()):
     parser.add_argument('inFastq', help='Input fastq file.')
     parser.add_argument('outFastq', help='Output fastq file with matching reads removed.')
     parser.add_argument('refDbs', nargs='+', help='One or more reference databases for blast.')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, deplete_blastn, split_args=True)
     return parser
 
@@ -625,7 +625,7 @@ def parser_deplete_blastn_paired(parser=argparse.ArgumentParser()):
     parser.add_argument('outfq1', help='Output fastq file with matching reads removed.')
     parser.add_argument('outfq2', help='Output fastq file with matching reads removed.')
     parser.add_argument('refDbs', nargs='+', help='One or more reference databases for blast.')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, deplete_blastn_paired, split_args=True)
     return parser
 
@@ -701,7 +701,7 @@ def parser_deplete_blastn_bam(parser=argparse.ArgumentParser()):
     parser.add_argument('--JVMmemory',
                         default=tools.picard.FilterSamReadsTool.jvmMemDefault,
                         help='JVM virtual memory size (default: %(default)s)')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, main_deplete_blastn_bam)
     return parser
 
@@ -740,7 +740,7 @@ def parser_lastal_build_db(parser=argparse.ArgumentParser()):
     parser.add_argument('outputDirectory', help='Location for the output files (default is cwd: %(default)s)')
     parser.add_argument('--outputFilePrefix',
                         help='Prefix for the output file name (default: inputFasta name, sans ".fasta" extension)')
-    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmpDir', None)))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, lastal_build_db, split_args=True)
     return parser
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -17,10 +17,10 @@ class TestCaseWithTmp(unittest.TestCase):
     'Base class for tests that use tempDir'
 
     def setUp(self):
-        util.file.set_tmpDir(type(self).__name__)
+        util.file.set_tmp_dir(type(self).__name__)
 
     def tearDown(self):
-        util.file.destroy_tmpDir()
+        util.file.destroy_tmp_dir()
 
     def assertEqualContents(self, f1, f2):
         assert_equal_contents(self, f1, f2)

--- a/test/unit/test_snake.py
+++ b/test/unit/test_snake.py
@@ -24,7 +24,7 @@ def setup_dummy_simple(sample_names=('G1234', 'G5678', 'G3671.1_r1', 'G3680-1_4'
 
     workdir = tempfile.mkdtemp()
     os.mkdir(os.path.join(workdir, 'data'))
-    os.mkdir(os.path.join(workdir, 'ref_genome'))
+    os.mkdir(os.path.join(workdir, 'ref_genome_dir'))
     os.mkdir(os.path.join(workdir, 'data', '00_raw'))
     os.mkdir(os.path.join(workdir, 'log'))
     os.mkdir(os.path.join(workdir, 'reports'))

--- a/tools/mafft.py
+++ b/tools/mafft.py
@@ -31,11 +31,11 @@ class MafftTool(tools.Tool):
             binaryDir = get_mafft_binary_path(mafft_os, mafft_bitdepth, full=False)
 
             target_rel_path = '{binPath}'.format(binPath=binaryPath)
-            verify_command = 'cd {dir}/mafft-{ver}/{binDir} && {dir}/mafft-{ver}/{binPath} --version > /dev/null 2>&1'.format(
+            verify_command = 'cd {dir}/mafft-{ver}/{bin_dir} && {dir}/mafft-{ver}/{binPath} --version > /dev/null 2>&1'.format(
                 dir=util.file.get_build_path(),
                 ver=tool_version,
                 binPath=binaryPath,
-                binDir=binaryDir)
+                bin_dir=binaryDir)
             destination_dir = '{dir}/mafft-{ver}'.format(dir=util.file.get_build_path(), ver=tool_version)
 
             install_methods.append(

--- a/tools/snpeff.py
+++ b/tools/snpeff.py
@@ -67,14 +67,14 @@ class SnpEff(tools.Tool):
         # if the database is not installed, we need to make it
         if not self.has_genome(databaseId):
             config_file = os.path.join(os.path.dirname(self.install_and_get_path()), 'snpEff.config')
-            dataDir = get_data_dir(config_file)
+            data_dir = get_data_dir(config_file)
 
             # if the data directory specified in the config is absolute, use it
             # otherwise get the data directory relative to the location of the config file
-            if os.path.isabs(dataDir):
-                outputDir = os.path.join(dataDir, databaseId)
+            if os.path.isabs(data_dir):
+                outputDir = os.path.join(data_dir, databaseId)
             else:
-                outputDir = os.path.realpath(os.path.join(os.path.dirname(config_file), dataDir, databaseId))
+                outputDir = os.path.realpath(os.path.join(os.path.dirname(config_file), data_dir, databaseId))
 
             util.genbank.fetch_full_records_from_genbank(accessions,
                                                            outputDir,
@@ -169,13 +169,13 @@ class SnpEff(tools.Tool):
 
 
 def get_data_dir(config_file):
-    dataDir = ""
+    data_dir = ""
     with open(config_file, 'rt') as inf:
         for line in inf:
             if line.strip().startswith('data.dir'):
-                dataDir = line[line.find("=") + 1:].strip()
+                data_dir = line[line.find("=") + 1:].strip()
                 break
-    return dataDir
+    return data_dir
 
 
 def add_genomes_to_snpeff_config_file(config_file, new_genomes):

--- a/util/cmd.py
+++ b/util/cmd.py
@@ -16,7 +16,7 @@ __author__ = "dpark@broadinstitute.org"
 __version__ = util.version.get_version()
 
 log = logging.getLogger()
-tmpDir = None
+tmp_dir = None
 
 
 def setup_logger(log_level):
@@ -32,7 +32,7 @@ def script_name():
     return os.path.basename(sys.argv[0]).rsplit('.', 1)[0]
 
 
-def common_args(parser, arglist=(('tmpDir', None), ('loglevel', None))):
+def common_args(parser, arglist=(('tmp_dir', None), ('loglevel', None))):
     for k, v in arglist:
         if k == 'loglevel':
             if not v:
@@ -42,17 +42,17 @@ def common_args(parser, arglist=(('tmpDir', None), ('loglevel', None))):
                                 help="Verboseness of output.  [default: %(default)s]",
                                 default=v,
                                 choices=('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL', 'EXCEPTION'))
-        elif k == 'tmpDir':
+        elif k == 'tmp_dir':
             if not v:
-                v = find_tmpDir()
-            parser.add_argument("--tmpDir",
-                                dest="tmpDir",
+                v = find_tmp_dir()
+            parser.add_argument("--tmp_dir",
+                                dest="tmp_dir",
                                 help="Base directory for temp files. [default: %(default)s]",
                                 default=v)
-            parser.add_argument("--tmpDirKeep",
+            parser.add_argument("--tmp_dirKeep",
                                 action="store_true",
-                                dest="tmpDirKeep",
-                                help="""Keep the tmpDir if an exception occurs while
+                                dest="tmp_dirKeep",
+                                help="""Keep the tmp_dir if an exception occurs while
                     running. Default is to delete all temp files at
                     the end, even if there's a failure.""",
                                 default=False)
@@ -73,7 +73,7 @@ def main_command(mainfunc):
 
     def _main(args):
         args2 = dict((k, v) for k, v in vars(args).items() if k not in (
-            'loglevel', 'tmpDir', 'tmpDirKeep', 'version', 'func_main', 'command'))
+            'loglevel', 'tmp_dir', 'tmp_dirKeep', 'version', 'func_main', 'command'))
         mainfunc(**args2)
 
     _main.__doc__ = mainfunc.__doc__
@@ -131,8 +131,8 @@ def main_argparse(commands, description):
     log.info("command: %s %s %s", sys.argv[0], sys.argv[1],
              ' '.join(["%s=%s" % (k, v) for k, v in vars(args).items() if k not in ('command', 'func_main')]))
 
-    if hasattr(args, 'tmpDir'):
-        # If this command has a tmpDir option, use that as a base directory
+    if hasattr(args, 'tmp_dir'):
+        # If this command has a tmp_dir option, use that as a base directory
         # and create a subdirectory within it which we will then destroy at
         # the end of execution.
 
@@ -140,15 +140,15 @@ def main_argparse(commands, description):
         if 'LSB_JOBID' in os.environ:
             proposed_dir = 'tmp-%s-%s-%s-%s' % (script_name(), args.command, os.environ['LSB_JOBID'],
                                                 os.environ['LSB_JOBINDEX'])
-        tempfile.tempdir = tempfile.mkdtemp(prefix='%s-' % proposed_dir, dir=args.tmpDir)
+        tempfile.tempdir = tempfile.mkdtemp(prefix='%s-' % proposed_dir, dir=args.tmp_dir)
         log.debug("using tempDir: %s", tempfile.tempdir)
         os.environ['TMPDIR'] = tempfile.tempdir  # this is for running R
         try:
             ret = args.func_main(args)
         except:
-            if hasattr(args, 'tmpDirKeep') and args.tmpDirKeep:
+            if hasattr(args, 'tmp_dirKeep') and args.tmp_dirKeep:
                 log.exception(
-                    "Exception occurred while running %s, saving tmpDir at %s", args.command, tempfile.tempdir)
+                    "Exception occurred while running %s, saving tmp_dir at %s", args.command, tempfile.tempdir)
             else:
                 shutil.rmtree(tempfile.tempdir)
             raise
@@ -162,9 +162,9 @@ def main_argparse(commands, description):
     return ret
 
 
-def find_tmpDir():
+def find_tmp_dir():
     ''' This provides a suggested base directory for a temp dir for use in your
-        argparse-based tmpDir option.
+        argparse-based tmp_dir option.
     '''
     tmpdir = '/tmp'
     if os.access('/local/scratch', os.X_OK | os.W_OK | os.R_OK) and os.path.isdir('/local/scratch'):

--- a/util/file.py
+++ b/util/file.py
@@ -87,17 +87,17 @@ def mkstempfname(suffix='', prefix='tmp', directory=None, text=False):
     return fn
 
 
-def set_tmpDir(name):
+def set_tmp_dir(name):
     proposed_prefix = ['tmp']
     if name:
         proposed_prefix.append(name)
     for e in ('LSB_JOBID', 'LSB_JOBINDEX'):
         if e in os.environ:
             proposed_prefix.append(os.environ[e])
-    tempfile.tempdir = tempfile.mkdtemp(prefix='-'.join(proposed_prefix) + '-', dir=util.cmd.find_tmpDir())
+    tempfile.tempdir = tempfile.mkdtemp(prefix='-'.join(proposed_prefix) + '-', dir=util.cmd.find_tmp_dir())
 
 
-def destroy_tmpDir():
+def destroy_tmp_dir():
     if tempfile.tempdir:
         shutil.rmtree(tempfile.tempdir)
     tempfile.tempdir = None


### PR DESCRIPTION
This PR makes a few breaking changes to the template Snakemake config file. 
**Variable names will need to be updated in any derivative config files:** 

* `bmTaggerDbDir` -> `bm_tagger_db_dir`
* `bmTaggerDbs_remove` -> `bm_tagger_dbs_remove`
* `blastDbDir` -> `blast_db_dir`
* `blastDb_remove` -> `blast_db_remove`
* `trim_clipDb` -> `trim_clip_db`
* `spikeinsDb` -> `spikeins_db`
* `dataDir` -> `data_dir`
* `tmpDir` -> `tmp_dir`
* `logDir` -> `log_dir`
* `reportsDir` -> `reports_dir`
* `binDir` -> `bin_dir`
* `venvDir` -> `venv_dir`
* `lastal_ref_db` -> `lastal_ref_db_dir`

The following changes have also been made:

* `number_of_chromosomes` is now set based on the number of accessions specified for the reference genome, rather than an integer given in the config file
* the reference file prefix is now hard-coded to "`reference`" rather than the `ref_genome_file_prefix` value given in the config file. 
* a check has also been added to the LSF cluster submitter to run a pre-exec command to check whether `ls` can be called on the `data_dir`.