### PR TITLE
easy deploy improvements

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -128,8 +128,17 @@ The following environment variables are needed:
  * ``EC2_REGION`` (ex. "us-west-2")
  * ``EC2_KEYPAIR_NAME`` (ex. "my-ssh-keypair")
  * ``EC2_PRIVATE_KEY_PATH`` (ex. "my-ssh-keypair.pem")
+ * ``EC2_SECURITY_GROUP`` (ex. "ssh-only-group")
 
+For more information, see the following AWS pages:
+
+* `Getting set up with AWS <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/get-set-up-for-amazon-ec2.html>`_
+* `How to create an AWS EC2 key pair <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#having-ec2-create-your-key-pair>`_
+* `Defining security group rules <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#adding-security-group-rule>`_
+* `List of EC2 regions <https://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region>`_
  
+Note that the EC2 instance created by the easy-deploy script is currently configured to be an m4.2xlarge, which costs ~$0.55/hour to run. It is suggested that the instance be terminated via the AWS web console once processing with viral-ngs is comple. See the `AWS page for current pricing <https://aws.amazon.com/ec2/pricing/>`_ .
+
 Limitations
 ~~~~~~~~~~~
 

--- a/easy-deploy/Vagrantfile
+++ b/easy-deploy/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure("2") do |config|
     override.vm.provision "ansible" do |ansible|
         ansible.playbook = "ansible-playbook.yml"
         ansible.extra_vars = {
-          ansible_ssh_user: "vagrant",
+          ansible_user: "vagrant",
         }
     end
   end
@@ -24,10 +24,27 @@ Vagrant.configure("2") do |config|
     # ubuntu AMI, see: https://cloud-images.ubuntu.com/locator/ec2/
     # Vivid 15.04, amd64 hvm:ebs-ssd @ us-west-2
     aws.ami = "ami-73b4af43"
+
+    if    ENV["EC2_REGION"]=="ap-northeast-1"; aws.ami="ami-1c0c3672";
+    elsif ENV["EC2_REGION"]=="ap-southeast-1"; aws.ami="ami-327cb351";
+    elsif ENV["EC2_REGION"]=="eu-central-1"; aws.ami="ami-f39e869f";
+    elsif ENV["EC2_REGION"]=="eu-west-1"; aws.ami="ami-3a229449";
+    elsif ENV["EC2_REGION"]=="sa-east-1"; aws.ami="ami-7b24a417";
+    elsif ENV["EC2_REGION"]=="us-east-1"; aws.ami="ami-f50e209f";
+    elsif ENV["EC2_REGION"]=="us-west-1"; aws.ami="ami-ae1b6dce";
+    elsif ENV["EC2_REGION"]=="cn-north-1"; aws.ami="ami-4c7ab321";
+    elsif ENV["EC2_REGION"]=="ap-southeast-2"; aws.ami="ami-c3b490a0";
+    elsif ENV["EC2_REGION"]=="us-west-2"; aws.ami="ami-6206e002"; end
+
     aws.instance_type = "m4.2xlarge"
-    aws.instance_ready_timeout = 180 # default: 120
+    aws.instance_ready_timeout = 250 # default: 120
     aws.keypair_name = ENV["EC2_KEYPAIR_NAME"]
     aws.region = ENV["EC2_REGION"]
+    aws.block_device_mapping = [{ 'DeviceName' => '/dev/sda1', 'Ebs.VolumeSize' => 300 }]
+
+    if ENV["EC2_SECURITY_GROUP"]
+        aws.security_groups = [ENV["EC2_SECURITY_GROUP"]]
+    end
 
     override.vm.box = "viral-ngs-vm"
     override.vm.box_url = "https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box"
@@ -39,8 +56,10 @@ Vagrant.configure("2") do |config|
 
     override.vm.provision "ansible" do |ansible|
         ansible.playbook = "ansible-playbook.yml"
+        ansible.host_key_checking = false
+        #ansible.verbose = "vvv"
         ansible.extra_vars = {
-          ansible_ssh_user: "ubuntu",
+          ansible_user: "ubuntu",
         }
     end
 

--- a/easy-deploy/ansible-playbook.retry
+++ b/easy-deploy/ansible-playbook.retry
@@ -1,0 +1,1 @@
+default

--- a/easy-deploy/ansible-playbook.yml
+++ b/easy-deploy/ansible-playbook.yml
@@ -2,7 +2,7 @@
   hosts: all
   vars:
     # Replace with ansible_user in ansible 2.0
-    user: "{{ ansible_ssh_user }}"
+    user: "{{ ansible_user }}"
     home_dir: "/home/{{ user }}"
     deploy: "clone"
     synced_git_dir: "{{ home_dir }}/viral-ngs"

--- a/easy-deploy/ansible.cfg
+++ b/easy-deploy/ansible.cfg
@@ -1,0 +1,2 @@
+[ssh_connection]
+control_path = /tmp/%%h-%%p-%%r

