### PR TITLE
add check=True to run_and_print() calls

### DIFF
--- a/assembly.py
+++ b/assembly.py
@@ -93,7 +93,7 @@ def trim_rmdup_subsamp_reads(inBam, clipDb, outBam, n_reads=100000):
            '-out',
            subsampfq[0],
            subsampfq[1],]
-    util.misc.run_and_print(cmd)
+    util.misc.run_and_print(cmd, check=True)
     os.unlink(purgefq[0])
     os.unlink(purgefq[1])
 

--- a/read_utils.py
+++ b/read_utils.py
@@ -44,7 +44,7 @@ def purge_unmated(inFastq1, inFastq2, outFastq1, outFastq2, regex=r'^@(\S+)/[1|2
     mergeShuffledFastqSeqsPath = os.path.join(util.file.get_scripts_path(), 'mergeShuffledFastqSeqs.pl')
     cmdline = [mergeShuffledFastqSeqsPath, '-t', '-r', regex, '-f1', inFastq1, '-f2', inFastq2, '-o', tempOutput]
     log.debug(' '.join(cmdline))
-    util.misc.run_and_print(cmdline)
+    util.misc.run_and_print(cmdline, check=True)
     shutil.move(tempOutput + '.1.fastq', outFastq1)
     shutil.move(tempOutput + '.2.fastq', outFastq2)
     return 0
@@ -823,7 +823,7 @@ def rmdup_prinseq_fastq(inFastq, outFastq):
             inFastq, '-out_bad', 'null', '-line_width', '0', '-out_good', outFastq[:-6]
         ]
         log.debug(' '.join(cmd))
-        util.misc.run_and_print(cmd)
+        util.misc.run_and_print(cmd, check=True)
 
 
 def parser_rmdup_prinseq_fastq(parser=argparse.ArgumentParser()):

--- a/taxon_filter.py
+++ b/taxon_filter.py
@@ -137,7 +137,7 @@ def trimmomatic(inFastq1, inFastq2, pairedOutFastq1, pairedOutFastq2, clipFasta)
     )
 
     log.debug(' '.join(javaCmd))
-    util.misc.run_and_print(javaCmd)
+    util.misc.run_and_print(javaCmd, check=True)
     os.unlink(tmpUnpaired1)
     os.unlink(tmpUnpaired2)
 
@@ -377,7 +377,7 @@ def filter_lastal(
             '-line_width', '0', '-out_good', outFastq[:-6]
         ]
         log.debug(' '.join(prinseqCmd))
-        util.misc.run_and_print(prinseqCmd)
+        util.misc.run_and_print(prinseqCmd, check=True)
     os.unlink(filteredFastq)
 
 
@@ -506,7 +506,7 @@ def partition_bmtagger(inFastq1, inFastq2, databases, outMatch=None, outNoMatch=
             curReads2, '-o', matchesFile
         ]
         log.debug(' '.join(cmdline))
-        util.misc.run_and_print(cmdline)
+        util.misc.run_and_print(cmdline, check=True)
         prevReads1, prevReads2 = curReads1, curReads2
         if count < len(databases) - 1:
             curReads1, curReads2 = mkstempfname(), mkstempfname()

--- a/test/unit/test_assembly.py
+++ b/test/unit/test_assembly.py
@@ -236,7 +236,7 @@ class TestRefineAssembly(TestCaseWithTmp):
         imputeFasta = util.file.mkstempfname('.imputed.fasta')
         refine1Fasta = util.file.mkstempfname('.refine1.fasta')
         shutil.copy(inFasta, imputeFasta)
