### PR TITLE
Make ansible vagrant easier to test changes

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -13,24 +13,73 @@ testing, you first need to perform the following steps:
 
 ::
 
-    pyenv install 2.7.10 3.4.3 3.5.0
+    $ pyenv install 2.7.10 3.4.3 3.5.0
 
 3. Change directory to the `viral-ngs` git checkout.
 4. Set the local pyenv versions:
 
 ::
 
-    pyenv local 3.5.0 3.4.3 2.7.10
+    $ pyenv local 3.5.0 3.4.3 2.7.10
 
 5. Install tox and tox-pyenv
 
 ::
 
-    pip3 install tox tox-pyenv
+    $ pip3 install tox tox-pyenv
 
 6. Run tox to run tests and check building docs.
 
 ::
 
-    tox
+    $ tox
 
+Testing easy_deploy with Vagrant and Ansible
+--------------------------------------------
+
+By default, easy_deploy installs a version of viral-ngs by cloning the github
+repository, which makes it difficult to test local changes to the playbook.
+Testing the easy_deploy setup locally can be done using Vagrant and the Ansible
+playbook with some custom commands. To do so, we need to take the following
+steps:
+
+1. `Install Vagrant <https://docs.vagrantup.com/v2/installation/>`_
+2. `Install Ansible <http://docs.ansible.com/ansible/intro_installation.html>`_
+3. Change to the easy_deploy directory
+
+::
+
+   $ cd easy_deploy
+
+4. Run the easy deploy script to bootstrap the VM and answer the prompts
+
+::
+
+   $ ./run.sh
+
+5. From now on, run Ansible playbook manually for provisioning:
+   http://docs.ansible.com/ansible/guide_vagrant.html#running-ansible-manually.
+
+6. Add `deploy=sync` or `deploy=archive` to the `--extra-vars` of the Ansible
+   playbook command
+
+::
+
+   $ ansible-playbook ... --extra-vars=deploy=sync
+
+To test playbook changes in a local repository, the choice of `deploy=sync` or
+`deploy=archive` changes the strategy used to "deploy" viral-ngs into the
+Vagrant VM.
+
+The `deploy=sync` option creates a symlink to the synced folder containing the
+root of your viral-ngs git repo. Therefore, any tool installation or other
+changes will be reflected on both the host and the guest machine. This is
+desirable for fast iteration of changes, but makes it difficult to isolate the
+host's viral-ngs installation from the installation on the guest VM.
+
+The `deploy=archive` option performs a `git archive` on the host's viral-ngs
+repository and untars it into the project directory. This is a clean install
+each time, which can be time consuming due to the need to reinstall all
+dependencies, and only the current HEAD commit will be reflected in the guest.
+No uncommitted/dirty changes will be picked up using this method. This is more
+ideally suited for a finalized clean test of the playbook.

--- a/easy-deploy/Vagrantfile
+++ b/easy-deploy/Vagrantfile
@@ -2,17 +2,18 @@ Vagrant.configure("2") do |config|
   config.vm.provider :virtualbox do |vb, override|
     vb.customize ["modifyvm", :id, "--memory", 8192]
     config.vm.hostname = "viral-ngs-vm"
-    
+
     override.vm.box = "viral-ngs-vm"
     override.vm.box = "ubuntu/vivid64"
 
     override.vm.synced_folder ".", "/vagrant", disabled: true
     override.vm.synced_folder "./data/", "/home/vagrant/data/", create: true
+    override.vm.synced_folder "..", "/home/vagrant/viral-ngs", create: true
 
     override.vm.provision "ansible" do |ansible|
         ansible.playbook = "ansible-playbook.yml"
         ansible.extra_vars = {
-          user: "vagrant",
+          ansible_ssh_user: "vagrant",
         }
     end
   end
