### PR TITLE
added conda install to ansible playbook of easy_install; added meryl to the list of binaries we check for when looking at the Trinity install

### DIFF
--- a/easy-deploy/ansible-playbook.yml
+++ b/easy-deploy/ansible-playbook.yml
@@ -13,11 +13,12 @@
     licensed_tools_dir: "{{ home_dir }}/licensed_tools"
     gatk_path: "{{ licensed_tools_dir }}/gatk"
     novoalign_path: "{{ licensed_tools_dir }}/novoalign"
+    conda_path: "{{home_dir}}/miniconda3/bin"
   environment:
     GATK_PATH: "{{ gatk_path }}"
     NOVOALIGN_PATH: "{{ novoalign_path }}"
     TEST_VAR: "foo"
-  sudo: yes
+  become: yes
   tasks:
     - name: update apt cache (apt-get update)
       apt: update_cache=yes
@@ -34,6 +35,31 @@
       apt: pkg=htop state=installed
     - name: Install git
       apt: pkg=git state=installed
+
+    - name: download conda installer script
+      get_url: 
+        url: https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh 
+        dest: "{{ home_dir }}/Miniconda3-latest-Linux-x86_64.sh"
+        mode: "0755"
+      register: conda_script_downloaded
+    - name: install conda
+      command: "bash {{ home_dir }}/Miniconda3-latest-Linux-x86_64.sh -b" # -b indicates agreement with license
+      become: no
+      args:
+        creates: "{{home_dir}}/miniconda3"
+      when: conda_script_downloaded|success
+    - name: "add {{conda_path}} to path"
+      lineinfile:
+        dest: /etc/environment
+        state: present
+        backrefs: yes
+        regexp: 'PATH=(["]*)((?!.*?{{conda_path}}).*?)(["]*)$'
+        line: 'PATH=\1\2:{{conda_path}}\3'
+    - name: "run conda_setup.sh"
+      script: conda_setup.sh
+      environment:
+        PATH: "{{ ansible_env.PATH }}:{{conda_path}}"
+
     - name: Install python-virtualenv
       apt: pkg=python-virtualenv state=installed
     - name: Install python3
@@ -214,6 +240,8 @@
       command: "{{ venv_dir }}/exec nosetests -v test.unit.test_tools.TestToolsInstallation"
       args:
         chdir: "{{ project_dir }}"
+      environment:
+        PATH: "{{ ansible_env.PATH }}:{{conda_path}}"
 
     - name: Modify .bashrc so venv is loaded on connect
       lineinfile:

--- a/easy-deploy/conda_setup.sh
+++ b/easy-deploy/conda_setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+hash -r
+conda config --set always_yes yes --set changeps1 no
+conda config --add channels bioconda
+conda config --add channels r
+conda update -q conda

--- a/tools/trinity.py
+++ b/tools/trinity.py
@@ -93,13 +93,16 @@ class DownloadAndBuildTrinity(tools.DownloadPackage):
     def verify_install(self):
         if not tools.DownloadPackage.verify_install(self):
             return False
+        self.installed = True
+
         # Verify that chrysalis and inchworm were built
         trinity_dir = os.path.join(self.destination_dir, TRINITY_VERSION)
         chrysalisPath = os.path.join(trinity_dir, 'Chrysalis', 'Chrysalis')
         inchwormPath = os.path.join(trinity_dir, 'Inchworm', 'src', 'inchworm')
-        for path in [chrysalisPath, inchwormPath]:
+        merylPath = os.path.join(trinity_dir, 'trinity-plugins', 'kmer', 'meryl', 'meryl')
+        for path in [chrysalisPath, inchwormPath, merylPath]:
             if not os.access(path, (os.X_OK | os.R_OK)):
                 log.debug('%s was not built.', path)
                 self.installed = False
-        self.installed = True
+        
         return self.installed


### PR DESCRIPTION
added conda install to ansible playbook of easy_install; added meryl to
the list of binaries we check for when looking at the Trinity install.
Trinity install now fails (correctly) if meryl, chrysalis, or inchworm
binaries did not build