-        tools.picard.CreateSequenceDictionaryTool().execute(imputeFasta)
+        tools.picard.CreateSequenceDictionaryTool().execute(imputeFasta, overwrite=True)
         tools.novoalign.NovoalignTool().index_fasta(imputeFasta)
         assembly.refine_assembly(
             imputeFasta,
@@ -256,7 +256,7 @@ class TestRefineAssembly(TestCaseWithTmp):
         refine1Fasta = util.file.mkstempfname('.refine1.fasta')
         refine2Fasta = util.file.mkstempfname('.refine2.fasta')
         shutil.copy(inFasta, refine1Fasta)
-        tools.picard.CreateSequenceDictionaryTool().execute(refine1Fasta)
+        tools.picard.CreateSequenceDictionaryTool().execute(refine1Fasta, overwrite=True)
         tools.novoalign.NovoalignTool().index_fasta(refine1Fasta)
         assembly.refine_assembly(
             refine1Fasta,

--- a/test/unit/test_taxon_filter.py
+++ b/test/unit/test_taxon_filter.py
@@ -146,7 +146,7 @@ class TestDepleteBlastn(TestCaseWithTmp):
             refDb = os.path.join(tempDir, dbname)
             os.symlink(os.path.join(myInputDir, dbname), refDb)
             refDbs.append(refDb)
-            util.misc.run_and_print([makeblastdbPath, '-dbtype', 'nucl', '-in', refDb])
+            util.misc.run_and_print([makeblastdbPath, '-dbtype', 'nucl', '-in', refDb], check=True)
 
         # Run deplete_blastn
         outFile = os.path.join(tempDir, 'out.fastq')
@@ -172,7 +172,7 @@ class TestDepleteBlastnBam(TestCaseWithTmp):
             refDb = os.path.join(tempDir, dbname)
             os.symlink(os.path.join(myInputDir, dbname), refDb)
             refDbs.append(refDb)
-            util.misc.run_and_print([makeblastdbPath, '-dbtype', 'nucl', '-in', refDb])
+            util.misc.run_and_print([makeblastdbPath, '-dbtype', 'nucl', '-in', refDb], check=True)
 
         # convert the input fastq's to a bam
         inFastq1 = os.path.join(myInputDir, "in1.fastq")

--- a/test/unit/test_tools_picard.py
+++ b/test/unit/test_tools_picard.py
@@ -26,7 +26,7 @@ class TestToolPicard(TestCaseWithTmp):
             shutil.copyfile(orig_ref, inRef)
             outDict = inRef[:-len(ext)] + '.dict'
 
-            picard_index.execute(inRef)
+            picard_index.execute(inRef, overwrite=True)
 
             # the dict files will not be exactly the same, just the first 3 cols
             with open(outDict, 'rt') as inf:

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -248,7 +248,7 @@ class CondaPackage(InstallMethod):
 
     @property
     def _package_installed(self):
-        result = util.misc.run_and_print(["conda", "list", "-f", "-c", "-p", self.env_path, "--json", self.package], silent=True, env=self.conda_env)
+        result = util.misc.run_and_print(["conda", "list", "-f", "-c", "-p", self.env_path, "--json", self.package], silent=True, check=True, env=self.conda_env)
         if result.returncode == 0:
             command_output = result.stdout.decode("UTF-8")
             data = json.loads(self._string_from_start_of_json(command_output))
@@ -278,7 +278,7 @@ class CondaPackage(InstallMethod):
     def _attempt_install(self):
         try:
             # check for presence of conda command
-            util.misc.run_and_print(["conda", "-V"], silent=True, env=self.conda_env)
+            util.misc.run_and_print(["conda", "-V"], silent=True, check=True, env=self.conda_env)
         except:
             _log.debug("conda NOT installed; using custom tool install")
             self._is_attempted = True
@@ -289,10 +289,10 @@ class CondaPackage(InstallMethod):
         # conda-build is not needed for pre-built binaries from conda channels
         # though we may will need it in the future for custom local builds
         # try:
-        #     util.misc.run_and_print(["conda", "build", "-V"], silent=True, env=self.conda_env)
+        #     util.misc.run_and_print(["conda", "build", "-V"], silent=True, check=True, env=self.conda_env)
         # except:
         #     _log.warning("conda-build must be installed; installing...")
-        #     util.misc.run_and_print(["conda", "install", "-y", "conda-build"])
+        #     util.misc.run_and_print(["conda", "install", "-y", "conda-build"], check=True)
 
         # if the package is already installed, we need to check if the version is correct
         if self.verify_install():
@@ -320,7 +320,7 @@ class CondaPackage(InstallMethod):
         run_cmd = ["conda", "list", "-c", "--json", "-f", "-p", self.env_path, self.package]
 
 
-        result = util.misc.run_and_print(run_cmd, silent=True, env=self.conda_env)
+        result = util.misc.run_and_print(run_cmd, silent=True, check=True, env=self.conda_env)
         if result.returncode == 0:
             try:
                 command_output = result.stdout.decode("UTF-8")
@@ -347,6 +347,7 @@ class CondaPackage(InstallMethod):
         result = util.misc.run_and_print(
             run_cmd,
             silent=True,
+            check=True,
             env=self.conda_env)
 
         if result.returncode == 0:
@@ -374,7 +375,7 @@ class CondaPackage(InstallMethod):
             python_version = "python=" + python_version if python_version else ""
             run_cmd.extend([python_version])
 
-        result = util.misc.run_and_print(run_cmd, silent=True, env=self.conda_env)
+        result = util.misc.run_and_print(run_cmd, silent=True, check=True, env=self.conda_env)
         try:
             command_output = result.stdout.decode("UTF-8")
             data = json.loads(self._string_from_start_of_json(command_output))
@@ -393,6 +394,7 @@ class CondaPackage(InstallMethod):
                     self._package_str
                 ],
                 silent=True,
+                check=True,
                 env=self.conda_env,
             )
 

