### PR TITLE
fix .pylintrc; section header was missing

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,4 @@
+[DESIGN]
 # the default of five is a bit too restrictive
 max-args = 12
 


### PR DESCRIPTION
fix .pylintrc; section header was missing