### PR TITLE
null pad Illumina SampleSheet.csv data rows if they are shorter than the header

### DIFF
--- a/illumina.py
+++ b/illumina.py
@@ -375,6 +375,13 @@ class SampleSheet(object):
                     else:
                         # data rows
                         row_num += 1
+
+                        # pad the row with null strings if it is shorter than the header list
+                        # sometimes a MiSeq produces an out-of-spec CSV file that lacks trailing commas,
+                        # removing null values that should be present to ensure a length match with the header
+                        while len(row) < len(header):
+                            row.append("")
+
                         assert len(header) == len(row)
                         row = dict((k, v) for k, v in zip(header, row) if k and v)
                         row['row_num'] = str(row_num)


### PR DESCRIPTION
sometimes the MiSeq does not write trailing commas in data rows,
mysteriously removing null values that would ensure the row length
matches the header length