--- a/tools/blast.py
+++ b/tools/blast.py
@@ -55,7 +55,7 @@ class BlastTools(tools.Tool):
         super(BlastTools, self).__init__(install_methods=install_methods)
 
     def execute(self, *args):
-        util.misc.run_and_print(self.exec_path, args)
+        util.misc.run_and_print(self.exec_path, args, check=True)
 
 
 class BlastnTool(BlastTools):

--- a/tools/bmtagger.py
+++ b/tools/bmtagger.py
@@ -35,7 +35,7 @@ class BmtaggerTools(tools.Tool):
         tools.Tool.__init__(self, install_methods=install_methods)
 
     def execute(self, *args):
-        util.misc.run_and_print(self.exec_path, args)
+        util.misc.run_and_print(self.exec_path, args, check=True)
 
 
 class BmtaggerShTool(BmtaggerTools):

--- a/tools/diamond.py
+++ b/tools/diamond.py
@@ -117,4 +117,4 @@ class DownloadAndBuildDiamond(tools.DownloadPackage):
             env['CC'] = 'gcc-4.9'
             env['CXX'] = 'g++-4.9'
         #util.misc.run_and_print(['cmake', '..'], env=env, cwd=build_dir)
-        util.misc.run_and_print(['make'], env=env, cwd=build_dir)
+        util.misc.run_and_print(['make'], env=env, cwd=build_dir, check=True)

--- a/tools/gatk.py
+++ b/tools/gatk.py
@@ -51,7 +51,7 @@ class GATKTool(tools.Tool):
             '-T', command
         ] + list(map(str, gatkOptions))
         _log.debug(' '.join(tool_cmd))
-        util.misc.run_and_print(tool_cmd)
+        util.misc.run_and_print(tool_cmd, check=True)
 
     @staticmethod
     def dict_to_gatk_opts(options):

--- a/tools/kraken.py
+++ b/tools/kraken.py
@@ -84,9 +84,9 @@ class DownloadAndInstallJellyfish(tools.DownloadPackage):
             os.path.join(jellyfish_dir, 'Makefile.am'), 'AM_CXXFLAGS = -g -O3',
             'AM_CXXFLAGS = -g -O3 -Wno-maybe-uninitialized'
         )
-        util.misc.run_and_print(['autoreconf', '-i'], cwd=jellyfish_dir, env=env)
-        util.misc.run_and_print(['./configure', '--prefix={}'.format(install_dir)], cwd=jellyfish_dir, env=env)
-        util.misc.run_and_print(['make', 'install'], cwd=jellyfish_dir, env=env)
+        util.misc.run_and_print(['autoreconf', '-i'], cwd=jellyfish_dir, env=env, check=True)
+        util.misc.run_and_print(['./configure', '--prefix={}'.format(install_dir)], cwd=jellyfish_dir, env=env, check=True)
+        util.misc.run_and_print(['make', 'install'], cwd=jellyfish_dir, env=env, check=True)
 
 
 class Kraken(tools.Tool):
