### PR TITLE
update docs to include links to pre-built hosted databases for depletion and metagenomics

### DIFF
--- a/docs/pipeuse.rst
+++ b/docs/pipeuse.rst
@@ -204,7 +204,7 @@ using `Kraken <https://ccb.jhu.edu/software/kraken/>`__,
 
     krona_db: "/path/to/krona"
 
-Pre-build databases for Kraken, Diamond, and Krona are available:
+Pre-built databases for Kraken, Diamond, and Krona are available:
 
 -  `kraken_db.tar.gz <https://storage.googleapis.com/sabeti-public/meta_dbs/kraken_db.tar.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/meta_dbs/kraken_db.tar.lz4>`__)
 -  `krona_taxonomy_20160502.tar.gz <https://storage.googleapis.com/sabeti-public/meta_dbs/krona_taxonomy_20160502.tar.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/meta_dbs/krona_taxonomy_20160502.tar.lz4>`__)
@@ -239,6 +239,10 @@ contaminents from reads:
 ::
 
     trim_clip_db: "/path/to/depletion_databases/contaminants.fasta"
+
+Pre-built databases for Trimmomatic:
+
+-  `contaminants.fasta.tar.gz <https://console.cloud.google.com/m/cloudstorage/b/sabeti-public/o/depletion_dbs/contaminants.fasta.tar.gz>`__ (`*.lz4 <https://console.cloud.google.com/m/cloudstorage/b/sabeti-public/o/depletion_dbs/contaminants.fasta.lz4>`__)
 
 A FASTA file containing spike-ins to be reported:
 

--- a/docs/pipeuse.rst
+++ b/docs/pipeuse.rst
@@ -162,6 +162,15 @@ docs <ftp://ftp.ncbi.nih.gov/pub/agarwala/bmtagger/README.bmtagger.txt>`__.
       - "GRCh37.68_ncRNA-GRCh37.68_transcripts-HS_rRNA_mitRNA"
       - "metagenomics_contaminants_v3"
 
+Pre-built depletion databases are available in both *.tar.gz and *.lz4 
+format, for removing human reads and common metagenomic contaminants:
+
+-  `https://storage.googleapis.com/sabeti-public/depletion_dbs/GRCh37.68_ncRNA-GRCh37.68_transcripts-HS_rRNA_mitRNA.tar.gz <https://storage.googleapis.com/sabeti-public/depletion_dbs/GRCh37.68_ncRNA-GRCh37.68_transcripts-HS_rRNA_mitRNA.tar.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/depletion_dbs/GRCh37.68_ncRNA-GRCh37.68_transcripts-HS_rRNA_mitRNA.lz4>`__)
+-  `https://storage.googleapis.com/sabeti-public/depletion_dbs/hg19.tar.gz <https://storage.googleapis.com/sabeti-public/depletion_dbs/hg19.tar.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/depletion_dbs/hg19.lz4>`__)
+-  `https://storage.googleapis.com/sabeti-public/depletion_dbs/metagenomics_contaminants_v3.tar.gz <https://storage.googleapis.com/sabeti-public/depletion_dbs/metagenomics_contaminants_v3.tar.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/depletion_dbs/metagenomics_contaminants_v3.lz4>`__)
+
+Note that these databases must be extracted prior to use.
+
 In addition to the databases used by BMTagger, you will need to specify
 the location and file prefix of the BLAST database to be used for
 depletion. The process for creating the BLAST database is described in
@@ -175,6 +184,33 @@ from the University of Oxford.
 
     blast_db_dir: "/path/to/depletion_databases"
     blast_db_remove: "metag_v3.ncRNA.mRNA.mitRNA.consensus"
+
+A pre-built depletion database is also available for BLAST:
+
+-  `https://storage.googleapis.com/sabeti-public/depletion_dbs/metag_v3.ncRNA.mRNA.mitRNA.consensus.tar.gz <https://storage.googleapis.com/sabeti-public/depletion_dbs/metag_v3.ncRNA.mRNA.mitRNA.consensus.tar.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/depletion_dbs/metag_v3.ncRNA.mRNA.mitRNA.consensus.lz4>`__)
+
+Note that this database must be extracted prior to use.
+
+Additional databases are needed to perform metagenomic classification 
+using `Kraken <https://ccb.jhu.edu/software/kraken/>`__, 
+`Diamond <https://github.com/bbuchfink/diamond>`__, or 
+`Krona <https://github.com/marbl/Krona/wiki>`__.
+
+::
+
+    kraken_db: "/path/to/kraken_full_20150910"
+
+    diamond_db: "/path/to/diamond_db/nr"
+
+    krona_db: "/path/to/krona"
+
+Pre-build databases for Kraken, Diamond, and Krona are available:
+
+-  `https://storage.googleapis.com/sabeti-public/meta_dbs/kraken_db.tar.gz <https://storage.googleapis.com/sabeti-public/meta_dbs/kraken_db.tar.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/meta_dbs/kraken_db.tar.lz4>`__)
+-  `https://storage.googleapis.com/sabeti-public/meta_dbs/krona_taxonomy_20160502.tar.gz <https://storage.googleapis.com/sabeti-public/meta_dbs/krona_taxonomy_20160502.tar.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/meta_dbs/krona_taxonomy_20160502.tar.lz4>`__)
+-  `https://storage.googleapis.com/sabeti-public/meta_dbs/nr.dmnd.gz <https://storage.googleapis.com/sabeti-public/meta_dbs/nr.dmnd.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/meta_dbs/nr.dmnd.lz4>`__)
+
+Note that these databases must be extracted prior to use.
 
 An array of the `NCBI GenBank
 CoreNucleotide <http://www.ncbi.nlm.nih.gov/nuccore/>`__ accessions for

