### PR TITLE
travis log capture and cleanup

### DIFF
--- a/assembly.py
+++ b/assembly.py
@@ -25,6 +25,7 @@ except ImportError:
 # intra-module
 import util.cmd
 import util.file
+import util.misc
 import util.vcf
 import read_utils
 import taxon_filter
@@ -92,7 +93,7 @@ def trim_rmdup_subsamp_reads(inBam, clipDb, outBam, n_reads=100000):
            '-out',
            subsampfq[0],
            subsampfq[1],]
-    subprocess.check_call(cmd)
+    util.misc.run_and_print(cmd)
     os.unlink(purgefq[0])
     os.unlink(purgefq[1])
 

--- a/read_utils.py
+++ b/read_utils.py
@@ -18,6 +18,7 @@ import subprocess
 from Bio import SeqIO
 import util.cmd
 import util.file
+import util.misc
 from util.file import mkstempfname
 import tools.picard
 import tools.samtools
@@ -43,7 +44,7 @@ def purge_unmated(inFastq1, inFastq2, outFastq1, outFastq2, regex=r'^@(\S+)/[1|2
     mergeShuffledFastqSeqsPath = os.path.join(util.file.get_scripts_path(), 'mergeShuffledFastqSeqs.pl')
     cmdline = [mergeShuffledFastqSeqsPath, '-t', '-r', regex, '-f1', inFastq1, '-f2', inFastq2, '-o', tempOutput]
     log.debug(' '.join(cmdline))
-    subprocess.check_call(cmdline)
+    util.misc.run_and_print(cmdline)
     shutil.move(tempOutput + '.1.fastq', outFastq1)
     shutil.move(tempOutput + '.2.fastq', outFastq2)
     return 0
@@ -822,7 +823,7 @@ def rmdup_prinseq_fastq(inFastq, outFastq):
             inFastq, '-out_bad', 'null', '-line_width', '0', '-out_good', outFastq[:-6]
         ]
         log.debug(' '.join(cmd))
-        subprocess.check_call(cmd)
+        util.misc.run_and_print(cmd)
 
 
 def parser_rmdup_prinseq_fastq(parser=argparse.ArgumentParser()):

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,2 +1,3 @@
 coveralls==1.1
 nose-cov==1.6
+nose-timer==0.6.0

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -5,7 +5,7 @@
 #python -m unittest discover -v
 # since test.unit.test_tools.TestToolsInstallation uses unittest-incompatible
 # test generators, we have to test using nosetests
-nosetests -v --with-xunit --with-coverage --nocapture \
+nosetests -v --with-xunit --with-coverage \
     --cover-inclusive --cover-branches --cover-tests \
     --cover-package broad_utils,illumina,assembly,interhost,intrahost,ncbi,read_utils,reports,taxon_filter,tools,util \
     test/unit/ test/integration/

--- a/test/unit/test_assembly.py
+++ b/test/unit/test_assembly.py
@@ -44,7 +44,7 @@ class TestAssembleTrinity(TestCaseWithTmp):
         inBam = os.path.join(inDir, 'G3952.1.subsamp.bam')
         clipDb = os.path.join(inDir, 'clipDb.fasta')
         outFasta = util.file.mkstempfname('.fasta')
-        assembly.assemble_trinity(inBam, outFasta, clipDb)
+        assembly.assemble_trinity(inBam, outFasta, clipDb, threads=4)
         self.assertGreater(os.path.getsize(outFasta), 0)
         os.unlink(outFasta)
 

--- a/test/unit/test_taxon_filter.py
+++ b/test/unit/test_taxon_filter.py
@@ -10,8 +10,10 @@ import shutil
 import filecmp
 import subprocess
 import argparse
+
 import taxon_filter
 import util.file
+import util.misc
 import tools.last
 import tools.bmtagger
 import tools.blast
