### PR TITLE
Separate trinity conda env from default conda env.

### DIFF
--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -181,8 +181,10 @@ class CondaPackage(InstallMethod):
         verifycmd=None,
         verifycode=0,
         require_executability=True,
-        env_path=None,
+        env=None,
+        env_root_path=None,
         conda_cache_path=None
+
     ):
         # if the executable name is specifed, use it; otherwise use the package name
         self.executable = executable or package
@@ -194,8 +196,10 @@ class CondaPackage(InstallMethod):
         self.verifycode = verifycode
         self.require_executability = require_executability
 
-        env_path = env_path or os.path.join(util.file.get_build_path(), 'conda-tools')
-        self.env_path = os.path.realpath(os.path.expanduser(env_path))
+        env_root_path = env_root_path or os.path.join(util.file.get_build_path(), 'conda-tools')
+        env = env or 'default'
+        self.env_path = os.path.realpath(os.path.expanduser(
+            os.path.join(env_root_path, env)))
 
         conda_cache_path = conda_cache_path or os.path.join(util.file.get_build_path(), 'conda-cache')
         self.conda_cache_path = os.path.realpath(os.path.expanduser(conda_cache_path))

--- a/tools/trinity.py
+++ b/tools/trinity.py
@@ -31,7 +31,7 @@ class TrinityTool(tools.Tool):
     def __init__(self, install_methods=None):
         if install_methods is None:
             install_methods = []
-            install_methods.append(tools.CondaPackage(TOOL_NAME, executable="Trinity", version=CONDA_TOOL_VERSION))
+            install_methods.append(tools.CondaPackage(TOOL_NAME, executable="Trinity", version=CONDA_TOOL_VERSION, env='trinity'))
             install_methods.append(DownloadAndBuildTrinity(url, TRINITY_VERSION + '/Trinity.pl'))
         tools.Tool.__init__(self, install_methods=install_methods)
 


### PR DESCRIPTION
Change the CondaPackage param from env_path to env to make separate
environments easier. Trinity is going to be installed in a non-default
env because it relies on perl-threaded, which conflicts with the default
perl package that krona uses (to be safe).