### PR TITLE
Append UGE resource usage at the end of jobscript.

### DIFF
--- a/pipes/Broad_UGER/jobscript.sh
+++ b/pipes/Broad_UGER/jobscript.sh
@@ -20,7 +20,14 @@ source "$VENVDIR/bin/activate"
 # For this to work, re-run must be set to y via "qsub -r y"
 ls "$DATADIR" || exit 99
 
+echo $JOB_ID
+echo "=============================="
+
 {exec_job}
+
+# Report resource consumption because it's not reported by default
+echo "------------------------------"
+qstat -j $JOB_ID | grep '^usage'
 
 # if the job succeeds, snakemake 
 # touches jobfinished, thus if it exists cat succeeds. if cat fails, the error code indicates job failure


### PR DESCRIPTION
Since UGE doesn't provide this information by default, logging this will
help keep tabs on appropriate resource reqs

<!---
@huboard:{"order":313.125218781252,"milestone_order":353,"custom_state":""}
-->