@@ -144,7 +146,7 @@ class TestDepleteBlastn(TestCaseWithTmp):
             refDb = os.path.join(tempDir, dbname)
             os.symlink(os.path.join(myInputDir, dbname), refDb)
             refDbs.append(refDb)
-            subprocess.check_call([makeblastdbPath, '-dbtype', 'nucl', '-in', refDb])
+            util.misc.run_and_print([makeblastdbPath, '-dbtype', 'nucl', '-in', refDb])
 
         # Run deplete_blastn
         outFile = os.path.join(tempDir, 'out.fastq')
@@ -170,7 +172,7 @@ class TestDepleteBlastnBam(TestCaseWithTmp):
             refDb = os.path.join(tempDir, dbname)
             os.symlink(os.path.join(myInputDir, dbname), refDb)
             refDbs.append(refDb)
-            subprocess.check_call([makeblastdbPath, '-dbtype', 'nucl', '-in', refDb])
+            util.misc.run_and_print([makeblastdbPath, '-dbtype', 'nucl', '-in', refDb])
 
         # convert the input fastq's to a bam
         inFastq1 = os.path.join(myInputDir, "in1.fastq")

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -272,7 +272,7 @@ class CondaPackage(InstallMethod):
             # check for presence of conda command
             util.misc.run_and_print(["conda", "-V"], silent=True, env=self.conda_env)
         except:
-            _log.warn("conda should be installed")
+            _log.debug("conda NOT installed; using custom tool install")
             self.is_attempted = True
             self.installed = False
             return

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -237,7 +237,7 @@ class CondaPackage(InstallMethod):
 
     @property
     def _package_installed(self):
-        result = util.misc.run_and_print(["conda", "list", "-f", "-c", "-p", self.env_path, "--json", self.package], silent=True, env=self.conda_env)
+        result = util.misc.run_and_print(["conda", "list", "-f", "-c", "-p", self.env_path, "--json", self.package], silent=True, env=self.conda_env, buffered=True)
         if result.returncode == 0:
             command_output = result.stdout.decode("UTF-8")
             data = json.loads(self._string_from_start_of_json(command_output))
@@ -270,7 +270,7 @@ class CondaPackage(InstallMethod):
     def _attempt_install(self):
         try:
             # check for presence of conda command
-            util.misc.run_and_print(["conda", "-V"], silent=True, env=self.conda_env)
+            util.misc.run_and_print(["conda", "-V"], silent=True, env=self.conda_env, buffered=True)
         except:
             _log.debug("conda NOT installed; using custom tool install")
             self.is_attempted = True
@@ -312,7 +312,7 @@ class CondaPackage(InstallMethod):
         run_cmd = ["conda", "list", "-c", "--json", "-f", "-p", self.env_path, self.package]
 
 
-        result = util.misc.run_and_print(run_cmd, silent=True, env=self.conda_env)
+        result = util.misc.run_and_print(run_cmd, silent=True, env=self.conda_env, buffered=True)
         if result.returncode == 0:
             try:
                 command_output = result.stdout.decode("UTF-8")
@@ -339,7 +339,8 @@ class CondaPackage(InstallMethod):
         result = util.misc.run_and_print(
             run_cmd,
             silent=True,
-            env=self.conda_env
+            env=self.conda_env,
+            buffered=True
         )
 
         if result.returncode == 0:
@@ -367,7 +368,7 @@ class CondaPackage(InstallMethod):
             python_version = "python=" + python_version if python_version else ""
             run_cmd.extend([python_version])
 
-        result = util.misc.run_and_print(run_cmd, silent=True, env=self.conda_env)
+        result = util.misc.run_and_print(run_cmd, silent=True, env=self.conda_env, buffered=True)
         try:
             command_output = result.stdout.decode("UTF-8")
             data = json.loads(self._string_from_start_of_json(command_output))
@@ -386,7 +387,8 @@ class CondaPackage(InstallMethod):
                     self._package_str
                 ],
                 silent=True,
-                env=self.conda_env
+                env=self.conda_env,
+                buffered=True
             )
 
             if result.returncode == 0:

