### PR TITLE
update CondaPackage to update versions; refactor of CondaPackage

### DIFF
--- a/test/unit/test_tools.py
+++ b/test/unit/test_tools.py
@@ -54,6 +54,3 @@ class TestToolsInstallation(object):
         '''Load every tool's default chain of install methods and try them.'''
         for tool_class in iter_leaf_subclasses(tools.Tool):
             yield self.check_tool, tool_class
-
-
-


### PR DESCRIPTION
CondaPackage now examines the installed version of a given package, and if the version differs from the one expected by CondaPackage, it uninstalls the incorrect version and installs the version specified by
the CondaPackage InstallMethod. This allows user packages to update in place automatically. If the version of a tool changes in the repo, a “git pull” is all users need to update their packages, as the tool wrappers will update the tools on first use of the tool, or upon “nosetests test.unit.test_tools”. Also some general refactoring of CondaPackage.