### PR TITLE
reduce concurrent job limit on Broad_UGER

### DIFF
--- a/pipes/Broad_UGER/run-pipe.sh
+++ b/pipes/Broad_UGER/run-pipe.sh
@@ -19,7 +19,7 @@ source "$VENVDIR/bin/activate"
 
 # invoke Snakemake in cluster mode with custom wrapper scripts
 snakemake --timestamp --rerun-incomplete --keep-going --nolock \
-    --jobs 100 --immediate-submit \
+    --jobs 90 --immediate-submit \
         --latency-wait 60 \
     --config mode=UGER \
     --directory . \


### PR DESCRIPTION
Broad limits to 100 jobs on UGER, but setting --jobs to 100 means you cannot qsub the run-pipe.sh script itself without exceeding the limit. Reduce --jobs to 90.