### PR TITLE
updated prinseq version for fixes and support for Perl 5.14+

### DIFF
--- a/tools/prinseq.py
+++ b/tools/prinseq.py
@@ -2,8 +2,9 @@
 
 import tools
 
+tool_version = '0.20.4'
 url = 'http://sourceforge.net/projects/prinseq/files/standalone/' \
-      'prinseq-lite-0.19.3.tar.gz'
+      'prinseq-lite-{ver}.tar.gz'.format(ver=tool_version)
 
 
 class PrinseqTool(tools.Tool):
@@ -11,7 +12,7 @@ class PrinseqTool(tools.Tool):
     def __init__(self, install_methods=None):
         if install_methods is None:
             install_methods = []
-            target_rel_path = 'prinseq-lite-0.19.3/prinseq-lite.pl'
+            target_rel_path = 'prinseq-lite-{ver}/prinseq-lite.pl'.format(ver=tool_version)
             install_methods.append(
                 tools.DownloadPackage(url,
                                       target_rel_path,


### PR DESCRIPTION
updated prinseq version for [fixes](http://sourceforge.net/projects/prinseq/files/README.txt/view) and support for Perl 5.14+ (since prinseq 19.3 fails to run on OSX 10.10+ and Ubuntu 14.04 due to their newer versions of Perl)