--- a/docs/pipeuse.rst
+++ b/docs/pipeuse.rst
@@ -165,9 +165,9 @@ docs <ftp://ftp.ncbi.nih.gov/pub/agarwala/bmtagger/README.bmtagger.txt>`__.
 Pre-built depletion databases are available in both *.tar.gz and *.lz4 
 format, for removing human reads and common metagenomic contaminants:
 
--  `https://storage.googleapis.com/sabeti-public/depletion_dbs/GRCh37.68_ncRNA-GRCh37.68_transcripts-HS_rRNA_mitRNA.tar.gz <https://storage.googleapis.com/sabeti-public/depletion_dbs/GRCh37.68_ncRNA-GRCh37.68_transcripts-HS_rRNA_mitRNA.tar.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/depletion_dbs/GRCh37.68_ncRNA-GRCh37.68_transcripts-HS_rRNA_mitRNA.lz4>`__)
--  `https://storage.googleapis.com/sabeti-public/depletion_dbs/hg19.tar.gz <https://storage.googleapis.com/sabeti-public/depletion_dbs/hg19.tar.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/depletion_dbs/hg19.lz4>`__)
--  `https://storage.googleapis.com/sabeti-public/depletion_dbs/metagenomics_contaminants_v3.tar.gz <https://storage.googleapis.com/sabeti-public/depletion_dbs/metagenomics_contaminants_v3.tar.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/depletion_dbs/metagenomics_contaminants_v3.lz4>`__)
+-  `GRCh37.68_ncRNA-GRCh37.68_transcripts-HS_rRNA_mitRNA.tar.gz <https://storage.googleapis.com/sabeti-public/depletion_dbs/GRCh37.68_ncRNA-GRCh37.68_transcripts-HS_rRNA_mitRNA.tar.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/depletion_dbs/GRCh37.68_ncRNA-GRCh37.68_transcripts-HS_rRNA_mitRNA.lz4>`__)
+-  `hg19.tar.gz <https://storage.googleapis.com/sabeti-public/depletion_dbs/hg19.tar.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/depletion_dbs/hg19.lz4>`__)
+-  `metagenomics_contaminants_v3.tar.gz <https://storage.googleapis.com/sabeti-public/depletion_dbs/metagenomics_contaminants_v3.tar.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/depletion_dbs/metagenomics_contaminants_v3.lz4>`__)
 
 Note that these databases must be extracted prior to use.
 
@@ -187,7 +187,7 @@ from the University of Oxford.
 
 A pre-built depletion database is also available for BLAST:
 
--  `https://storage.googleapis.com/sabeti-public/depletion_dbs/metag_v3.ncRNA.mRNA.mitRNA.consensus.tar.gz <https://storage.googleapis.com/sabeti-public/depletion_dbs/metag_v3.ncRNA.mRNA.mitRNA.consensus.tar.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/depletion_dbs/metag_v3.ncRNA.mRNA.mitRNA.consensus.lz4>`__)
+-  `metag_v3.ncRNA.mRNA.mitRNA.consensus.tar.gz <https://storage.googleapis.com/sabeti-public/depletion_dbs/metag_v3.ncRNA.mRNA.mitRNA.consensus.tar.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/depletion_dbs/metag_v3.ncRNA.mRNA.mitRNA.consensus.lz4>`__)
 
 Note that this database must be extracted prior to use.
 
@@ -206,9 +206,9 @@ using `Kraken <https://ccb.jhu.edu/software/kraken/>`__,
 
 Pre-build databases for Kraken, Diamond, and Krona are available:
 
