### PR TITLE
add metagenomic_report_merge()

### DIFF
--- a/metagenomics.py
+++ b/metagenomics.py
@@ -25,6 +25,7 @@ import tools.kraken
 import tools.krona
 import tools.diamond
 import tools.picard
+import csv
 
 __commands__ = []
 
@@ -410,6 +411,10 @@ def kraken_dfs(db, lines, taxa_hits, total_hits, taxid, level):
 
 def kraken(inBam, db, outReport=None, outReads=None,
            filterThreshold=None, numThreads=1):
+    '''
+        Classify reads by taxon using Kraken
+    '''
+
     assert outReads or outReport, (
         'Either --outReads or --outReport must be specified.')
     kraken_tool = tools.kraken.Kraken()
@@ -437,24 +442,6 @@ def kraken(inBam, db, outReport=None, outReads=None,
         kraken_tool.report(tmp_filtered_reads, db, outReport)
 
 
-def krona(inTsv, db, outHtml, queryColumn=None, taxidColumn=None,
-          scoreColumn=None, noHits=None, noRank=None):
-
-    krona_tool = tools.krona.Krona()
-    if inTsv.endswith('.gz'):
-        tmp_tsv = util.file.mkstempfname('.tsv')
-        with gzip.open(inTsv, 'rb') as f_in:
-            with open(tmp_tsv, 'wb') as f_out:
-                shutil.copyfileobj(f_in, f_out)
-                to_import = [tmp_tsv]
-    else:
-        to_import = [inTsv]
-
-    krona_tool.import_taxonomy(
-        db, to_import, outHtml, query_column=queryColumn, taxid_column=taxidColumn,
-        score_column=scoreColumn, no_hits=noHits, no_rank=noRank)
-
-
 def parser_kraken(parser=argparse.ArgumentParser()):
     parser.add_argument('inBam', help='Input unaligned reads, BAM format.')
     parser.add_argument('db', help='Kraken database directory.')
@@ -469,6 +456,27 @@ def parser_kraken(parser=argparse.ArgumentParser()):
                                   ('tmp_dir', None)))
     util.cmd.attach_main(parser, kraken, split_args=True)
     return parser
+
+
+def krona(inTsv, db, outHtml, queryColumn=None, taxidColumn=None,
+          scoreColumn=None, noHits=None, noRank=None):
+    '''
+        Create an interactive HTML report from a tabular metagenomic report
+    '''
+
+    krona_tool = tools.krona.Krona()
+    if inTsv.endswith('.gz'):
+        tmp_tsv = util.file.mkstempfname('.tsv')
+        with gzip.open(inTsv, 'rb') as f_in:
+            with open(tmp_tsv, 'wb') as f_out:
+                shutil.copyfileobj(f_in, f_out)
+                to_import = [tmp_tsv]
+    else:
+        to_import = [inTsv]
+
+    krona_tool.import_taxonomy(
+        db, to_import, outHtml, query_column=queryColumn, taxid_column=taxidColumn,
+        score_column=scoreColumn, no_hits=noHits, no_rank=noRank)
 
 
 def parser_krona(parser=argparse.ArgumentParser()):
@@ -491,6 +499,9 @@ def parser_krona(parser=argparse.ArgumentParser()):
 
 
 def diamond(inBam, db, taxDb, outReport, outM8=None, outLca=None, numThreads=1):
+    '''
+        Classify reads by the taxon of the Lowest Common Ancestor (LCA)
+    '''
     tmp_fastq = util.file.mkstempfname('.fastq')
     tmp_fastq2 = util.file.mkstempfname('.fastq')
     picard = tools.picard.SamToFastqTool()
@@ -547,10 +558,80 @@ def parser_diamond(parser=argparse.ArgumentParser()):
     util.cmd.attach_main(parser, diamond, split_args=True)
     return parser
 
