### PR TITLE
join accessions list into space-separated string

### DIFF
--- a/pipes/rules/ncbi.rules
+++ b/pipes/rules/ncbi.rules
@@ -26,7 +26,7 @@ rule download_reference_genome:
         expand( '{refDir}/'+'{feature_tbl_name}.tbl', refDir=config["ref_genome_dir"], feature_tbl_name=config["accessions_for_ref_genome_build"] )
     params:
         emailAddress=config["email_point_of_contact_for_ncbi"],
-        accessionsList=config["accessions_for_ref_genome_build"]
+        accessionsList=" ".join(config["accessions_for_ref_genome_build"])
     run:
         makedirs( expand( "{dir}", dir=[config["ref_genome_dir"]] ) )
         shell("{config[bin_dir]}/ncbi.py fetch_fastas {params.emailAddress} {config[ref_genome_dir]} {params.accessionsList} --combinedFilePrefix reference --removeSeparateFiles --forceOverwrite")


### PR DESCRIPTION
fairly sure this was a non-issue before. bug introduced by a newer version of Snakemake?