### PR TITLE
add missing 'threads' kwargs to deplete_bmtagger_bam

### DIFF
--- a/taxon_filter.py
+++ b/taxon_filter.py
@@ -398,7 +398,7 @@ __commands__.append(('filter_lastal', parser_filter_lastal))
 # ============================
 
 
-def deplete_bmtagger_bam(inBam, db, outBam, JVMmemory=None):
+def deplete_bmtagger_bam(inBam, db, outBam, threads=None, JVMmemory=None):
     """
     Use bmtagger to partition the input reads into ones that match at least one
         of the databases and ones that don't match any of the databases.


### PR DESCRIPTION
‘threads’ was added as a kwarg for deplete_blastn_bam, however it is invoked by multi_db_deplete_bam, which also calls deplete_bmtagger_bam, so the signature for this second depletion function must also include ‘threads’ 