--- a/tools/blast.py
+++ b/tools/blast.py
@@ -54,6 +54,9 @@ class BlastTools(tools.Tool):
         #tools.Tool.__init__(self, install_methods=install_methods)
         super(BlastTools, self).__init__(install_methods=install_methods)
 
+    def execute(self, *args):
+        util.misc.run_and_print(self.exec_path, args)
+
 
 class BlastnTool(BlastTools):
     """ Tool wrapper for blastn """

--- a/tools/bmtagger.py
+++ b/tools/bmtagger.py
@@ -34,6 +34,9 @@ class BmtaggerTools(tools.Tool):
             install_methods.append(DownloadBmtagger(self.subtool_name))
         tools.Tool.__init__(self, install_methods=install_methods)
 
+    def execute(self, *args):
+        util.misc.run_and_print(self.exec_path, args)
+
 
 class BmtaggerShTool(BmtaggerTools):
     """ tool wrapper for bmtagger """

--- a/tools/gatk.py
+++ b/tools/gatk.py
@@ -64,7 +64,7 @@ class GATKTool(tools.Tool):
 
     def _get_tool_version(self):
         cmd = ['java', '-jar', self.install_and_get_path(), '--version']
-        self.tool_version = util.misc.run_and_print(cmd, buffered=True).stdout.strip()
+        self.tool_version = util.misc.run_and_print(cmd, buffered=True, silent=True).stdout.strip()
 
     def ug(self, inBam, refFasta, outVcf, options=None, JVMmemory=None, threads=1):
         options = options or ["--min_base_quality_score", 15, "-ploidy", 4]

--- a/tools/gatk.py
+++ b/tools/gatk.py
@@ -10,6 +10,8 @@ import tools
 import tools.picard
 import tools.samtools
 import util.file
+import util.misc
+
 import logging
 import os
 import os.path
@@ -32,7 +34,7 @@ class GATKTool(tools.Tool):
                 install_methods.append(
                     tools.PrexistingUnixCommand(
                         jarpath,
-                        verifycmd='java -jar %s --version' % jarpath,
+                        verifycmd='java -jar %s --version &> /dev/null' % jarpath,
                         verifycode=0,
                         require_executability=False
                     )
@@ -49,7 +51,7 @@ class GATKTool(tools.Tool):
             '-T', command
         ] + list(map(str, gatkOptions))
         _log.debug(' '.join(tool_cmd))
-        subprocess.check_call(tool_cmd)
+        util.misc.run_and_print(tool_cmd)
 
     @staticmethod
     def dict_to_gatk_opts(options):

--- a/tools/gatk.py
+++ b/tools/gatk.py
@@ -64,7 +64,7 @@ class GATKTool(tools.Tool):
 
     def _get_tool_version(self):
         cmd = ['java', '-jar', self.install_and_get_path(), '--version']
-        self.tool_version = util.misc.run_and_print(cmd).stdout.strip()
+        self.tool_version = util.misc.run_and_print(cmd, buffered=True).stdout.strip()
 
     def ug(self, inBam, refFasta, outVcf, options=None, JVMmemory=None, threads=1):
         options = options or ["--min_base_quality_score", 15, "-ploidy", 4]

--- a/tools/last.py
+++ b/tools/last.py
@@ -36,7 +36,7 @@ class LastTools(tools.Tool):
 
 class DownloadAndBuildLast(tools.DownloadPackage):
     """ class for platform-specific last download and install """
-    last_with_version = 'last-490'
+    last_with_version = 'last-719'
 
     def __init__(self, subtool_name):
         url = 'http://last.cbrc.jp/{}.zip'.format(self.last_with_version)

--- a/tools/mafft.py
+++ b/tools/mafft.py
@@ -9,6 +9,8 @@ from Bio import SeqIO
 import logging
 import tools
 import util.file
+import util.misc 
+
 import os
 import os.path
 import subprocess