@@ -186,7 +186,7 @@ class DownloadAndInstallKraken(tools.DownloadPackage):
             shutil.move(os.path.join(self.destination_dir, KRAKEN_COMMIT_DIR), kraken_dir)
         libexec_dir = os.path.join(kraken_dir, 'libexec')
         bin_dir = os.path.join(kraken_dir, 'bin')
-        util.misc.run_and_print(['./install_kraken.sh', 'libexec'], cwd=kraken_dir, env=env)
+        util.misc.run_and_print(['./install_kraken.sh', 'libexec'], cwd=kraken_dir, env=env, check=True)
         util.file.mkdir_p(bin_dir)
         for bin_name in Kraken.BINS:
             libexec_bin = os.path.join(libexec_dir, bin_name)

--- a/tools/mummer.py
+++ b/tools/mummer.py
@@ -48,7 +48,7 @@ class MummerTool(tools.Tool):
         toolCmd = [os.path.join(self.install_and_get_path(), 'mummer'),
             refFasta] + qryFastas
         log.debug(' '.join(toolCmd))
-        util.misc.run_and_print(toolCmd)
+        util.misc.run_and_print(toolCmd, check=True)
 
     def nucmer(self, refFasta, qryFasta, outDelta, extend=None, breaklen=None,
             maxgap=None, minmatch=None, mincluster=None):
@@ -72,7 +72,7 @@ class MummerTool(tools.Tool):
             toolCmd.extend(['--mincluster', str(mincluster)])
         toolCmd.extend([refFasta, qryFasta])
         log.debug(' '.join(toolCmd))
-        util.misc.run_and_print(toolCmd)
+        util.misc.run_and_print(toolCmd, check=True)
 
     def promer(self, refFasta, qryFasta, outDelta, extend=None, breaklen=None,
             maxgap=None, minmatch=None, mincluster=None):
@@ -96,7 +96,7 @@ class MummerTool(tools.Tool):
             toolCmd.extend(['--mincluster', str(mincluster)])
         toolCmd.extend([refFasta, qryFasta])
         log.debug(' '.join(toolCmd))
-        util.misc.run_and_print(toolCmd)
+        util.misc.run_and_print(toolCmd, check=True)
 
     def delta_filter(self, inDelta, outDelta):
         toolCmd = [os.path.join(self.install_and_get_path(), 'delta-filter'),

--- a/tools/muscle.py
+++ b/tools/muscle.py
@@ -68,7 +68,7 @@ class MuscleTool(tools.Tool):
             tool_cmd.extend(('-log', logFile))
 
         _log.debug(' '.join(tool_cmd))
-        util.misc.run_and_print(tool_cmd)
+        util.misc.run_and_print(tool_cmd, check=True)
     # pylint: enable=W0221
 
 

--- a/tools/mvicuna.py
+++ b/tools/mvicuna.py
@@ -60,7 +60,7 @@ class MvicunaTool(tools.Tool):
             outUnpaired, '-drm_op', ','.join(tmp1OutPair), '-tasks', 'DupRm'
         ]
         _log.debug(' '.join(cmdline))
-        util.misc.run_and_print(cmdline)
+        util.misc.run_and_print(cmdline, check=True)
         for tmpfname, outfname in zip(tmp2OutPair, outPair):
             shutil.copyfile(tmpfname, outfname)
 

--- a/tools/novoalign.py
+++ b/tools/novoalign.py
@@ -203,7 +203,7 @@ class NovoalignTool(tools.Tool):
             cmd.extend(['-s', str(s)])
         cmd.extend([outfname, refFasta])
         _log.debug(' '.join(cmd))
-        util.misc.run_and_print(cmd)
+        util.misc.run_and_print(cmd, check=True)
         try:
             mode = os.stat(outfname).st_mode & ~stat.S_IXUSR & ~stat.S_IXGRP & ~stat.S_IXOTH
             os.chmod(outfname, mode)

--- a/tools/picard.py
+++ b/tools/picard.py
@@ -57,7 +57,7 @@ class PicardTools(tools.Tool):
                 self.install_and_get_path(), '-Xmx' + JVMmemory, '-Djava.io.tmpdir=' + tempfile.tempdir, command
             ] + picardOptions
         _log.debug(' '.join(tool_cmd))
