### PR TITLE
Mark .rules as Python for Github.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.rules linguist-language=Python


### PR DESCRIPTION
Doesn't help with syntax highlighting, but at least recommended.