+def metagenomic_report_merge(kraken_reports, diamond_reports, out_kraken_summary, kraken_db, out_krona_input):
+    '''
+        Merge multiple metegenomic reports into a single metagenomic report. 
+        Any Krona input files created by this 
+    '''
+    assert out_kraken_summary or out_krona_input, (
+        "Either --outKrakenSummary or --outKronaInput must be specified")
+    assert kraken_reports or diamond_reports, (
+        'Either --krakenReports or --diamondReports must be given as input')
+    assert kraken_reports if out_kraken_summary else True, (
+        'The input files --krakenReports must be provided if --outKrakenSummary is specified')
+    assert kraken_db if out_kraken_summary else True, (
+        'A Kraken db must be provided via --krakenDB if outKrakenSummary is specified')
+
+    # column numbers containing the query (sequence) ID and taxonomic ID
+    # these are one-indexed
+    # See: http://ccb.jhu.edu/software/kraken/MANUAL.html#output-format
+    tool_data_columns = {
+        "diamond": (1, 2),
+        "kraken": (2, 3)
+    }
+
+    # if we're creating a Krona input file
+    if out_krona_input:
+        # open the output file (as gz if necessary)
+        with util.file.open_or_gzopen(out_krona_input ,"wt") as outf:
+            # create a TSV writer for the output file
+            output_writer = csv.writer(outf, delimiter='\t')
+
+            if kraken_reports:
+                # for each Kraken file specified, pull out the appropriate columns
+                # and write them to the TSV output
+                for kraken_file in kraken_reports:
+                    with util.file.open_or_gzopen(kraken_file.name ,"rt") as inf:
+                        file_reader = csv.reader(inf, delimiter='\t')
+                        for row in file_reader:
+                            output_writer.writerow([row[c-1] for c in tool_data_columns["kraken"]])
+
+            if diamond_reports:
+                # for each Diamond file specified, pull out the appropriate columns
+                # and write them to the TSV output
+                for diamond_file in diamond_reports:
+                    with util.file.open_or_gzopen(diamond_file.name, "rt") as inf:
+                        file_reader = csv.reader(inf, delimiter='\t')
+                        for row in file_reader:
+                            output_writer.writerow([row[c-1] for c in tool_data_columns["diamond"]])
+
+
+    # create a human-readable summary of the Kraken reports
+    # kraken-report can only be used on kraken reports since it depends on queries being in its database
+    if out_kraken_summary:
+        # create temporary file to hold combined kraken report
+        tmp_kraken_combined_txt = util.file.mkstempfname('.txt')
+        
+        util.file.cat(tmp_kraken_combined_txt, [kraken_file.name for kraken_file in kraken_reports])
+
+        kraken_tool = tools.kraken.Kraken()
+        kraken_tool.report(tmp_kraken_combined_txt, kraken_db.name, out_kraken_summary)
+  
+
+def parser_metagenomic_report_merge(parser=argparse.ArgumentParser()):
+    parser.add_argument("--krakenReports", dest="kraken_reports", help="Input metagenomic reports created by Kraken", nargs='+', type=argparse.FileType('r'))
+    parser.add_argument("--diamondReports", dest="diamond_reports", help="Input metagenomic reports created by Diamond", nargs='+', type=argparse.FileType('r'))
+    parser.add_argument("--outKrakenSummary", dest="out_kraken_summary", help="Input metagenomic reports created by Diamond") #, type=argparse.FileType('w'))
+    parser.add_argument("--krakenDB", dest="kraken_db", help="Kraken database (needed for outKrakenSummary)", nargs='+', type=argparse.FileType('r'))
+    parser.add_argument("--outKronaInput", dest="out_krona_input", help="Output metagenomic report suitable for Krona input. Note that this writes only the two columns needed by Krona, so Krona must be invoked accordingly.") #, type=argparse.FileType('w'))
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
+    util.cmd.attach_main(parser, metagenomic_report_merge, split_args=True)
+    return parser
 
 __commands__.append(('kraken', parser_kraken))
 __commands__.append(('diamond', parser_diamond))
 __commands__.append(('krona', parser_krona))
