### PR TITLE
remove yappi and filechunkio

### DIFF
--- a/requirements-pipes.txt
+++ b/requirements-pipes.txt
@@ -1,5 +1,3 @@
 boto==2.38.0
-filechunkio==1.6
 snakemake==3.5.5
-yappi==0.94
 PyYAML==3.11


### PR DESCRIPTION
yappi is not used by us, and filechunkio is now installed by snakemake