--- a/easy-deploy/run.sh
+++ b/easy-deploy/run.sh
@@ -284,7 +284,7 @@ if all_commands_exist $relevant_commands; then
                 fi
             fi
 
-            if [ -z "$EC2_ACCESS_KEY_ID" ] || [ -z "$EC2_SECRET_ACCESS_KEY" ] || [ -z "$EC2_KEYPAIR_NAME" ] || [ -z "$EC2_PRIVATE_KEY_PATH" ] || [ -z "$EC2_REGION" ]; then 
+            if [ -z "$EC2_ACCESS_KEY_ID" ] || [ -z "$EC2_SECRET_ACCESS_KEY" ] || [ -z "$EC2_KEYPAIR_NAME" ] || [ -z "$EC2_PRIVATE_KEY_PATH" ] || [ -z "$EC2_REGION" ] || [ -z "$EC2_SECURITY_GROUP" ]; then 
                 echo "==========================================================================================="
                 echo "Prior to deploying to EC2 you must obtain AWS IAM credentials permitting instance creation." 
                 echo "You must also create a private/public keypair for use with EC2." 
@@ -296,14 +296,17 @@ if all_commands_exist $relevant_commands; then
                 if [ -z "$EC2_SECRET_ACCESS_KEY" ]; then
                     echo "    EC2_SECRET_ACCESS_KEY"
                 fi
+                if [ -z "$EC2_REGION" ]; then
+                    echo "    EC2_REGION"
+                fi
                 if [ -z "$EC2_KEYPAIR_NAME" ]; then
                     echo "    EC2_KEYPAIR_NAME"
                 fi
                 if [ -z "$EC2_PRIVATE_KEY_PATH" ]; then
                     echo "    EC2_PRIVATE_KEY_PATH"
                 fi
-                if [ -z "$EC2_REGION" ]; then
-                    echo "    EC2_REGION"
+                if [ -z "$EC2_SECURITY_GROUP" ]; then
+                    echo "    EC2_SECURITY_GROUP"
                 fi
                 echo ""
                 echo "If you wish, you may specify these values now for use in only this session."
@@ -325,8 +328,15 @@ if all_commands_exist $relevant_commands; then
                         fi
                     done
 
+                    while [ -z "$EC2_REGION" ]; do
+                        read -p "What is the EC2 region (ex. 'us-east-1')? " EC2_REGION
+                        if [ $(echo ${#EC2_REGION}) -gt 0 ]; then
+                            export EC2_REGION="$EC2_REGION"
+                        fi
+                    done
+
                     while [ -z "$EC2_KEYPAIR_NAME" ]; do
-                        read -p "What is AWS keypair name? " EC2_KEYPAIR_NAME
+                        read -p "What is AWS keypair name (region-specific)? " EC2_KEYPAIR_NAME
                         if [ $(echo ${#EC2_KEYPAIR_NAME}) -gt 0 ]; then
                             export EC2_KEYPAIR_NAME="$EC2_KEYPAIR_NAME"
                         fi
@@ -339,10 +349,10 @@ if all_commands_exist $relevant_commands; then
                         fi
                     done
 
-                    while [ -z "$EC2_REGION" ]; do
-                        read -p "What is the EC2 region? " EC2_REGION
-                        if [ $(echo ${#EC2_REGION}) -gt 0 ]; then
-                            export EC2_REGION="$EC2_REGION"
+                    while [ -z "$EC2_SECURITY_GROUP" ]; do
+                        read -p "Specify the *name* of the EC2 security group to use; the group must permit access on TCP port 22 (region-specific): " EC2_SECURITY_GROUP
+                        if [ $(echo ${#EC2_SECURITY_GROUP}) -gt 0 ]; then
+                            export EC2_SECURITY_GROUP="$EC2_SECURITY_GROUP"
                         fi
                     done
                 else
@@ -355,6 +365,7 @@ if all_commands_exist $relevant_commands; then
                echo "EC2_KEYPAIR_NAME is set."
                echo "EC2_PRIVATE_KEY_PATH is set."
                echo "EC2_REGION is set."
+               echo "EC2_SECURITY_GROUP is set."
                echo "Continuing..."
             fi
 
@@ -367,6 +378,7 @@ if all_commands_exist $relevant_commands; then
 
                 if ! [ $? -eq 0 ]; then
                     echo "The VM was not set up correctly. Check above for error messages."
+                    vagrant destroy
                     exit 1
                 fi
 


### PR DESCRIPTION
vagrantfile now selects AMI based on region specified (was us-west-1
only before); run.sh asks for region; wait-for-instance-ssh timeout
lengthened; EBS size changed from 8 to 300GB; run.sh now asks for
security group, vagrantfile uses it; ansible.cfg now specifies shorter
ssh control path; additional information in easy deploy docs