### PR TITLE
change reports_only Snakemake rules to rely on samples-assembly.txt and samples-assembly-failures.txt rather than on samples-depletion.txt

### DIFF
--- a/pipes/rules/reports_only
+++ b/pipes/rules/reports_only
@@ -39,7 +39,7 @@ rule all_assembly_reports:
     input:
             expand("{reports_dir}/assembly/{sample}.txt",
                 reports_dir=config["reports_dir"],
-                sample=read_file(config["samples_depletion"]))
+                sample=list(read_file(config["samples_assembly"]))+list(read_file(config["samples_assembly_failures"])) )
     output:
             config["reports_dir"]+"/summary.assembly.txt"
     params: LSF="-N"


### PR DESCRIPTION
change reports_only Snakemake rules to rely on samples-assembly.txt and
samples-assembly-failures.txt rather than on samples-depletion.txt