+__commands__.append(('metagenomic_report_merge', parser_metagenomic_report_merge))
 
 
 def full_parser():

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -566,9 +566,9 @@ def metagenomic_report_merge(metagenomic_reports, out_kraken_summary, kraken_db,
         Any Krona input files created by this 
     '''
     assert out_kraken_summary or out_krona_input, (
-        "Either --outKrakenSummary or --outKronaInput must be specified")
+        "Either --outSummaryReport or --outByQueryToTaxonID must be specified")
     assert kraken_db if out_kraken_summary else True, (
-        'A Kraken db must be provided via --krakenDB if outKrakenSummary is specified')
+        'A Kraken db must be provided via --krakenDB if outSummaryReport is specified')
 
     # column numbers containing the query (sequence) ID and taxonomic ID
     # these are one-indexed
@@ -591,7 +591,9 @@ def metagenomic_report_merge(metagenomic_reports, out_kraken_summary, kraken_db,
                     with util.file.open_or_gzopen(metag_file.name ,"rt") as inf:
                         file_reader = csv.reader(inf, delimiter='\t')
                         for row in file_reader:
-                            output_writer.writerow([row[c-1] for c in tool_data_columns["kraken"]])
+                            # for only the two relevant columns
+                            output_writer.writerow([f for f in row])
+                            #output_writer.writerow([row[c-1] for c in tool_data_columns["kraken"]])
 
 
     # create a human-readable summary of the Kraken reports
@@ -607,10 +609,10 @@ def metagenomic_report_merge(metagenomic_reports, out_kraken_summary, kraken_db,
   
 
 def parser_metagenomic_report_merge(parser=argparse.ArgumentParser()):
-    parser.add_argument("metagenomic_reports", help="Input metagenomic reports created by Kraken", nargs='+', type=argparse.FileType('r'))
-    parser.add_argument("--outKrakenSummary", dest="out_kraken_summary", help="Input metagenomic reports created by Diamond") #, type=argparse.FileType('w'))
-    parser.add_argument("--krakenDB", dest="kraken_db", help="Kraken database (needed for outKrakenSummary)", nargs='+', type=argparse.FileType('r'))
-    parser.add_argument("--outKronaInput", dest="out_krona_input", help="Output metagenomic report suitable for Krona input. Note that this writes only the two columns needed by Krona, so Krona must be invoked accordingly.") #, type=argparse.FileType('w'))
+    parser.add_argument("metagenomic_reports", help="Input metagenomic reports with the query ID and taxon ID in the 2nd and 3rd columns (Kraken format)", nargs='+', type=argparse.FileType('r'))
+    parser.add_argument("--outSummaryReport", dest="out_kraken_summary", help="Path of human-readable metagenomic summary report, created by kraken-report")
+    parser.add_argument("--krakenDB", dest="kraken_db", help="Kraken database (needed for outSummaryReport)", type=argparse.FileType('r'))
+    parser.add_argument("--outByQueryToTaxonID", dest="out_krona_input", help="Output metagenomic report suitable for Krona input. ") 
     util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, metagenomic_report_merge, split_args=True)
     return parser

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -500,7 +500,7 @@ def parser_krona(parser=argparse.ArgumentParser()):
     return parser
 
 
-def diamond(inBam, db, taxDb, outReport, outM8=None, outLca=None, numThreads=1, padToKraken=True):
+def diamond(inBam, db, taxDb, outReport, outM8=None, outLca=None, numThreads=1):
     '''
         Classify reads by the taxon of the Lowest Common Ancestor (LCA)
     '''
@@ -543,7 +543,7 @@ def diamond(inBam, db, taxDb, outReport, outM8=None, outLca=None, numThreads=1, 
     with open(tmp_lca_tsv) as f:
         hits = taxa_hits_from_tsv(f)
     with open(outReport, 'w') as f:
-        for line in kraken_dfs_report(tax_db, hits, prepend_column=padToKraken):
+        for line in kraken_dfs_report(tax_db, hits, prepend_column=True):
             print(line, file=f)
 
 
@@ -556,7 +556,6 @@ def parser_diamond(parser=argparse.ArgumentParser()):
     parser.add_argument('--outM8', help='Blast m8 formatted output file.')
     parser.add_argument('--outLca', help='Output LCA assignments for each read.')
     parser.add_argument('--numThreads', default=1, help='Number of threads (default: %(default)s)')
-    parser.add_argument('--padToKraken', action='store_true', help='Add an empty column to the output so the query and taxon IDs are in the same columns as a Kraken output file (default: %(default)s)')
     util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, diamond, split_args=True)
     return parser

--- a/pipes/rules/metagenomics.rules
+++ b/pipes/rules/metagenomics.rules
@@ -29,7 +29,7 @@ rule diamond:
     params: numThreads=str(config.get("number_of_threads", 1))
     shell:
         """
-        {config[bin_dir]}/metagenomics.py diamond {input} {config[diamond_db]} {config[taxonomy_db]} {output.report} --outLca {output.lca} --numThreads {params.numThreads}
+        {config[bin_dir]}/metagenomics.py diamond {input} {config[diamond_db]} {config[taxonomy_db]} {output.report} --outLca {output.lca} --numThreads {params.numThreads} --padToKraken
         """
 
 rule kraken:
@@ -48,7 +48,10 @@ rule krona_import_taxonomy:
            ".".join([wildcards.sample, method_props[wildcards.method]['reads_ext']]))
     output: join(config["data_dir"], config["subdirs"]["metagenomics"], "{sample}.{method,\w+}.krona.html")
     run:
-        query_col, taxid_col = method_props[wildcards.method]['krona_columns']
+        # method_props key can be changed to allow for different tools, 
+        # but with new changes Diamond output should look like Kraken output
+        # in terms of the location of the two needed columns
+        query_col, taxid_col = method_props["kraken"]['krona_columns']
         shell("""
         {config[bin_dir]}/metagenomics.py krona {input} {config[krona_db]} {output} --noRank \
           --queryColumn {query_col}  --taxidColumn {taxid_col}

--- a/pipes/rules/metagenomics.rules
+++ b/pipes/rules/metagenomics.rules
@@ -29,7 +29,7 @@ rule diamond:
     params: numThreads=str(config.get("number_of_threads", 1))
     shell:
         """
-        {config[bin_dir]}/metagenomics.py diamond {input} {config[diamond_db]} {config[taxonomy_db]} {output.report} --outLca {output.lca} --numThreads {params.numThreads} --padToKraken
+        {config[bin_dir]}/metagenomics.py diamond {input} {config[diamond_db]} {config[taxonomy_db]} {output.report} --outLca {output.lca} --numThreads {params.numThreads}
         """
 
 rule kraken:

--- a/util/file.py
+++ b/util/file.py
@@ -326,9 +326,9 @@ def replace_in_file(filename, original, new):
 
 def cat(output_file, input_files):
     '''Cat list of input filenames to output filename.'''
-    with open(output_file, 'wb') as wfd:
+    with open_or_gzopen(output_file, 'wb') as wfd:
         for f in input_files:
-            with open(f, 'rb') as fd:
+            with open_or_gzopen(f, 'rb') as fd:
                 shutil.copyfileobj(fd, wfd, 1024*1024*10)
 
 


### PR DESCRIPTION
This addresses #314, and adds a function, `metagenomic_report_merge()`,  to `metagenomics.py` to combine multiple metagenomic reports into a single file usable as Krona input, with an option to recreate the Kraken summary (db required).


<!---
@huboard:{"order":263.5,"milestone_order":342,"custom_state":""}
-->
