### PR TITLE
move pytest from requirements to requirements-tests

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,3 +1,4 @@
+pytest==2.9.1
 coveralls==1.1
 pycodestyle
 mock==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@
 biopython==1.64
 future>=0.15.2
 futures==3.0.3; python_version == '2.6' or python_version=='2.7'
-pytest==2.9.1
 pysam==0.8.3
 PyYAML==3.11


### PR DESCRIPTION
py.test no longer required for installation of viral-ngs