### PR TITLE
add post_verify_command to CondaPackage; copy novoalign.lic

### DIFF
--- a/tools/novoalign.py
+++ b/tools/novoalign.py
@@ -40,7 +40,9 @@ class NovoalignTool(tools.Tool):
                     )
                 )
         if os.environ.get("NOVOALIGN_LICENSE_PATH"):
-            install_methods.append(tools.CondaPackage(TOOL_NAME, version=TOOL_VERSION, post_install_command="cp $NOVOALIGN_LICENSE_PATH ./"))
+            # called relative to the conda bin/ directory
+            post_verify_command = "cp {lic_path} ./".format(lic_path=os.environ.get("NOVOALIGN_LICENSE_PATH"))
+            install_methods.append(tools.CondaPackage(TOOL_NAME, version=TOOL_VERSION, post_verify_command=post_verify_command))
         else:
             install_methods.append(tools.CondaPackage(TOOL_NAME, version=TOOL_VERSION))
         tools.Tool.__init__(self, install_methods=install_methods)


### PR DESCRIPTION
Add a post_verify_command to CondaPackage that will run after an
install has been verified. Use this to copy in the novoalign.lic file
if the environment variable NOVOALIGN_LICENSE_PATH is set.
post_verify_command is memoized and only run once if successful.