### PR TITLE
change num_threads=0 for IlluminaBasecallsConverter

### DIFF
--- a/tools/picard.py
+++ b/tools/picard.py
@@ -292,7 +292,7 @@ class IlluminaBasecallsToSamTool(PicardTools):
         'adapters_to_check': ('PAIRED_END', 'NEXTERA_V1', 'NEXTERA_V2'),
         'max_reads_in_ram_per_tile': 100000,
         'max_records_in_ram': 100000,
-        'num_processors': 4,
+        'num_processors': 0, # 0 = all available
         'force_gc': False,
         'include_non_pf_reads': False,
     }


### PR DESCRIPTION
pass num_threads=0 to picard’s IlluminaBasecallsToSam so that
IlluminaBasecallsConverter uses all available cores rather than the 4
cores previously hard-coded