### PR TITLE
explicitly specify python as the interpreter for maf-convert

### DIFF
--- a/taxon_filter.py
+++ b/taxon_filter.py
@@ -275,7 +275,7 @@ def lastal_chunked_fastq(
 
             mafconvert_out = mkstempfname('.mafconvert')
             with open(mafconvert_out, 'wt') as outf:
-                cmd = [mafconvert_path, 'tab', mafsort_out]
+                cmd = ["python", mafconvert_path, 'tab', mafsort_out]
                 log.debug(' '.join(cmd) + ' > ' + mafconvert_out)
                 subprocess.check_call(cmd, stdout=outf)
             os.unlink(mafsort_out)


### PR DESCRIPTION
explicitly specify python as the interpreter for maf-convert, since
conda has a bug where long shebang prefixes are broken