### PR TITLE
parallelize blastn calls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 
 biopython==1.64
 future>=0.15.2
+futures==3.0.3
 pytest==2.9.1
 pysam==0.8.3
 PyYAML==3.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 biopython==1.64
 future>=0.15.2
-futures==3.0.3
+futures==3.0.3; python_version == '2.6' or python_version=='2.7'
 pytest==2.9.1
 pysam==0.8.3
 PyYAML==3.11

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -238,6 +238,7 @@ class CondaPackage(InstallMethod):
         # CONDA_ENV_PATH is always a path, but not always present        
         self.env_path = None
         if "CONDA_ENV_PATH" in os.environ and len(os.environ["CONDA_ENV_PATH"]):
+            _log.debug('CONDA_ENV_PATH found')
             last_path_component = os.path.basename(os.path.normpath(os.environ["CONDA_ENV_PATH"]))
             self.env_path = os.path.dirname(os.environ["CONDA_ENV_PATH"]) if last_path_component == "bin" else os.environ["CONDA_ENV_PATH"]
         elif "CONDA_DEFAULT_ENV" in os.environ and len(os.environ["CONDA_DEFAULT_ENV"]):
@@ -248,7 +249,7 @@ class CondaPackage(InstallMethod):
                     _log.debug('Conda env found is specified as dir: %s' % conda_env_path)
                     conda_env_path = os.path.abspath(conda_env_path)
                     last_path_component = os.path.basename(os.path.normpath(conda_env_path))
-                    self.env_path = os.path.dirname(last_path_component) if last_path_component == "bin" else last_path_component
+                    self.env_path = os.path.dirname(last_path_component) if last_path_component == "bin" else conda_env_path
                 else: # if conda env is an environment name, infer the path
                     _log.debug('Conda env found is specified by name: %s' % conda_env_path)
                     result = util.misc.run_and_print(["conda", "env", "list", "--json"], loglevel=logging.DEBUG, env=os.environ)

--- a/util/file.py
+++ b/util/file.py
@@ -15,6 +15,7 @@ import errno
 import logging
 import json
 import util.cmd
+import util.misc
 
 # imports needed for download_file() and webfile_readlines()
 import re
@@ -388,3 +389,11 @@ def string_to_file_name(string_value):
     string_value = string_value.strip(".")
 
     return string_value
+
+def fasta_length(fasta_path):
+    env = os.environ.copy()
+    env['LC_ALL'] = 'C' #use C locale rather than UTF8 for faster grep
+    
+    # grep for record start characters, in fixed-string mode (no regex)
+    number_of_seqs = util.misc.run_and_print(["grep", "-cF", ">", fasta_path], silent=False, check=True, env=env)
+    return int(number_of_seqs.stdout.decode("utf-8").rstrip(os.linesep))


### PR DESCRIPTION
In taxon_filter.py, input to blastn was already chunked. This uses concurrent.futures to spawn separate parallel processes for each blastn call, scaling chunk size to roughly match the limits we had before (in aggregate), with bounds on thread count and minimum chunk size.