### PR TITLE
more logging of stats during scaffolding

### DIFF
--- a/assembly.py
+++ b/assembly.py
@@ -320,6 +320,11 @@ def impute_from_reference(inFasta, inReference, outFasta, minLengthFraction, min
                 minLength = len(refSeqObj) * minLengthFraction
                 non_n_count = unambig_count(asmSeqObj.seq)
                 seq_len = len(asmSeqObj)
+                log.info("Assembly Quality - segment {idx} - name {segname} - contig len {len_actual} / {len_desired} ({min_frac}) - unambiguous bases {unamb_actual} / {unamb_desired} ({min_unamb})".format(
+                    idx=idx+1, segname=refSeqObj.id,
+                    len_actual=seq_len, len_desired=len(refseqObj), min_frac=minLengthFraction,
+                    unamb_actual=non_n_count, unamb_desired=seq_len*minUnambig, min_unamb=minUnambig
+                ))
                 if seq_len < minLength or non_n_count < seq_len * minUnambig:
                     raise PoorAssemblyError(idx + 1, seq_len, non_n_count)
 

--- a/assembly.py
+++ b/assembly.py
@@ -402,11 +402,11 @@ def parser_impute_from_reference(parser=argparse.ArgumentParser()):
     parser.add_argument("--newName", default=None, help="rename output chromosome (default: do not rename)")
     parser.add_argument("--minLengthFraction",
                         type=float,
-                        default=0.9,
+                        default=0.5,
                         help="minimum length for contig, as fraction of reference (default: %(default)s)")
     parser.add_argument("--minUnambig",
                         type=float,
-                        default=0.8,
+                        default=0.5,
                         help="minimum percentage unambiguous bases for contig (default: %(default)s)")
     parser.add_argument("--replaceLength",
                         type=int,

--- a/assembly.py
+++ b/assembly.py
@@ -322,7 +322,7 @@ def impute_from_reference(inFasta, inReference, outFasta, minLengthFraction, min
                 seq_len = len(asmSeqObj)
                 log.info("Assembly Quality - segment {idx} - name {segname} - contig len {len_actual} / {len_desired} ({min_frac}) - unambiguous bases {unamb_actual} / {unamb_desired} ({min_unamb})".format(
                     idx=idx+1, segname=refSeqObj.id,
-                    len_actual=seq_len, len_desired=len(refseqObj), min_frac=minLengthFraction,
+                    len_actual=seq_len, len_desired=len(refSeqObj), min_frac=minLengthFraction,
                     unamb_actual=non_n_count, unamb_desired=seq_len*minUnambig, min_unamb=minUnambig
                 ))
                 if seq_len < minLength or non_n_count < seq_len * minUnambig:

--- a/assembly.py
+++ b/assembly.py
@@ -323,7 +323,7 @@ def impute_from_reference(inFasta, inReference, outFasta, minLengthFraction, min
                 log.info("Assembly Quality - segment {idx} - name {segname} - contig len {len_actual} / {len_desired} ({min_frac}) - unambiguous bases {unamb_actual} / {unamb_desired} ({min_unamb})".format(
                     idx=idx+1, segname=refSeqObj.id,
                     len_actual=seq_len, len_desired=len(refSeqObj), min_frac=minLengthFraction,
-                    unamb_actual=non_n_count, unamb_desired=seq_len*minUnambig, min_unamb=minUnambig
+                    unamb_actual=non_n_count, unamb_desired=seq_len, min_unamb=minUnambig
                 ))
                 if seq_len < minLength or non_n_count < seq_len * minUnambig:
                     raise PoorAssemblyError(idx + 1, seq_len, non_n_count)

--- a/pipes/config.yaml
+++ b/pipes/config.yaml
@@ -92,11 +92,11 @@ accessions_file_for_lastal_db_build: ""
 # to be considered acceptible quality, specified as
 # a fraction of the length of the reference sequene.
 # This is specific to a particular segment/chromosome.
-assembly_min_length_fraction_of_reference: 0.90
+assembly_min_length_fraction_of_reference: 0.50
 
 # The minimum fraction of unambiguous (non-N) bases an assembled
-# sequence must have to be considered acceptible quality.
-assembly_min_unambig: 0.80
+# sequence must have to be considered acceptable quality.
+assembly_min_unambig: 0.50
 
 # Alignment parameters for nucmer (MUMmer) during the scaffolding step.
 # Shown below are defaults.

--- a/tools/mummer.py
+++ b/tools/mummer.py
@@ -245,6 +245,11 @@ class MummerTool(tools.Tool):
                 else:
                     s = '+'
                 fs.add(c, start, stop, strand=s, other=alt_seq)
+                log.info("mummer alignment %s:%d-%d - %s:%d-%d (%s)" % (
+                    c, start, stop,
+                    alt_seq[0], alt_seq[1], alt_seq[2],
+                    s
+                ))
         os.unlink(tiling)
 
         # load all contig-to-ref alignments into AlignsReaders


### PR DESCRIPTION
Add more useful info on scaffolding stats in order to aid post-mortem (or post-success) analysis of tricky assemblies. Emit the stats from PoorAssemblyError even when it doesn't error. Emit all the nucmer alignments used for contigs against reference. Based on BN10dx user testing (KS, AP).

Also, relax the default cutoffs used for assembly quality at this stage.