@@ -39,9 +40,9 @@ Vagrant.configure("2") do |config|
     override.vm.provision "ansible" do |ansible|
         ansible.playbook = "ansible-playbook.yml"
         ansible.extra_vars = {
-          user: "ubuntu",
+          ansible_ssh_user: "ubuntu",
         }
     end
 
-  end 
+  end
 end

--- a/easy-deploy/ansible-playbook.yml
+++ b/easy-deploy/ansible-playbook.yml
@@ -1,7 +1,12 @@
 -
   hosts: all
   vars:
+    # Replace with ansible_user in ansible 2.0
+    user: "{{ ansible_ssh_user }}"
     home_dir: "/home/{{ user }}"
+    deploy: "clone"
+    synced_git_dir: "{{ home_dir }}/viral-ngs"
+    viral_ngs_tree_id_cache: "{{ home_dir }}/viral-ngs-hash"
     project_dir: "{{ home_dir }}/bin"
     venv_dir: "{{ home_dir }}/venv"
     data_dir: "{{ home_dir }}/data"
@@ -21,8 +26,8 @@
       apt: pkg=gcc-4.7 state=installed
 
     #- name: Add Ubuntu universe repository # needed for bamtools
-    #  apt_repository: 
-    #    repo: 'deb-src http://archive.canonical.com/ubuntu vivid universe' 
+    #  apt_repository:
+    #    repo: 'deb-src http://archive.canonical.com/ubuntu vivid universe'
     #    state: present
 
     - name: Install htop
@@ -73,12 +78,52 @@
     - name: Install libbamtools-dev
       apt: pkg=libbamtools-dev state=installed
 
+    - name: Get cached viral ngs tree id
+      command: "cat {{ viral_ngs_tree_id_cache }}"
+      register: cached_viral_ngs_tree_id
+      ignore_errors: yes
+      when: deploy == "archive"
+
+    - name: Get synced git HEAD tree id
+      command: git rev-parse --verify HEAD
+      register: viral_ngs_head_id
+      args:
+        chdir: "{{ synced_git_dir }}"
+      when: deploy == "archive"
+
+    - name: Viral ngs git archive copy from synced folder
+      shell: "{{ item }}"
+      args:
+        chdir: "{{ synced_git_dir }}"
+      with_items:
+        - "rm -rf {{ project_dir }}"
+        - "mkdir -p {{ project_dir }}"
+        - "git archive {{ viral_ngs_head_id.stdout }} | tar -x -C {{ project_dir }}"
+        - "git describe --tags --always --dirty > {{ project_dir }}/VERSION"
+        - "echo {{ viral_ngs_head_id.stdout }} > {{ viral_ngs_tree_id_cache }}"
+      when: deploy == "archive" and cached_viral_ngs_tree_id.stdout != viral_ngs_head_id.stdout
+
     - name: Cloning latest version of viral-ngs from GitHub
-      git: 
+      git:
         repo: https://github.com/broadinstitute/viral-ngs.git
         dest: "{{ project_dir }}"
         version: HEAD
         accept_hostkey: yes
+        depth: 1
+      when: deploy == "clone"
+
+    - name: Deleting directory for symlink deploy
+      file:
+        path: "{{ project_dir }}"
+        state: absent
+      when: deploy == "sync"
+
+    - name: Symlinking synced git repo to project dir
+      file:
+        src: "{{ synced_git_dir }}"
+        dest: "{{ project_dir }}"
+        state: link
+      when: deploy == "sync"
 
     - name: copy viral-ngs config.json
       command: "cp {{ project_dir }}/pipes/config.json  {{ home_dir }}/config.json" # {{ data_dir }}/config.json
@@ -94,32 +139,32 @@
 
     - name: copy gatk; REQUIRES host GATK_PATH set to licensed copy
       copy:
-        owner: "{{ user }}" 
-        group: "{{ user }}"  
+        owner: "{{ user }}"
+        group: "{{ user }}"
         src: "{{ lookup('env','GATK_PATH') }}/" # trailing slash to copy contents only like rsync
         dest: "{{ gatk_path }}"
 
     - name: copy novoalign; REQUIRES host NOVOALIGN_PATH set to licensed copy
       copy:
