### PR TITLE
change git clone depth 50->3 for travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,9 @@ addons:
     - g++-4.9
     - libboost1.55-all-dev
 
+git:
+  depth: 3
+
 before_install:
   - travis/before_install.sh
 


### PR DESCRIPTION
Travis performs a shallow clone for each test, but the default is to include the past 50 commits which is more than we need, especially since we are not performing git operations on historical commits as part of the built/test process. This commit changes the clone depth to 3 commits (Travis cautions a depth of one can cause test queues to stack up).