### PR TITLE
hide "Undocumented" for subparser help on RTD

### DIFF
--- a/util/cmd.py
+++ b/util/cmd.py
@@ -158,7 +158,11 @@ def make_parser(commands, description):
         parser.add_argument('--version', '-V', action='version', version=__version__, help=argparse.SUPPRESS)
         subparsers = parser.add_subparsers(title='subcommands', dest='command', metavar='\033[F') # \033[F moves cursor up
         for cmd_name, cmd_parser in commands:
-            p = subparsers.add_parser(cmd_name, help=cmd_parser.__doc__)
+            if os.environ.get('READTHEDOCS'):
+                p = subparsers.add_parser(cmd_name, help="  ")
+            else:
+                help_str = cmd_parser.__doc__ if cmd_parser.__doc__ and len(cmd_parser.__doc__) else None
+                p = subparsers.add_parser(cmd_name, help=help_str)
             cmd_parser(p)
     return parser
 

--- a/util/cmd.py
+++ b/util/cmd.py
@@ -156,9 +156,9 @@ def make_parser(commands, description):
         parser = argparse.ArgumentParser(description=description, usage='%(prog)s subcommand', add_help=False)
         parser.add_argument('--help', '-h', action=_HelpAction, help=argparse.SUPPRESS)
         parser.add_argument('--version', '-V', action='version', version=__version__, help=argparse.SUPPRESS)
-        subparsers = parser.add_subparsers(title='subcommands', dest='command')
+        subparsers = parser.add_subparsers(title='subcommands', dest='command', metavar='\033[F') # \033[F moves cursor up
         for cmd_name, cmd_parser in commands:
-            p = subparsers.add_parser(cmd_name)
+            p = subparsers.add_parser(cmd_name, help=cmd_parser.__doc__)
             cmd_parser(p)
     return parser
 

--- a/util/cmd.py
+++ b/util/cmd.py
@@ -158,11 +158,12 @@ def make_parser(commands, description):
         parser.add_argument('--version', '-V', action='version', version=__version__, help=argparse.SUPPRESS)
         subparsers = parser.add_subparsers(title='subcommands', dest='command', metavar='\033[F') # \033[F moves cursor up
         for cmd_name, cmd_parser in commands:
-            if os.environ.get('READTHEDOCS'):
-                p = subparsers.add_parser(cmd_name, help="  ")
-            else:
-                help_str = cmd_parser.__doc__ if cmd_parser.__doc__ and len(cmd_parser.__doc__) else None
-                p = subparsers.add_parser(cmd_name, help=help_str)
+            help_str = cmd_parser.__doc__ if cmd_parser.__doc__ and len(cmd_parser.__doc__) else None
+            # give a blank string for help if the parser docstring is null
+            # so sphinx-argparse doesnt't render "Undocumented"
+            if (not help_str) and os.environ.get('READTHEDOCS') or 'sphinx' in sys.modules:
+                help_str = "   "
+            p = subparsers.add_parser(cmd_name, help=help_str)
             cmd_parser(p)
     return parser
 


### PR DESCRIPTION
give a blank string for subparser help if the parser function docstring is null so sphinx-argparse doesn't render "Undocumented”. Only make this change when interpreted by sphinx because argparse itself can’t handle blank help strings

![screen shot 2016-06-29 at 3 00 11 pm](https://cloud.githubusercontent.com/assets/53064/16464934/6f6f2094-3e0a-11e6-9626-c0e44f66f9db.png)