### PR TITLE
git call in versions.py now silent via util.misc.run_and_print()

### DIFF
--- a/util/version.py
+++ b/util/version.py
@@ -10,6 +10,7 @@ import os
 import re
 import time, datetime
 import os.path
+import util.misc
 
 
 def get_project_path():
@@ -29,10 +30,13 @@ def call_git_describe():
     try:
         os.chdir(get_project_path())
         cmd = ['git', 'describe', '--tags', '--always', '--dirty']
-        out = subprocess.check_output(cmd)
-        if not isinstance(out, str):
-            out = out.decode('utf-8')
-        ver = out.strip()
+        result = util.misc.run_and_print(cmd, silent=True)
+        ver = None
+        if result.returncode == 0:
+            out = result.stdout    
+            if not isinstance(out, str):
+                out = out.decode('utf-8')
+            ver = out.strip()
     except Exception:
         ver = None
     os.chdir(cwd)


### PR DESCRIPTION
we inspect the result of ‘git describe’ as one method of inferring the
version of viral-ngs, but the stderr was previously not captured, so
‘fatal’ (for the subprocess call) errors occurred when versions.py was
called in a non-git directory. This commit runs the git command with
silent=True so we don’t see the potentially-misleading error message in
our logs