@@ -173,7 +175,7 @@ class MafftTool(tools.Tool):
 
         # run the MAFFT alignment
         with open(outFile, 'w') as outf:
-            subprocess.check_call(tool_cmd, stdout=outf)
+            util.misc.run_and_save(tool_cmd, outf=outf)
 
         if len(tempCombinedInputFile):
             # remove temp FASTA file

--- a/tools/mummer.py
+++ b/tools/mummer.py
@@ -48,7 +48,7 @@ class MummerTool(tools.Tool):
         toolCmd = [os.path.join(self.install_and_get_path(), 'mummer'),
             refFasta] + qryFastas
         log.debug(' '.join(toolCmd))
-        subprocess.check_call(toolCmd)
+        util.misc.run_and_print(toolCmd)
 
     def nucmer(self, refFasta, qryFasta, outDelta, extend=None, breaklen=None):
         if not outDelta.endswith('.delta'):
@@ -65,7 +65,7 @@ class MummerTool(tools.Tool):
             toolCmd.extend(['--breaklen', str(breaklen)])
         toolCmd.extend([refFasta, qryFasta])
         log.debug(' '.join(toolCmd))
-        subprocess.check_call(toolCmd)
+        util.misc.run_and_print(toolCmd)
 
     def promer(self, refFasta, qryFasta, outDelta, extend=None, breaklen=None):
         if not outDelta.endswith('.delta'):
@@ -82,7 +82,7 @@ class MummerTool(tools.Tool):
             toolCmd.extend(['--breaklen', str(breaklen)])
         toolCmd.extend([refFasta, qryFasta])
         log.debug(' '.join(toolCmd))
