### PR TITLE
Tools simplification

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,6 @@
 coveralls==1.1
 flake8<=3
+pycodestyle
 mock==2.0.0
 six<2
 pytest-xdist==1.14

--- a/test/unit/test_tools_diamond.py
+++ b/test/unit/test_tools_diamond.py
@@ -3,38 +3,46 @@
 from builtins import super
 import collections
 import glob
+import mock
 import os.path
-from os.path import join
 import tempfile
 import unittest
-from mock import patch
-from util import file
+import util.file
 import util.misc
 import tools.diamond
-from test import TestCaseWithTmp
+import test
 
 
 CompletedProcess = collections.namedtuple(
     'CompletedProcess', ['args', 'returncode', 'stdout', 'stderr'])
 
 
-class TestToolDiamond(TestCaseWithTmp):
+class TestToolDiamond(test.TestCaseWithTmp):
 
     def setUp(self):
         super().setUp()
-        self.diamond = tools.diamond.Diamond()
-        self.diamond.install()
 
-        patcher = patch('util.misc.run_and_print', autospec=True)
+        patcher = mock.patch('subprocess.check_call', autospec=True)
         self.addCleanup(patcher.stop)
         self.mock_run = patcher.start()
         self.mock_run.return_value = CompletedProcess([], 0, '', '')
 
-        self.data_dir = join(util.file.get_test_input_path(), 'TestMetagenomicsSimple')
-        self.db_dir = join(self.data_dir, 'db')
+        patcher = mock.patch('tools.CondaPackage', autospec=True)
+        self.addCleanup(patcher.stop)
+        self.mock_conda = patcher.start()
+        self.mock_conda.return_value.verify_install.return_value = "mock"
+        self.mock_conda.return_value.is_attempted.return_value = True
+        self.mock_conda.return_value.is_installed.return_value = True
+        self.mock_conda.return_value.require_executability = False
+        self.mock_conda.return_value.executable_path.return_value = "/dev/null"
+
+        self.diamond = tools.diamond.Diamond()
+        self.diamond.install()
+        self.data_dir = os.path.join(util.file.get_test_input_path(), 'TestMetagenomicsSimple')
+        self.db_dir = os.path.join(self.data_dir, 'db')
 
     def test_create_and_blastx(self):
-        db = join(tempfile.tempdir, 'fake.dmnd')
+        db = os.path.join(tempfile.tempdir, 'fake.dmnd')
 
         # To be replaced with recursive glob in Python 3.5.
         protein_fastas = glob.glob('{}/library/*/*/*.ffn'.format(self.db_dir))
@@ -45,11 +53,11 @@ class TestToolDiamond(TestCaseWithTmp):
         self.assertIn('--db', args)
         self.assertIn(db, args)
 
-        inputs = [join(self.data_dir, f)
+        inputs = [os.path.join(self.data_dir, f)
                   for f in ['zaire_ebola.1.fastq', 'zaire_ebola.2.fastq']]
 
-        output = join(tempfile.tempdir, 'zaire_ebola.daa')
-        output_tab = join(tempfile.tempdir, 'zaire_ebola.m8')
+        output = os.path.join(tempfile.tempdir, 'zaire_ebola.daa')
+        output_tab = os.path.join(tempfile.tempdir, 'zaire_ebola.m8')
 
         tmpdir = tempfile.gettempdir()
         self.diamond.blastx(db, inputs, output, options={'--tmpdir': tmpdir})

--- a/test/unit/test_tools_kraken.py
+++ b/test/unit/test_tools_kraken.py
@@ -42,7 +42,7 @@ class TestToolKrakenMocked(TestCaseWithTmp):
     def test_kraken_classify(self):
         out_reads = util.file.mkstempfname('.reads.txt')
         self.kraken.classify(self.inBam, self.db, out_reads)
-        args = self.mock_run_and_print.call_args[0][0]
+        args = self.mock_check_call.call_args[0][0]
         self.assertEqual('kraken', os.path.basename(args[0]))
         self.assertTrue(util.misc.list_contains(['--db', self.db], args), args)
         self.assertTrue(util.misc.list_contains(['--output', out_reads], args), args)
@@ -73,7 +73,7 @@ class TestToolKrakenMocked(TestCaseWithTmp):
         out_reads = util.file.mkstempfname('.reads.txt')
         
         self.kraken.classify(self.inBam, self.db, out_reads)
-        args = self.mock_run_and_print.call_args[0][0]
+        args = self.mock_check_call.call_args[0][0]
         self.assertEqual('kraken', os.path.basename(args[0]))
         self.assertIn('--threads', args)
         actual = args[args.index('--threads')+1]
@@ -82,7 +82,7 @@ class TestToolKrakenMocked(TestCaseWithTmp):
         for requested in (1,2,3,8,11,20):
             expected = min(util.misc.available_cpu_count(), requested)
             self.kraken.classify(self.inBam, self.db, out_reads, numThreads=requested)
-            args = self.mock_run_and_print.call_args[0][0]
+            args = self.mock_check_call.call_args[0][0]
             self.assertEqual('kraken', os.path.basename(args[0]))
             self.assertIn('--threads', args)
             actual = args[args.index('--threads')+1]

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -8,6 +8,7 @@ import re
 import logging
 import tempfile
 import shutil
+import subprocess
 import util.file
 import util.misc
 import json
@@ -339,8 +340,7 @@ class CondaPackage(InstallMethod):
         file_path = os.path.join(self.env_path, path)
         patch_path = os.path.join(
             util.file.get_project_path(), 'tools', 'patches', patch)
-        return util.misc.run_and_print(['patch', file_path, patch_path],
-                                       check=True)
+        return subprocess.check_call(['patch', file_path, patch_path])
 
     @property
     def _package_installed(self):

--- a/tools/bmtagger.py
+++ b/tools/bmtagger.py
@@ -4,6 +4,7 @@ import tools
 import util.file
 import os
 import logging
+import subprocess
 from tools import urlretrieve
 _log = logging.getLogger(__name__)
 
@@ -37,7 +38,7 @@ class BmtaggerTools(tools.Tool):
     def execute(self, *args):
         cmd = [self.install_and_get_path()]
         cmd.extend(args)
-        util.misc.run_and_print(cmd, check=True)
+        subprocess.check_call(cmd)
 
 
 class BmtaggerShTool(BmtaggerTools):

--- a/tools/gatk.py
+++ b/tools/gatk.py
@@ -63,7 +63,7 @@ class GATKTool(tools.Tool):
             ] + list(map(str, gatkOptions))
 
         _log.debug(' '.join(tool_cmd))