-        owner: "{{ user }}"  
-        group: "{{ user }}"  
+        owner: "{{ user }}"
+        group: "{{ user }}"
         src: "{{ lookup('env','NOVOALIGN_PATH') }}/" # trailing slash to copy contents only like rsync
         dest: "{{ novoalign_path }}"
 
     - name: Set GATK_PATH env var
-      lineinfile: 
+      lineinfile:
         dest: "/etc/environment"
-        line: "GATK_PATH={{ gatk_path }}" 
-        insertafter: 'EOF' 
-        regexp: "GATK_PATH={{ gatk_path }}" 
+        line: "GATK_PATH={{ gatk_path }}"
+        insertafter: 'EOF'
+        regexp: "GATK_PATH={{ gatk_path }}"
         state: present
 
     - name: Set NOVOALIGN_PATH env var
-      lineinfile: 
+      lineinfile:
         dest: "/etc/environment"
-        line: "NOVOALIGN_PATH={{ novoalign_path }}" 
-        insertafter: 'EOF' 
-        regexp: "NOVOALIGN_PATH={{ novoalign_path }}" 
+        line: "NOVOALIGN_PATH={{ novoalign_path }}"
+        insertafter: 'EOF'
+        regexp: "NOVOALIGN_PATH={{ novoalign_path }}"
         state: present
 
     - name: Create virtualenv
@@ -141,7 +186,7 @@
       file:
         path: "{{ item }}"
         state: directory
-        owner: "{{ user }}"  
+        owner: "{{ user }}"
         group: "{{ user }}"
         #mode: 0755
         recurse: yes
@@ -159,10 +204,10 @@
         - "{{ gatk_path }}/"
         - "{{ novoalign_path }}/"
 
-    - name: Copy virtualenv wrapper template  
-      template: 
+    - name: Copy virtualenv wrapper template
+      template:
         src: "venv_exec.j2"
-        dest: "{{ venv_dir }}/exec" 
+        dest: "{{ venv_dir }}/exec"
         mode: 0755
 
     - name: Install viral-ngs tools
@@ -171,10 +216,10 @@
         chdir: "{{ project_dir }}"
 
     - name: Modify .bashrc so venv is loaded on connect
-      lineinfile: 
+      lineinfile:
         dest: "{{ home_dir }}/.bashrc"
-        line: 'test -z "$VIRTUAL_ENV" && source {{ venv_dir }}/bin/activate' 
-        insertafter: 'EOF' 
+        line: 'test -z "$VIRTUAL_ENV" && source {{ venv_dir }}/bin/activate'
+        insertafter: 'EOF'
         regexp: 'test -z "$VIRTUAL_ENV" && source {{ venv_dir }}/bin/activate'
         state: present
 
@@ -182,7 +227,7 @@
       file:
         path: "{{ item }}"
         state: touch
-        owner: "{{ user }}"  
+        owner: "{{ user }}"
         group: "{{ user }}"
       with_items:
         - "{{ home_dir }}/samples-depletion.txt"
@@ -195,7 +240,7 @@
       file:
         path: "{{ item }}"
         state: directory
-        owner: "{{ user }}"  
+        owner: "{{ user }}"
         group: "{{ user }}"
         #mode: 0755
         recurse: yes
@@ -210,4 +255,3 @@
         - "{{ data_dir }}/03_align_to_ref/"
         - "{{ data_dir }}/03_interhost/"
         - "{{ data_dir }}/04_intrahost/"
-


### PR DESCRIPTION
Previously easy_deploy relied on git clone of repo from github, which
makes playbook changes hard to test without committing to the master
repo.

Now, we vagrant sync the local git repo into the VM, then perform a git
archive export to the final project directory so tool installation in VM
does not affect the host machine.

This is forked off from #167 