-        subprocess.check_call(toolCmd)
+        util.misc.run_and_print(toolCmd)
     
     def delta_filter(self, inDelta, outDelta):
         toolCmd = [os.path.join(self.install_and_get_path(), 'delta-filter'),

--- a/tools/muscle.py
+++ b/tools/muscle.py
@@ -3,12 +3,15 @@
     http://www.drive5.com/muscle
 '''
 
-import logging
+
 import tools
 import util.file
+import util.misc
+
 import os
 import os.path
 import subprocess
+import logging
 
 TOOL_NAME = "muscle"
 TOOL_VERSION = '3.8.1551'
@@ -65,7 +68,7 @@ class MuscleTool(tools.Tool):
             tool_cmd.extend(('-log', logFile))
 
         _log.debug(' '.join(tool_cmd))
-        subprocess.check_call(tool_cmd)
+        util.misc.run_and_print(tool_cmd)
     # pylint: enable=W0221
 
 

--- a/tools/mvicuna.py
+++ b/tools/mvicuna.py
@@ -4,8 +4,10 @@ import logging
 import os
 import subprocess
 import shutil
+
 import tools
 import util.file
+import util.misc
 
 # BroadUnixPath = '/gsap/garage-viral/viral/analysis/xyang/programs'\
 #                 '/M-Vicuna/bin/mvicuna'
@@ -58,7 +60,7 @@ class MvicunaTool(tools.Tool):
             outUnpaired, '-drm_op', ','.join(tmp1OutPair), '-tasks', 'DupRm'
         ]
         _log.debug(' '.join(cmdline))
-        subprocess.check_call(cmdline)
+        util.misc.run_and_print(cmdline)
         for tmpfname, outfname in zip(tmp2OutPair, outPair):
             shutil.copyfile(tmpfname, outfname)
 

--- a/tools/picard.py
+++ b/tools/picard.py
@@ -5,12 +5,12 @@
 import logging
 import os
 import os.path
-import subprocess
 import tempfile
 import shutil
 import pysam
 import tools
 import util.file
+import util.misc
 
 TOOL_NAME = "picard"
 TOOL_VERSION = '1.126'
@@ -57,7 +57,7 @@ class PicardTools(tools.Tool):
                 self.install_and_get_path(), '-Xmx' + JVMmemory, '-Djava.io.tmpdir=' + tempfile.tempdir, command
             ] + picardOptions
         _log.debug(' '.join(tool_cmd))
-        subprocess.check_call(tool_cmd)
+        util.misc.run_and_print(tool_cmd)
 
     @staticmethod
     def dict_to_picard_opts(options):

--- a/tools/samtools.py
+++ b/tools/samtools.py
@@ -15,6 +15,7 @@
 import logging
 import tools
 import util.file
+import util.misc
 import os
 import os.path
 import subprocess
@@ -22,10 +23,9 @@ from collections import OrderedDict
 #import pysam
 
 TOOL_NAME = 'samtools'
-TOOL_VERSION = '0.1.19'
+TOOL_VERSION = '1.2'
+TOOL_URL = 'https://github.com/samtools/samtools/releases/download/{ver}/samtools-{ver}.tar.bz2'.format(ver=TOOL_VERSION)
 CONDA_TOOL_VERSION = '1.2'
-TOOL_URL = 'http://sourceforge.net/projects/samtools/files/samtools/' \
-    + '{ver}/samtools-{ver}.tar.bz2'.format(ver=TOOL_VERSION)
 
 log = logging.getLogger(__name__)
 

--- a/tools/snpeff.py
+++ b/tools/snpeff.py
@@ -59,7 +59,7 @@ class SnpEff(tools.Tool):
             ] + args
 
         _log.debug(' '.join(tool_cmd))
-        return util.misc.run_and_print(tool_cmd, stdin=stdin, buffered=True)
+        return util.misc.run_and_print(tool_cmd, stdin=stdin, buffered=True, silent=True)
 
     def has_genome(self, genome):
         if not self.known_dbs:

--- a/tools/snpeff.py
+++ b/tools/snpeff.py
@@ -59,7 +59,7 @@ class SnpEff(tools.Tool):
             ] + args
 
         _log.debug(' '.join(tool_cmd))
-        return util.misc.run(tool_cmd, stdin=stdin)
+        return util.misc.run_and_print(tool_cmd, stdin=stdin, buffered=True)
 
     def has_genome(self, genome):
         if not self.known_dbs:

--- a/tools/trimmomatic.py
+++ b/tools/trimmomatic.py
@@ -1,6 +1,7 @@
 "tools.Tool for trimmomatic."
 
 import tools
+import util.misc
 
 TOOL_NAME = "trimmomatic"
 TOOL_VERSION = "0.35"
@@ -23,3 +24,6 @@ class TrimmomaticTool(tools.Tool):
                 )
             )
         tools.Tool.__init__(self, install_methods=install_methods)
+
+    def execute(self, *args):
+        util.misc.run_and_print(self.exec_path, args)

--- a/tools/trinity.py
+++ b/tools/trinity.py
@@ -12,7 +12,9 @@ import os.path
 import subprocess
 import tempfile
 import shutil
+
 import tools
+import util.misc
 
 TOOL_NAME = "trinity"
 TOOL_VERSION = "2011-11-26"
@@ -54,7 +56,7 @@ class TrinityTool(tools.Tool):
             '--output', outdir
         ]
         log.debug(' '.join(cmd))
-        subprocess.check_call(cmd)
+        util.misc.run_and_print(cmd)
         shutil.copyfile(os.path.join(outdir, 'Trinity.fasta'), outFasta)
         shutil.rmtree(outdir, ignore_errors=True)
 

--- a/travis/install-conda.sh
+++ b/travis/install-conda.sh
@@ -2,7 +2,7 @@
 set -e
 
 # the miniconda directory may exist if it has been restored from cache
-if [ -d "$MINICONDA_DIR" ] && [ -x "$MINICONDA_DIR/bin/conda" ]; then
+if [ -d "$MINICONDA_DIR" ] && [ -e "$MINICONDA_DIR/bin/conda" ]; then
     echo "Miniconda install already present from cache: $MINICONDA_DIR"
 else # if it does not exist, we need to install miniconda
     rm -rf "$MINICONDA_DIR" # remove the directory in case we have an empty cached directory

--- a/travis/tests-long.sh
+++ b/travis/tests-long.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-echo travis_fold:start:tests-long
-
 echo "TRAVIS_BRANCH: $TRAVIS_BRANCH"
 echo "TRAVIS_PULL_REQUEST: $TRAVIS_PULL_REQUEST"
 
@@ -16,5 +14,3 @@ if [ $TRAVIS_PULL_REQUEST != "false" -o $TRAVIS_BRANCH = "master" -o -n "$TRAVIS
 else
     echo "This is not a pull request: skipping long running tests."
 fi
-
-echo travis_fold:end:tests-long

--- a/travis/tests-long.sh
+++ b/travis/tests-long.sh
@@ -6,7 +6,9 @@ echo "TRAVIS_PULL_REQUEST: $TRAVIS_PULL_REQUEST"
 
 if [ $TRAVIS_PULL_REQUEST != "false" -o $TRAVIS_BRANCH = "master" -o -n "$TRAVIS_TAG" ]; then
     echo "This is on master or is a pull request: executing long running tests..."
-    nosetests -v --with-xunit --with-coverage \
+    nosetests -v \
+        --logging-clear-handlers \
+        --with-xunit --with-coverage \
         --cover-inclusive --cover-branches --cover-tests \
         --cover-package broad_utils,illumina,assembly,interhost,intrahost,ncbi,read_utils,reports,taxon_filter,tools,util \
         -w test/integration/

--- a/travis/tests-long.sh
+++ b/travis/tests-long.sh
@@ -8,7 +8,7 @@ echo "TRAVIS_PULL_REQUEST: $TRAVIS_PULL_REQUEST"
 
 if [ $TRAVIS_PULL_REQUEST != "false" -o $TRAVIS_BRANCH = "master" -o -n "$TRAVIS_TAG" ]; then
     echo "This is on master or is a pull request: executing long running tests..."
-    nosetests -v --with-xunit --with-coverage --nocapture \
+    nosetests -v --with-xunit --with-coverage \
         --cover-inclusive --cover-branches --cover-tests \
         --cover-package broad_utils,illumina,assembly,interhost,intrahost,ncbi,read_utils,reports,taxon_filter,tools,util \
         -w test/integration/

--- a/travis/tests-long.sh
+++ b/travis/tests-long.sh
@@ -8,6 +8,7 @@ if [ $TRAVIS_PULL_REQUEST != "false" -o $TRAVIS_BRANCH = "master" -o -n "$TRAVIS
     echo "This is on master or is a pull request: executing long running tests..."
     nosetests -v \
         --logging-clear-handlers \
+        --with-timer \
         --with-xunit --with-coverage \
         --cover-inclusive --cover-branches --cover-tests \
         --cover-package broad_utils,illumina,assembly,interhost,intrahost,ncbi,read_utils,reports,taxon_filter,tools,util \

--- a/travis/tests-unit.sh
+++ b/travis/tests-unit.sh
@@ -3,7 +3,7 @@ set -e
 
 echo travis_fold:start:tests-unit
 
-nosetests -v --with-xunit --with-coverage --nocapture \
+nosetests -v --with-xunit --with-coverage \
     --cover-inclusive --cover-branches --cover-tests \
     --cover-package broad_utils,illumina,assembly,interhost,intrahost,ncbi,read_utils,reports,taxon_filter,tools,util \
     -w test/unit/

--- a/travis/tests-unit.sh
+++ b/travis/tests-unit.sh
@@ -3,6 +3,7 @@
 
 nosetests -v \
     --logging-clear-handlers \
+    --with-timer \
     --with-xunit --with-coverage \
     --cover-inclusive --cover-branches --cover-tests \
     --cover-package broad_utils,illumina,assembly,interhost,intrahost,ncbi,read_utils,reports,taxon_filter,tools,util \

--- a/travis/tests-unit.sh
+++ b/travis/tests-unit.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-set -e
+#set -e
 
-nosetests -v --with-xunit --with-coverage \
+nosetests -v \
+    --logging-clear-handlers \
+    --with-xunit --with-coverage \
     --cover-inclusive --cover-branches --cover-tests \
     --cover-package broad_utils,illumina,assembly,interhost,intrahost,ncbi,read_utils,reports,taxon_filter,tools,util \
     -w test/unit/

--- a/travis/tests-unit.sh
+++ b/travis/tests-unit.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 set -e
 
-echo travis_fold:start:tests-unit
-
 nosetests -v --with-xunit --with-coverage \
     --cover-inclusive --cover-branches --cover-tests \
     --cover-package broad_utils,illumina,assembly,interhost,intrahost,ncbi,read_utils,reports,taxon_filter,tools,util \
     -w test/unit/
-
-echo travis_fold:end:tests-unit

--- a/util/misc.py
+++ b/util/misc.py
@@ -3,6 +3,7 @@ from __future__ import division  # Division of integers with / should never roun
 import collections
 import itertools
 import subprocess
+import sys
 
 __author__ = "dpark@broadinstitute.org"
 
@@ -139,6 +140,29 @@ def run_and_print(args, stdin=None, shell=False, env=None, cwd=None,
     if not silent:
         print(result.stdout.decode('utf-8'))
     return result
+
+def run_and_save(args, stdin=None, outf=None, stderr=None, preexec_fn=None, close_fds=False, shell=False, cwd=None, env=None):
+    assert outf is not None
+
+    sp = subprocess.Popen(args,
+                          stdin=stdin,
+                          stdout=outf,
+                          stderr=subprocess.PIPE,
+                          preexec_fn=preexec_fn, 
+                          close_fds=close_fds,
+                          shell=shell,
+                          cwd=cwd,
+                          env=env)
+    out, err = sp.communicate()
+
+    # redirect stderror to stdout so it can be captured by nose
+    if err:
+        sys.stdout.write(err.decode("UTF-8"))
+
+    if sp.returncode != 0:
+           raise subprocess.CalledProcessError(sp.returncode, " ".join(args[0]))
+
+    return sp
 
 class FeatureSorter(object):
     ''' This class helps sort genomic features. It's not terribly optimized

--- a/util/misc.py
+++ b/util/misc.py
@@ -154,8 +154,10 @@ def run_and_print(args, stdin=None, shell=False, env=None, cwd=None,
                 for c in iter(process.stdout.read, b""):
                     print(c.decode('utf-8'), end="") # print for py3 / p2 from __future__ 
 
-        for c in iter(lambda: process.stdout.read(1), b""):
-            print(c, end="")
+        # in case there are still chars in the pipe buffer
+        if not silent:
+            for c in iter(lambda: process.stdout.read(1), b""):
+                print(c, end="")
 
         result = CompletedProcess(args, process.returncode, "", '')
 

--- a/util/misc.py
+++ b/util/misc.py
@@ -151,8 +151,11 @@ def run_and_print(args, stdin=None, shell=False, env=None, cwd=None,
 
         while process.poll() is None:
             if not silent:
-                for c in iter(lambda: process.stdout.read(1), ''):
-                    print(c, end="") # print for py3 / p2 from __future__ 
+                for c in iter(process.stdout.read, b""):
+                    print(c.decode('utf-8'), end="") # print for py3 / p2 from __future__ 
+
+        for c in iter(lambda: process.stdout.read(1), b""):
+            print(c, end="")
 
         result = CompletedProcess(args, process.returncode, "", '')
 


### PR DESCRIPTION
Replace subprocess calls with custom calls that capture subprocess output and pipe to stdout (or files where appropriate), so nose can capture all output and only show stdout for failures. In order for nose to capture log messages, it is necessary to clear existing logging handlers via “—logging-clear-handlers” in the nosetests call. This should clean up the Travis logs