-        util.misc.run_and_print(tool_cmd, check=True)
+        subprocess.check_call(tool_cmd)
 
     @staticmethod
     def dict_to_gatk_opts(options):

--- a/tools/kraken.py
+++ b/tools/kraken.py
@@ -127,7 +127,7 @@ class Kraken(tools.Tool):
         log.debug('Calling %s: %s', command, ' '.join(cmd))
 
         if command == 'kraken':
-            util.misc.run_and_print(cmd, check=True, silent=False)
+            subprocess.check_call(cmd)
         elif command == 'kraken-build':
             jellyfish_path = Jellyfish().install_and_get_path()
             env = os.environ.copy()

--- a/tools/mummer.py
+++ b/tools/mummer.py
@@ -48,7 +48,7 @@ class MummerTool(tools.Tool):
         toolCmd = [os.path.join(self.install_and_get_path(), 'mummer'),
             refFasta] + qryFastas
         log.debug(' '.join(toolCmd))
-        util.misc.run_and_print(toolCmd, check=True)
+        subprocess.check_call(toolCmd)
 
     def nucmer(self, refFasta, qryFasta, outDelta, extend=None, breaklen=None,
             maxgap=None, minmatch=None, mincluster=None):
@@ -72,7 +72,7 @@ class MummerTool(tools.Tool):
             toolCmd.extend(['--mincluster', str(mincluster)])
         toolCmd.extend([refFasta, qryFasta])
         log.debug(' '.join(toolCmd))
-        util.misc.run_and_print(toolCmd, check=True)
+        subprocess.check_call(toolCmd)
 
     def promer(self, refFasta, qryFasta, outDelta, extend=None, breaklen=None,
             maxgap=None, minmatch=None, mincluster=None):
@@ -96,7 +96,7 @@ class MummerTool(tools.Tool):
             toolCmd.extend(['--mincluster', str(mincluster)])
         toolCmd.extend([refFasta, qryFasta])
         log.debug(' '.join(toolCmd))
-        util.misc.run_and_print(toolCmd, check=True)
+        subprocess.check_call(toolCmd)
 
     def delta_filter(self, inDelta, outDelta):
         toolCmd = [os.path.join(self.install_and_get_path(), 'delta-filter'),

--- a/tools/muscle.py
+++ b/tools/muscle.py
@@ -68,7 +68,7 @@ class MuscleTool(tools.Tool):
             tool_cmd.extend(('-log', logFile))
 
         _log.debug(' '.join(tool_cmd))
-        util.misc.run_and_print(tool_cmd, check=True)
+        subprocess.check_call(tool_cmd)
     # pylint: enable=W0221
 
 

--- a/tools/mvicuna.py
+++ b/tools/mvicuna.py
@@ -7,7 +7,6 @@ import shutil
 
 import tools
 import util.file
-import util.misc
 
 # BroadUnixPath = '/gsap/garage-viral/viral/analysis/xyang/programs'\
 #                 '/M-Vicuna/bin/mvicuna'
@@ -60,7 +59,7 @@ class MvicunaTool(tools.Tool):
             outUnpaired, '-drm_op', ','.join(tmp1OutPair), '-tasks', 'DupRm'
         ]
         _log.debug(' '.join(cmdline))
-        util.misc.run_and_print(cmdline, check=True)
+        subprocess.check_call(cmdline)
         for tmpfname, outfname in zip(tmp2OutPair, outPair):
             shutil.copyfile(tmpfname, outfname)
 

