### PR TITLE
Upgrade util.misc.run more like py3.5 run.

### DIFF
--- a/test/unit/test_tools_kraken.py
+++ b/test/unit/test_tools_kraken.py
@@ -51,15 +51,15 @@ class TestToolKraken(TestCaseWithTmp):
         inputs = [os.path.join(self.data_dir, f)
                   for f in ['zaire_ebola.1.fastq', 'zaire_ebola.2.fastq']]
         output = os.path.join(tempfile.tempdir, 'zaire_ebola.kraken')
-        self.assertEqual(0, self.kraken.classify(db, args=inputs, options={
-            '--output': output
-        }).returncode)
+        output_filtered = os.path.join(tempfile.tempdir, 'zaire_ebola.filtered-kraken')
+        output_report = os.path.join(tempfile.tempdir, 'zaire_ebola.kraken-report')
+        self.assertEqual(0, self.kraken.classify(db, inputs, output).returncode)
         result = self.kraken.execute(
-            'kraken-filter', db, args=[output],
+            'kraken-filter', db, output_filtered, [output],
             options={'--threshold': 0.05})
         self.assertEqual(0, result.returncode)
         result = self.kraken.execute(
-            'kraken-report', db, args=[output])
+            'kraken-report', db, output_report, [output_filtered])
         self.assertEqual(0, result.returncode)
 
 

--- a/tools/diamond.py
+++ b/tools/diamond.py
@@ -8,6 +8,7 @@ import os
 import os.path
 import shlex
 import shutil
+import subprocess
 import tools
 import util.file
 import util.misc
@@ -95,7 +96,7 @@ class Diamond(tools.Tool):
         if option_string:
             cmd.extend(shlex.split(option_string))
         log.debug("Calling {}: {}".format(command, " ".join(cmd)))
-        return util.misc.run(cmd)
+        return util.misc.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
 
 class DownloadAndBuildDiamond(tools.DownloadPackage):

--- a/tools/kraken.py
+++ b/tools/kraken.py
@@ -1,13 +1,15 @@
 '''
 KRAKEN metagenomics classifier
 '''
+from __future__ import print_function
 import itertools
 import logging
 import os
 import os.path
 import shlex
 import shutil
-import stat
+import subprocess
+import sys
 import tools
 import util.file
 import util.misc
@@ -103,6 +105,8 @@ class Kraken(tools.Tool):
 
     @property
     def libexec(self):
+        if not self.executable_path():
+            self.install_and_get_path()
         return os.path.dirname(self.executable_path())
 
     def build(self, db, options=None, option_string=None):
@@ -113,43 +117,61 @@ class Kraken(tools.Tool):
             taxonomy/ subdirectories to build from.
           *args: List of input filenames to process.
         '''
-        return self.execute('kraken-build', db, options=options, option_string=option_string)
+        return self.execute('kraken-build', db, db, options=options,
+                            option_string=option_string)
 
-    def classify(self, db, args=None, options=None, option_string=None):
+    def classify(self, db, args, output, options=None, option_string=None):
         """Classify input fasta/fastq
 
         Args:
           db: Kraken built database directory.
           args: List of input filenames to process.
+          output: Output file of command.
         """
         assert len(args), 'Kraken requires input filenames.'
-        return self.execute('kraken', db, args=args, options=options, option_string=option_string)
+        return self.execute('kraken', db, output, args=args, options=options,
+                            option_string=option_string)
 
-    def execute(self, command, db, args=None, options=None, option_string=None):
+    def execute(self, command, db, output, args=None, options=None,
+                option_string=None):
         '''Run a kraken-* command.
 
         Args:
           db: Kraken database directory.
+          output: Output file of command.
           args: List of positional args.
           options: List of keyword options.
           option_string: Raw strip command line options.
         '''
         assert command in Kraken.BINS, 'Kraken command is unknown'
         options = options or {}
+
+        if command == 'kraken':
+            options['--output'] = output
         option_string = option_string or ''
         args = args or []
 
         jellyfish_path = Jellyfish().install_and_get_path()
         env = os.environ.copy()
-        env['PATH'] = '{}:{}'.format(os.path.dirname(jellyfish_path), env['PATH'])
+        env['PATH'] = '{}:{}'.format(os.path.dirname(jellyfish_path),
+                                     env['PATH'])
         cmd = [os.path.join(self.libexec, command), '--db', db]
         # We need some way to allow empty options args like --build, hence
         # we filter out on 'x is None'.
-        cmd.extend([str(x) for x in itertools.chain(*options.items()) if x is not None])
+        cmd.extend([str(x) for x in itertools.chain(*options.items())
+                    if x is not None])
         cmd.extend(shlex.split(option_string))
         cmd.extend(args)
         log.debug('Calling %s: %s', command, ' '.join(cmd))
-        return util.misc.run_and_print(cmd, env=env)
+
+        if command in ('kraken', 'kraken-build'):
+            return util.misc.run_and_print(cmd, env=env, check=True)
+        else:
+            with open(output, 'w') as of:
+                res = util.misc.run(cmd,  stdout=of, stderr=subprocess.PIPE,
+                                    env=env, check=True, timeout=10)
+            print(res.stderr.decode('utf-8'), file=sys.stderr)
+            return res
 
 
 class DownloadAndInstallKraken(tools.DownloadPackage):
@@ -168,4 +190,6 @@ class DownloadAndInstallKraken(tools.DownloadPackage):
         util.file.mkdir_p(bin_dir)
         for bin_name in Kraken.BINS:
             libexec_bin = os.path.join(libexec_dir, bin_name)
-            os.symlink(libexec_bin, os.path.join(bin_dir, bin_name))
+            bin = os.path.join(bin_dir, bin_name)
+            if not os.path.islink(bin):
+                os.symlink(libexec_bin, bin)

--- a/tools/trinity.py
+++ b/tools/trinity.py
@@ -89,7 +89,7 @@ class DownloadAndBuildTrinity(tools.DownloadPackage):
             shutil.copymode(badFilePath + '.orig', badFilePath)
 
         # Now we can make:
-        os.system('cd "{}" && make -s'.format(trinity_dir))
+        util.misc.run_and_print(['make', '-s'], cwd=trinity_dir)
         shutil.rmtree(os.path.join(trinity_dir, 'sample_data'), ignore_errors=True)
 
     def verify_install(self):

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,7 @@ platform = linux|darwin
 minversion = 2.0
 
 [testenv]
-deps=nose
-  -rrequirements.txt
+deps=-rrequirements.txt
   -rrequirements-pipes.txt
 passenv=GATK_PATH
   NOVOALIGN_PATH
@@ -16,8 +15,7 @@ commands=
   nosetests
 
 [testenv:py27]
-deps=nose
-  -rrequirements.txt
+deps=-rrequirements.txt
 
 [testenv:docs]
 changedir = docs


### PR DESCRIPTION
Change the run function to be more feature complete like py3.5's run
function. Relies on temporary files for stdout/stderr since
subprocess.PIPE is not allowed when we're trying to capture them.
Otherwise, use check_output like before which is more efficient if we
are redirecting stderr to stdout or not capturing.

Therefore allow kraken to separate stdout as datastream writing to file
and stderr in log messages.