### PR TITLE
change trinity version string to reflect string on bioconda

### DIFF
--- a/tools/trinity.py
+++ b/tools/trinity.py
@@ -18,7 +18,7 @@ import util.misc
 
 TOOL_NAME = "trinity"
 TOOL_VERSION = "2011-11-26"
-CONDA_TOOL_VERSION = "2011_11_26" # conda versions cannot have hyphens...
+CONDA_TOOL_VERSION = "date.2011_11_26" # conda versions cannot have hyphens...
 TRINITY_VERSION = "trinityrnaseq_r{}".format(TOOL_VERSION)
 url = "http://sourceforge.net/projects/trinityrnaseq/files/{}.tgz".format(TRINITY_VERSION)
 


### PR DESCRIPTION
change trinity version string to reflect version string used on
bioconda. Note that this does not change the version of Trinity used
(2011_11_26), it merely responds to a [change](https://github.com/bioconda/bioconda-recipes/pull/1315/files) in the upstream conda
version string which is now prefixed with “date.” to ensure correct
sorting relative to newer versions