--- a/tools/novoalign.py
+++ b/tools/novoalign.py
@@ -206,7 +206,7 @@ class NovoalignTool(tools.Tool):
             cmd.extend(['-s', str(s)])
         cmd.extend([outfname, refFasta])
         _log.debug(' '.join(cmd))
-        util.misc.run_and_print(cmd, check=True)
+        subprocess.check_call(cmd)
         try:
             mode = os.stat(outfname).st_mode & ~stat.S_IXUSR & ~stat.S_IXGRP & ~stat.S_IXOTH
             os.chmod(outfname, mode)

--- a/tools/picard.py
+++ b/tools/picard.py
@@ -9,6 +9,7 @@ import tempfile
 import shutil
 import pysam
 import shutil
+import subprocess
 import tools
 import tools.samtools
 import util.file
@@ -59,7 +60,7 @@ class PicardTools(tools.Tool):
                 self.install_and_get_path(), '-Xmx' + JVMmemory, '-Djava.io.tmpdir=' + tempfile.tempdir, command
             ] + picardOptions
         _log.debug(' '.join(tool_cmd))
-        util.misc.run_and_print(tool_cmd, check=True)
+        subprocess.check_call(tool_cmd)
 
     @staticmethod
     def dict_to_picard_opts(options):

--- a/tools/samtools.py
+++ b/tools/samtools.py
@@ -18,12 +18,11 @@
 import logging
 import tools
 import util.file
-import util.misc
 import os
 import os.path
 import subprocess
 from collections import OrderedDict
-import pysam
+#import pysam
 
 TOOL_NAME = 'samtools'
 TOOL_VERSION = '1.2'
@@ -39,17 +38,6 @@ class SamtoolsTool(tools.Tool):
         if install_methods is None:
             install_methods = []
             install_methods.append(tools.CondaPackage(TOOL_NAME, version=CONDA_TOOL_VERSION))
-            '''
-            install_methods.append(
-                tools.DownloadPackage(
-                    TOOL_URL,
-                    'samtools-{}/samtools'.format(TOOL_VERSION),
-                    post_download_command='cd samtools-{}; make -s'.format(
-                        TOOL_VERSION
-                    )
-                )
-            )
-            '''
         tools.Tool.__init__(self, install_methods=install_methods)
 
     def version(self):
@@ -104,8 +92,8 @@ class SamtoolsTool(tools.Tool):
                 os.unlink(outfname)
             else:
                 return
-        pysam.faidx(inFasta)
-        #self.execute('faidx', [inFasta])
+        #pysam.faidx(inFasta)
+        self.execute('faidx', [inFasta])
 
     def reheader(self, inBam, headerFile, outBam):
         self.execute('reheader', [headerFile, inBam], stdout=outBam)

--- a/tools/trimmomatic.py
+++ b/tools/trimmomatic.py
@@ -1,13 +1,10 @@
 "tools.Tool for trimmomatic."
 
+import subprocess
 import tools
-import util.misc
 
 TOOL_NAME = "trimmomatic"
 TOOL_VERSION = "0.35"
-
-TOOL_URL = 'http://www.usadellab.org/cms/uploads/supplementary/' \
-                 'Trimmomatic/Trimmomatic-0.32.zip'
 
 
 class TrimmomaticTool(tools.Tool):
@@ -16,14 +13,8 @@ class TrimmomaticTool(tools.Tool):
         if install_methods is None:
             install_methods = []
             install_methods.append(tools.CondaPackage(TOOL_NAME, version=TOOL_VERSION))
-            install_methods.append(
-                tools.DownloadPackage(
-                    TOOL_URL,
-                    'Trimmomatic-0.32/trimmomatic-0.32.jar',
-                    require_executability=False
-                )
-            )
         tools.Tool.__init__(self, install_methods=install_methods)
 
     def execute(self, *args):
-        util.misc.run_and_print(self.exec_path, args, check=True)
+        cmd = [self.exec_path] + args
+        subprocess.check_call(cmd)

--- a/util/misc.py
+++ b/util/misc.py
@@ -214,7 +214,13 @@ def run_and_print(args, stdout=None, stderr=None,
                            timeout=timeout, check=check)
             except subprocess.CalledProcessError as e:
                 if loglevel:
-                    log.log(loglevel, result.stdout.decode('utf-8'))
+                    try:
+                        log.log(loglevel, result.stdout.decode('utf-8'))
+                    except NameError:
+                        # in some situations, result does not get assigned anything
+                        pass
+                    except AttributeError:
+                        log.log(loglevel, result.output.decode('utf-8'))
                 else:
                     print(e.output.decode('utf-8'))
                     try:


### PR DESCRIPTION
- Revert samtools.faidx to call samtools instead of pysam (fix transient errors on travis py3.5).
- Ease debuggability of diamond (partly to help debug current failures on dnanexus CI) and a simplify a bunch of code by reverting all simple run_and_print calls to subprocess.check_call (any scenario where silent=False, check=True, and no output is captured, no env is specified, etc).
- Remove a few non-conda installers for some tools.