-        util.misc.run_and_print(tool_cmd)
+        util.misc.run_and_print(tool_cmd, check=True)
 
     @staticmethod
     def dict_to_picard_opts(options):

--- a/tools/snpeff.py
+++ b/tools/snpeff.py
@@ -59,7 +59,7 @@ class SnpEff(tools.Tool):
             ] + args
 
         _log.debug(' '.join(tool_cmd))
-        return util.misc.run_and_print(tool_cmd, stdin=stdin, buffered=True, silent=True)
+        return util.misc.run_and_print(tool_cmd, stdin=stdin, buffered=True, silent=True, check=True)
 
     def has_genome(self, genome):
         if not self.known_dbs:

--- a/tools/trimmomatic.py
+++ b/tools/trimmomatic.py
@@ -26,4 +26,4 @@ class TrimmomaticTool(tools.Tool):
         tools.Tool.__init__(self, install_methods=install_methods)
 
     def execute(self, *args):
-        util.misc.run_and_print(self.exec_path, args)
+        util.misc.run_and_print(self.exec_path, args, check=True)

--- a/tools/trinity.py
+++ b/tools/trinity.py
@@ -56,7 +56,7 @@ class TrinityTool(tools.Tool):
             '--output', outdir
         ]
         log.debug(' '.join(cmd))
-        util.misc.run_and_print(cmd)
+        util.misc.run_and_print(cmd, check=True)
         shutil.copyfile(os.path.join(outdir, 'Trinity.fasta'), outFasta)
         shutil.rmtree(outdir, ignore_errors=True)
 

--- a/util/misc.py
+++ b/util/misc.py
@@ -127,7 +127,7 @@ except ImportError:
                 output = subprocess.check_output(
                     args, stdin=stdin, stderr=stderr, shell=shell,
                     env=env, cwd=cwd)
-                returncode = 0
+                return CompletedProcess(args, 0, output, b'')
             # Py3.4 doesn't have stderr attribute
             except subprocess.CalledProcessError as e:
                 if check:
@@ -161,8 +161,13 @@ except ImportError:
             else:
                 error = ''
             if check and returncode != 0:
-                raise subprocess.CalledProcessError(
-                    returncode, b' '.join(args), str(output)+str(error))
+                print(output.decode("utf-8"))
+                try:
+                    raise subprocess.CalledProcessError(
+                        returncode, args, output, error)
+                except TypeError: # py2 CalledProcessError does not accept error
+                    raise subprocess.CalledProcessError(
+                        returncode, args, output.decode("utf-8"))
             return CompletedProcess(args, returncode, output, error)
         finally:
             if stdout_pipe:

--- a/util/misc.py
+++ b/util/misc.py
@@ -206,11 +206,13 @@ def run_and_print(args, stdout=None, stderr=None,
                 for c in iter(process.stdout.read, b""):
                     output.append(c)
                     print(c.decode('utf-8'), end="") # print for py3 / p2 from __future__
+                    sys.stdout.flush() # flush buffer to stdout
 
         # in case there are still chars in the pipe buffer
         if not silent:
             for c in iter(lambda: process.stdout.read(1), b""):
                 print(c, end="")
+                sys.stdout.flush() # flush buffer to stdout
 
         if check and process.returncode != 0:
             raise subprocess.CalledProcessError(process.returncode, args,

--- a/util/misc.py
+++ b/util/misc.py
@@ -162,7 +162,7 @@ except ImportError:
                 error = ''
             if check and returncode != 0:
                 raise subprocess.CalledProcessError(
-                    returncode, b' '.join(args), output, error)
+                    returncode, b' '.join(args), str(output)+str(error))
             return CompletedProcess(args, returncode, output, error)
         finally:
             if stdout_pipe:


### PR DESCRIPTION
the ‘check’ kwarg (default False) was added to misc.py:run_and_print(),
which checks the return code of the called command and raises a
CalledProcessError if returncode != 0. This commit adds check=True to
instances of run_and_print where run_and_print previously replaced
invocations of subprocess.check_call() (but not invocations of
subprocess.call())