### PR TITLE
Fix JSON serializability bug

### DIFF
--- a/pipes/rules/interhost.rules
+++ b/pipes/rules/interhost.rules
@@ -71,10 +71,10 @@ rule ref_guided_diversity:
             refGenome=os.path.join(config["ref_genome_dir"],"reference"+".fasta"),
             inFastas = expand("{data_dir}/{subdir}/{sample}.fasta",
                 data_dir=config["data_dir"], subdir=config["subdirs"]["align_ref"],
-                sample=read_samples_file(config["samples_per_run"])),
+                sample=list(read_samples_file(config["samples_per_run"]))),
             inVcfs = expand("{data_dir}/{subdir}/{sample}.vcf.gz",
                 data_dir=config["data_dir"], subdir=config["subdirs"]["align_ref"],
-                sample=read_samples_file(config["samples_per_run"]))
+                sample=list(read_samples_file(config["samples_per_run"])))
     run:
             update_timestamps(input)
             shell("cat {params.inFastas} > {output[0]}")
@@ -101,7 +101,7 @@ rule multi_align_mafft:
             logid="all",
             refGenome=os.path.join(config["ref_genome_dir"],"reference"+".fasta"),
             snpEff_ref=config["accessions_for_ref_genome_build"],
-            samples=read_samples_file(config["samples_assembly"]),
+            samples=list(read_samples_file(config["samples_assembly"])),
             ep=str(config["mafft_ep"]),
             maxiters=str(config["mafft_maxiters"]),
             numThreads=str(config.get("number_of_threads", 1))

--- a/pipes/rules/intrahost.rules
+++ b/pipes/rules/intrahost.rules
@@ -56,7 +56,7 @@ rule isnvs_vcf:
             emailAddress=config["email_point_of_contact_for_ncbi"]
     run:
             shell("{config[bin_dir]}/intrahost.py merge_to_vcf {params.refGenome} {output[0]}"
-                + " --samples {params.samples}"
+                + " --samples " + " ".join(params.samples)
                 + " --isnvs " + " ".join(["{config[data_dir]}/{config[subdirs][intrahost]}/vphaser2."+s+".txt.gz" for s in params.samples])
                 + " --alignments " + " ".join(["{config[data_dir]}/{config[subdirs][multialign_ref]}/aligned_" + str(n) + ".fasta" for n in range(1, len(config["accessions_for_ref_genome_build"])+1)])
                 + " --strip_chr_version"
@@ -90,7 +90,7 @@ rule isnvs_vcf_filtered:
             emailAddress=config["email_point_of_contact_for_ncbi"]
     run:
             shell("{config[bin_dir]}/intrahost.py merge_to_vcf {params.refGenome} {output[0]}"
-                + " --samples {params.samples}"
+                + " --samples " + " ".join(params.samples)
                 + " --isnvs " + " ".join(["{config[data_dir]}/{config[subdirs][intrahost]}/vphaser2."+s+".txt.gz" for s in params.samples])
                 + " --alignments " + " ".join(["{config[data_dir]}/{config[subdirs][multialign_ref]}/aligned_" + str(n) + ".fasta" for n in range(1, len(config["accessions_for_ref_genome_build"])+1)])
                 + " --strip_chr_version"

--- a/pipes/rules/intrahost.rules
+++ b/pipes/rules/intrahost.rules
@@ -7,7 +7,6 @@ __author__ = 'Daniel Park <dpark@broadinstitute.org>'
 from snakemake.utils import makedirs
 import os, os.path, time
 
-
 rule all_intrahost:
     input:
             config["data_dir"]+'/'+config["subdirs"]["intrahost"] +'/isnvs.vcf.gz',
@@ -53,7 +52,7 @@ rule isnvs_vcf:
             logid="all",
             refGenome=os.path.join(config["ref_genome_dir"],"reference"+".fasta"),
             snpEff_ref=config["accessions_for_ref_genome_build"],
-            samples=read_samples_file(config["samples_assembly"]),
+            samples=list(read_samples_file(config["samples_assembly"])),
             emailAddress=config["email_point_of_contact_for_ncbi"]
     run:
             shell("{config[bin_dir]}/intrahost.py merge_to_vcf {params.refGenome} {output[0]}"
@@ -87,7 +86,7 @@ rule isnvs_vcf_filtered:
             logid="all",
             refGenome=os.path.join(config["ref_genome_dir"],"reference"+".fasta"),
             snpEff_ref=config["accessions_for_ref_genome_build"],
-            samples=read_samples_file(config["samples_assembly"]),
+            samples=list(read_samples_file(config["samples_assembly"])),
             emailAddress=config["email_point_of_contact_for_ncbi"]
     run:
             shell("{config[bin_dir]}/intrahost.py merge_to_vcf {params.refGenome} {output[0]}"

--- a/pipes/rules/ncbi.rules
+++ b/pipes/rules/ncbi.rules
@@ -105,7 +105,7 @@ rule prepare_genbank:
                 UGER=config.get('UGER_queues', {}).get('short', '-q short'),
                 fasta_files=expand("{dir}/{subdir}/{sample}.fasta",
                     dir=[config["data_dir"]], subdir=[config["subdirs"]["assembly"]],
-                    sample=read_samples_file(config["samples_assembly"])),
+                    sample=list(read_samples_file(config["samples_assembly"]))),
                 genbank_template=config.get('genbank',{}).get('author_template', ''),
                 genbank_source_table=config.get('genbank',{}).get('source_modifier_table', ''),
                 biosample_map=config.get('genbank',{}).get('biosample_map', ''),


### PR DESCRIPTION
When passing information into params, snakemake requires that it be
JSON serializable. However, `read_samples_file` is a generator and
is not serializable. snakemake fails with `TypeError: <generator
object read_samples_file at ... is not JSON serializable>`. This
fix wraps the call to `read_samples_file` with list(..) to obtain
the output of the generator, which can be serialized.