--  `https://storage.googleapis.com/sabeti-public/meta_dbs/kraken_db.tar.gz <https://storage.googleapis.com/sabeti-public/meta_dbs/kraken_db.tar.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/meta_dbs/kraken_db.tar.lz4>`__)
--  `https://storage.googleapis.com/sabeti-public/meta_dbs/krona_taxonomy_20160502.tar.gz <https://storage.googleapis.com/sabeti-public/meta_dbs/krona_taxonomy_20160502.tar.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/meta_dbs/krona_taxonomy_20160502.tar.lz4>`__)
--  `https://storage.googleapis.com/sabeti-public/meta_dbs/nr.dmnd.gz <https://storage.googleapis.com/sabeti-public/meta_dbs/nr.dmnd.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/meta_dbs/nr.dmnd.lz4>`__)
+-  `kraken_db.tar.gz <https://storage.googleapis.com/sabeti-public/meta_dbs/kraken_db.tar.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/meta_dbs/kraken_db.tar.lz4>`__)
+-  `krona_taxonomy_20160502.tar.gz <https://storage.googleapis.com/sabeti-public/meta_dbs/krona_taxonomy_20160502.tar.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/meta_dbs/krona_taxonomy_20160502.tar.lz4>`__)
+-  `nr.dmnd.gz <https://storage.googleapis.com/sabeti-public/meta_dbs/nr.dmnd.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/meta_dbs/nr.dmnd.lz4>`__)
 
 Note that these databases must be extracted prior to use.
 

--- a/pipes/config.yaml
+++ b/pipes/config.yaml
@@ -12,6 +12,10 @@ email_point_of_contact_for_ncbi: "someone@example.com"
 # Directory path containing the bmTagger databases used for depletion
 # of human reads and metagenomic contaminants
 # See: ftp://ftp.ncbi.nih.gov/pub/agarwala/bmtagger/README.bmtagger.txt
+# For pre-built hosted databases, you may download:
+#  - https://storage.googleapis.com/sabeti-public/depletion_dbs/GRCh37.68_ncRNA-GRCh37.68_transcripts-HS_rRNA_mitRNA.tar.gz
+#  - https://storage.googleapis.com/sabeti-public/depletion_dbs/hg19.tar.gz
+#  - https://storage.googleapis.com/sabeti-public/depletion_dbs/metagenomics_contaminants_v3.tar.gz
 bmtagger_db_dir: "/idi/sabeti-scratch/kandersen/references/depletion_databases"
 bmtagger_dbs_remove:
   - "hg19"
@@ -21,23 +25,33 @@ bmtagger_dbs_remove:
 # Path for the directory containing blast databases used for additional depletion
 # See: ftp://ftp.ncbi.nih.gov/blast/documents/formatdb.html
 #      http://www.compbio.ox.ac.uk/analysis_tools/BLAST/formatdb.shtml
+# For pre-built hosted databases, you may download:
+#  - https://storage.googleapis.com/sabeti-public/depletion_dbs/metag_v3.ncRNA.mRNA.mitRNA.consensus.tar.gz
 blast_db_dir: "/idi/sabeti-scratch/kandersen/references/depletion_databases"
 # Within blast_db_dir, the prefix of the database containing sequences to remove during depletion
 blast_db_remove: "metag_v3.ncRNA.mRNA.mitRNA.consensus"
 
 # A fasta file containing sequences of adapters/primers/barcodes to be removed via Trimmomatic
+# For pre-built hosted databases, you may download:
+#  - https://console.cloud.google.com/m/cloudstorage/b/sabeti-public/o/depletion_dbs/contaminants.fasta.tar.gz
 trim_clip_db: "/idi/sabeti-scratch/kandersen/references/depletion_databases/contaminants.fasta"
 
 # a fasta file containing sequences to report downstream as spike-ins
 spikeins_db: "/idi/sabeti-scratch/kandersen/references/other/ercc_spike-ins.fasta"
 
 # Directory of kraken database for metagenomics identification
+# For pre-built hosted databases, you may download:
+#  - https://storage.googleapis.com/sabeti-public/meta_dbs/kraken_db.tar.gz
 kraken_db: "/idi/sabeti-scratch/yesimon/db/kraken_full_20150910"
 
 # Path of DIAMOND database file for metagenomics identification
+# For pre-built hosted databases, you may download:
+#  - https://storage.googleapis.com/sabeti-public/meta_dbs/nr.dmnd.gz
 diamond_db: "/idi/sabeti-scratch/yesimon/db/diamond_db/nr"
 
 # Directory of the krona database for generating html reports.
+# For pre-built hosted databases, you may download:
+#  - https://storage.googleapis.com/sabeti-public/meta_dbs/krona_taxonomy_20160502.tar.gz
 krona_db: "/idi/sabeti-scratch/yesimon/db/krona"
 
 # Directory of the NCBI taxonomy dmp files


### PR DESCRIPTION
update docs to include links to pre-built hosted databases for depletion and metagenomics; note that the databases are still being uploaded, so this PR should not be merged into master until all are live