### PR TITLE
improved detection of active conda env path

### DIFF
--- a/tools/bmtagger.py
+++ b/tools/bmtagger.py
@@ -27,7 +27,7 @@ class BmtaggerTools(tools.Tool):
     # subtool_name must be defined in subclass
 
     def __init__(self, install_methods=None):
-        self.subtool_name = self.subtool_name if hasattr(self, "subtool_name") else None
+        self.subtool_name = self.subtool_name if hasattr(self, "subtool_name") else "bmtagger.sh"
         if install_methods is None:
             install_methods = []
             install_methods.append(tools.CondaPackage(TOOL_NAME, executable=self.subtool_name, version=TOOL_VERSION))


### PR DESCRIPTION
CONDA_DEFAULT_ENV should be used when CONDA_ENV_PATH is not populated (some legacy versions, sometimes during package build). Legacy versions of conda sometimes set CONDA_DEFAULT_ENV to an environment name rather than a full path, so we need to account for this. 