### PR TITLE
pre-assembly filter updates

### DIFF
--- a/assembly.py
+++ b/assembly.py
@@ -73,8 +73,6 @@ def trim_rmdup_subsamp_reads(inBam, clipDb, outBam, n_reads=100000):
             shutil.copyfile(infq[i], trimfq[i])
     else:
         taxon_filter.trimmomatic(infq[0], infq[1], trimfq[0], trimfq[1], clipDb)
-    os.unlink(infq[0])
-    os.unlink(infq[1])
     n_trim = max(map(util.file.count_fastq_reads, trimfq))
 
     # Prinseq duplicate removal
@@ -89,8 +87,6 @@ def trim_rmdup_subsamp_reads(inBam, clipDb, outBam, n_reads=100000):
         prinseq = tools.prinseq.PrinseqTool()
         prinseq.rmdup_fastq_paired(trimfq[0], trimfq[1], rmdupfq[0], rmdupfq[1], purgeUnmated=False)
         n_rmdup = max(map(util.file.count_fastq_reads, rmdupfq))
-    os.unlink(trimfq[0])
-    os.unlink(trimfq[1])
 
     # Purge unmated
     purgefq = list(map(util.file.mkstempfname, ['.mated.1.fastq', '.mated.2.fastq']))
@@ -106,8 +102,6 @@ def trim_rmdup_subsamp_reads(inBam, clipDb, outBam, n_reads=100000):
         if n_purge < n_reads:
             log.warn("We purged %s reads down to %s mated reads, which is below subsample threshold (%s). TO DO: add smarter subsampling in this scenario. Proceeding with %s mated reads for now." %(
                 n_rmdup, n_purge, n_reads, n_purge))
-    os.unlink(rmdupfq[0])
-    os.unlink(rmdupfq[1])
 
     # Log count
     log.info("PRE-SUBSAMPLE COUNT: %s read pairs", n_purge)
@@ -132,8 +126,6 @@ def trim_rmdup_subsamp_reads(inBam, clipDb, outBam, n_reads=100000):
                subsampfq[0],
                subsampfq[1],]
         util.misc.run_and_print(cmd, check=True)
-    os.unlink(purgefq[0])
-    os.unlink(purgefq[1])
     n_subsamp = util.file.count_fastq_reads(subsampfq[0])
 
     # Fastq -> BAM
@@ -153,11 +145,13 @@ def trim_rmdup_subsamp_reads(inBam, clipDb, outBam, n_reads=100000):
         tools.samtools.SamtoolsTool().reheader(tmp_bam, tmp_header, outBam)
     os.unlink(tmp_bam)
     os.unlink(tmp_header)
-    os.unlink(subsampfq[0])
-    os.unlink(subsampfq[1])
     
     log.info("Pre-Trinity read filters: %s reads at start. %s reads after Trimmomatic. %s reads after Prinseq rmdup. %s reads after removing unpaired mates. %s reads after subsampling.",
              n_input, n_trim, n_rmdup, n_purge, n_subsamp)
+    # clean up temp files
+    for i in range(2):
+        for f in infq, trimfq, rmdupfq, purgefq, subsampfq:
+            os.unlink(f[i])
     return (n_input, n_trim, n_rmdup, n_purge, n_subsamp)
 
 
@@ -180,7 +174,7 @@ def parser_trim_rmdup_subsamp(parser=argparse.ArgumentParser()):
 __commands__.append(('trim_rmdup_subsamp', parser_trim_rmdup_subsamp))
 
 
-def assemble_trinity(inBam, outFasta, clipDb,
+def assemble_trinity(inBam, clipDb, outFasta,
     n_reads=100000, outReads=None, always_succeed=False,
     JVMmemory=None, threads=1):
     ''' This step runs the Trinity assembler.

--- a/read_utils.py
+++ b/read_utils.py
@@ -810,24 +810,6 @@ def main_dup_remove_mvicuna(args):
 __commands__.append(('dup_remove_mvicuna', parser_dup_remove_mvicuna))
 
 
-def rmdup_prinseq_fastq(inFastq, outFastq):
-    # remove duplicate reads and reads with multiple Ns
-    if not outFastq.endswith('.fastq'):
-        raise Exception()
-    if os.path.getsize(inFastq) == 0:
-        # prinseq-lite fails on empty file input (which can happen in real life
-        # if no reads match the refDbs) so handle this scenario specially
-        log.info("output is empty: no reads in input match refDb")
-        shutil.copyfile(inFastq, outFastq)
-    else:
-        cmd = [
-            'perl', tools.prinseq.PrinseqTool().install_and_get_path(), '-ns_max_n', '1', '-derep', '1', '-fastq',
-            inFastq, '-out_bad', 'null', '-line_width', '0', '-out_good', outFastq[:-6]
-        ]
-        log.debug(' '.join(cmd))
-        util.misc.run_and_print(cmd, check=True)
-
-
 def parser_rmdup_prinseq_fastq(parser=argparse.ArgumentParser()):
     parser.add_argument('inFastq1', help='Input fastq file; 1st end of paired-end reads.')
     parser.add_argument('inFastq2', help='Input fastq file; 2nd end of paired-end reads.')
@@ -842,8 +824,8 @@ def main_rmdup_prinseq_fastq(args):
     ''' Run prinseq-lite's duplicate removal operation on paired-end
         reads.  Also removes reads with more than one N.
     '''
-    rmdup_prinseq_fastq(args.inFastq1, args.outFastq1)
-    rmdup_prinseq_fastq(args.inFastq2, args.outFastq2)
+    prinseq = tools.prinseq.PrinseqTool()
+    prinseq.rmdup_fastq_paired(args.inFastq1, args.inFastq2, args.outFastq1, args.outFastq2)
     return 0
 
 

--- a/test/unit/test_assembly.py
+++ b/test/unit/test_assembly.py
@@ -39,13 +39,15 @@ class TestCommandHelp(unittest.TestCase):
 class TestAssembleTrinity(TestCaseWithTmp):
     ''' Test the assemble_trinity command (no validation of output) '''
 
-    def test_execution(self):
+    def test_assembly(self):
         inDir = util.file.get_test_input_path(self)
         inBam = os.path.join(inDir, '..', 'G5012.3.subset.bam')
         clipDb = os.path.join(inDir, 'clipDb.fasta')
         outFasta = util.file.mkstempfname('.fasta')
-        assembly.assemble_trinity(inBam, outFasta, clipDb, threads=4)
+        assembly.assemble_trinity(inBam, clipDb, outFasta, threads=4)
         self.assertGreater(os.path.getsize(outFasta), 0)
+        contig_lens = list(sorted(len(seq.seq) for seq in Bio.SeqIO.parse(outFasta, 'fasta')))
+        self.assertEqual(contig_lens, [328, 328, 376])
         os.unlink(outFasta)
 
     def test_empty_input_succeed(self):
@@ -53,7 +55,7 @@ class TestAssembleTrinity(TestCaseWithTmp):
         inBam = os.path.join(inDir, 'empty.bam')
         clipDb = os.path.join(inDir, 'TestAssembleTrinity', 'clipDb.fasta')
         outFasta = util.file.mkstempfname('.fasta')
-        assembly.assemble_trinity(inBam, outFasta, clipDb, threads=4, always_succeed=True)
+        assembly.assemble_trinity(inBam, clipDb, outFasta, threads=4, always_succeed=True)
         self.assertEqual(os.path.getsize(outFasta), 0)
         os.unlink(outFasta)
 
@@ -64,7 +66,56 @@ class TestAssembleTrinity(TestCaseWithTmp):
         outFasta = util.file.mkstempfname('.fasta')
         self.assertRaises(assembly.DenovoAssemblyError,
             assembly.assemble_trinity,
-            inBam, outFasta, clipDb, threads=4, always_succeed=False)
+            inBam, clipDb, outFasta, threads=4, always_succeed=False)
+
+
+class TestTrimRmdupSubsamp(TestCaseWithTmp):
+    ''' Test the trim_rmdup_subsamp command '''
+
+    def test_subsamp_empty(self):
+        inDir = util.file.get_test_input_path()
+        inBam = os.path.join(inDir, 'empty.bam')
+        clipDb = os.path.join(inDir, 'TestAssembleTrinity', 'clipDb.fasta')
+        outBam = util.file.mkstempfname('.out.bam')
+        read_stats = assembly.trim_rmdup_subsamp_reads(inBam, clipDb, outBam, n_reads=10)
+        os.unlink(outBam)
+        self.assertEqual(read_stats, (0,0,0,0,0))
+
+    def test_subsamp_small_50(self):
+        inDir = util.file.get_test_input_path()
+        inBam = os.path.join(inDir, 'G5012.3.subset.bam')
+        clipDb = os.path.join(inDir, 'TestAssembleTrinity', 'clipDb.fasta')
+        outBam = util.file.mkstempfname('.out.bam')
+        read_stats = assembly.trim_rmdup_subsamp_reads(inBam, clipDb, outBam, n_reads=50)
+        os.unlink(outBam)
+        self.assertEqual(read_stats, (100,86,86,86,50))
+
+    def test_subsamp_small_90(self):
+        inDir = util.file.get_test_input_path()
+        inBam = os.path.join(inDir, 'G5012.3.subset.bam')
+        clipDb = os.path.join(inDir, 'TestAssembleTrinity', 'clipDb.fasta')
+        outBam = util.file.mkstempfname('.out.bam')
+        read_stats = assembly.trim_rmdup_subsamp_reads(inBam, clipDb, outBam, n_reads=90)
+        os.unlink(outBam)
+        self.assertEqual(read_stats, (100,86,86,86,86))
+
+    def test_subsamp_small_200(self):
+        inDir = util.file.get_test_input_path()
+        inBam = os.path.join(inDir, 'G5012.3.subset.bam')
+        clipDb = os.path.join(inDir, 'TestAssembleTrinity', 'clipDb.fasta')
+        outBam = util.file.mkstempfname('.out.bam')
+        read_stats = assembly.trim_rmdup_subsamp_reads(inBam, clipDb, outBam, n_reads=200)
+        os.unlink(outBam)
+        self.assertEqual(read_stats, (100,86,86,86,86))
+
+    def test_subsamp_big_500(self):
+        inDir = util.file.get_test_input_path()
+        inBam = os.path.join(inDir, 'G5012.3.testreads.bam')
+        clipDb = os.path.join(inDir, 'TestAssembleTrinity', 'clipDb.fasta')
+        outBam = util.file.mkstempfname('.out.bam')
+        read_stats = assembly.trim_rmdup_subsamp_reads(inBam, clipDb, outBam, n_reads=500)
+        os.unlink(outBam)
+        self.assertEqual(read_stats, (9355,8155,8155,8155,500))
 
 
 class TestAmbiguityBases(unittest.TestCase):

--- a/tools/prinseq.py
+++ b/tools/prinseq.py
@@ -5,6 +5,7 @@ import os.path
 import shutil
 import subprocess
 import tools
+import util.file
 
 TOOL_NAME = "prinseq"
 TOOL_VERSION = '0.20.4'
@@ -20,38 +21,49 @@ class PrinseqTool(tools.Tool):
         tools.Tool.__init__(self, install_methods=install_methods)
 
     def rmdup_fastq_single(inFastq, outFastq):
-	    # remove duplicate reads and reads with multiple Ns
-	    if not outFastq.endswith('.fastq'):
-	        raise Exception()
-	    if os.path.getsize(inFastq) == 0:
-	        # prinseq-lite fails on empty file input (which can happen in real life
-	        # if no reads match the refDbs) so handle this scenario specially
-	        log.info("output is empty: no reads in input match refDb")
-	        shutil.copyfile(inFastq, outFastq)
-	    else:
-	        cmd = [
-	            'perl', self.install_and_get_path(), '-ns_max_n', '1', '-derep', '1', '-fastq',
-	            inFastq, '-out_bad', 'null', '-line_width', '0', '-out_good', outFastq[:-6]
-	        ]
-	        log.debug(' '.join(cmd))
-	        subprocess.check_call(cmd)
+        ''' remove duplicate reads and reads with multiple Ns '''
 
-    def rmdup_fastq_paired(inFastq1, inFastq2, outFastq1, outFastq2):
-        self.rmdup_fastq_single(inFastq1, outFastq1)
-        self.rmdup_fastq_single(inFastq2, outFastq2)
-        return
-	    # remove duplicate reads and reads with multiple Ns
-	    if not outFastq.endswith('.fastq'):
-	        raise Exception()
-	    if os.path.getsize(inFastq) == 0:
-	        # prinseq-lite fails on empty file input (which can happen in real life
-	        # if no reads match the refDbs) so handle this scenario specially
-	        log.info("output is empty: no reads in input match refDb")
-	        shutil.copyfile(inFastq, outFastq)
-	    else:
-	        cmd = [
-	            'perl', self.install_and_get_path(), '-ns_max_n', '1', '-derep', '1', '-fastq',
-	            inFastq, '-out_bad', 'null', '-line_width', '0', '-out_good', outFastq[:-6]
-	        ]
-	        log.debug(' '.join(cmd))
-	        subprocess.check_call(cmd)
+        outprefix = util.file.mkstempfname("-prinseq-rmdup-out")
+        if os.path.getsize(inFastq) == 0:
+            # prinseq-lite fails on empty file input so handle this scenario specially
+            log.debug("prinseq input is empty")
+            shutil.copyfile(inFastq, outFastq)
+        else:
+            cmd = [
+                'perl', self.install_and_get_path(), '-verbose',
+                '-ns_max_n', '1', '-derep', '1',
+                '-fastq', inFastq,
+                '-out_bad', 'null', '-line_width', '0', '-out_good', outprefix
+            ]
+            log.debug(' '.join(cmd))
+            subprocess.check_call(cmd)
+            shutil.copyfile(outprefix+'.fastq', outFastq)
+            os.unlink(outprefix+'.fastq')
+
+    def rmdup_fastq_paired(inFastq1, inFastq2, outFastq1, outFastq2, purgeUnmated=False):
+        ''' remove duplicate reads and reads with multiple Ns '''
+
+        outprefix = util.file.mkstempfname("-prinseq-rmdup-out")
+        if os.path.getsize(inFastq) == 0:
+            # prinseq-lite fails on empty file input so handle this scenario specially
+            log.debug("prinseq input is empty")
+            shutil.copyfile(inFastq, outFastq)
+        else:
+            cmd = [
+                'perl', self.install_and_get_path(), '-verbose',
+                '-ns_max_n', '1', '-derep', '1',
+                '-fastq', inFastq1, '-fastq2', inFastq2,
+                '-out_bad', 'null', '-line_width', '0', '-out_good', outprefix
+            ]
+            log.debug(' '.join(cmd))
+            subprocess.check_call(cmd)
+            if purgeUnmated:
+                shutil.copyfile(outprefix+'_1.fastq', outFastq1)
+                shutil.copyfile(outprefix+'_2.fastq', outFastq2)
+            else:
+                util.file.cat(outFastq1, outprefix+'_1.fastq', outprefix+'_1_singletons.fastq')
+                util.file.cat(outFastq2, outprefix+'_2.fastq', outprefix+'_2_singletons.fastq')
+            os.unlink(outprefix+'_1.fastq')
+            os.unlink(outprefix+'_2.fastq')
+            os.unlink(outprefix+'_1_singletons.fastq')
+            os.unlink(outprefix+'_2_singletons.fastq')

--- a/tools/prinseq.py
+++ b/tools/prinseq.py
@@ -20,15 +20,15 @@ class PrinseqTool(tools.Tool):
             install_methods.append(tools.CondaPackage(TOOL_NAME, executable="prinseq-lite.pl", version=TOOL_VERSION))
         tools.Tool.__init__(self, install_methods=install_methods)
 
-    def rmdup_fastq_single(inFastq, outFastq):
+    def rmdup_fastq_single(self, inFastq, outFastq):
         ''' remove duplicate reads and reads with multiple Ns '''
 
-        outprefix = util.file.mkstempfname("-prinseq-rmdup-out")
         if os.path.getsize(inFastq) == 0:
             # prinseq-lite fails on empty file input so handle this scenario specially
             log.debug("prinseq input is empty")
             shutil.copyfile(inFastq, outFastq)
         else:
+            outprefix = util.file.mkstempfname("-prinseq-rmdup-out")
             cmd = [
                 'perl', self.install_and_get_path(), '-verbose',
                 '-ns_max_n', '1', '-derep', '1',
@@ -40,15 +40,25 @@ class PrinseqTool(tools.Tool):
             shutil.copyfile(outprefix+'.fastq', outFastq)
             os.unlink(outprefix+'.fastq')
 
-    def rmdup_fastq_paired(inFastq1, inFastq2, outFastq1, outFastq2, purgeUnmated=False):
+    def rmdup_fastq_paired(self, inFastq1, inFastq2, outFastq1, outFastq2, purgeUnmated=False):
         ''' remove duplicate reads and reads with multiple Ns '''
 
-        outprefix = util.file.mkstempfname("-prinseq-rmdup-out")
-        if os.path.getsize(inFastq) == 0:
+        if not os.path.exists(inFastq2) or os.path.getsize(inFastq2) == 0:
+            # input is single-end
+            log.debug("prinseq input is unpaired")
+            util.file.touch(outFastq2)
+            if purgeUnmated:
+                # purgeUnmated on unpaired input implies no output
+                util.file.touch(outFastq1)
+            else:
+                self.rmdup_fastq_single(inFastq1, outFastq1)
+        elif os.path.getsize(inFastq1) == 0:
             # prinseq-lite fails on empty file input so handle this scenario specially
             log.debug("prinseq input is empty")
-            shutil.copyfile(inFastq, outFastq)
+            util.file.touch(outFastq1)
+            util.file.touch(outFastq2)
         else:
+            outprefix = util.file.mkstempfname("-prinseq-rmdup-out")
             cmd = [
                 'perl', self.install_and_get_path(), '-verbose',
                 '-ns_max_n', '1', '-derep', '1',
@@ -57,12 +67,16 @@ class PrinseqTool(tools.Tool):
             ]
             log.debug(' '.join(cmd))
             subprocess.check_call(cmd)
+            for fn in (outprefix+'_1.fastq', outprefix+'_1_singletons.fastq',
+                    outprefix+'_2.fastq', outprefix+'_2_singletons.fastq'):
+                # if any of the four output files is empty, prinseq doesn't create it at all, which is bad for us
+                util.file.touch(fn)
             if purgeUnmated:
                 shutil.copyfile(outprefix+'_1.fastq', outFastq1)
                 shutil.copyfile(outprefix+'_2.fastq', outFastq2)
             else:
-                util.file.cat(outFastq1, outprefix+'_1.fastq', outprefix+'_1_singletons.fastq')
-                util.file.cat(outFastq2, outprefix+'_2.fastq', outprefix+'_2_singletons.fastq')
+                util.file.cat(outFastq1, (outprefix+'_1.fastq', outprefix+'_1_singletons.fastq'))
+                util.file.cat(outFastq2, (outprefix+'_2.fastq', outprefix+'_2_singletons.fastq'))
             os.unlink(outprefix+'_1.fastq')
             os.unlink(outprefix+'_2.fastq')
             os.unlink(outprefix+'_1_singletons.fastq')

--- a/tools/prinseq.py
+++ b/tools/prinseq.py
@@ -1,9 +1,15 @@
 "tools.Tool for prinseq."
 
+import logging
+import os.path
+import shutil
+import subprocess
 import tools
 
 TOOL_NAME = "prinseq"
 TOOL_VERSION = '0.20.4'
+
+log = logging.getLogger(__name__)
 
 class PrinseqTool(tools.Tool):
 
@@ -12,3 +18,40 @@ class PrinseqTool(tools.Tool):
             install_methods = []
             install_methods.append(tools.CondaPackage(TOOL_NAME, executable="prinseq-lite.pl", version=TOOL_VERSION))
         tools.Tool.__init__(self, install_methods=install_methods)
+
+    def rmdup_fastq_single(inFastq, outFastq):
+	    # remove duplicate reads and reads with multiple Ns
+	    if not outFastq.endswith('.fastq'):
+	        raise Exception()
+	    if os.path.getsize(inFastq) == 0:
+	        # prinseq-lite fails on empty file input (which can happen in real life
+	        # if no reads match the refDbs) so handle this scenario specially
+	        log.info("output is empty: no reads in input match refDb")
+	        shutil.copyfile(inFastq, outFastq)
+	    else:
+	        cmd = [
+	            'perl', self.install_and_get_path(), '-ns_max_n', '1', '-derep', '1', '-fastq',
+	            inFastq, '-out_bad', 'null', '-line_width', '0', '-out_good', outFastq[:-6]
+	        ]
+	        log.debug(' '.join(cmd))
+	        subprocess.check_call(cmd)
+
+    def rmdup_fastq_paired(inFastq1, inFastq2, outFastq1, outFastq2):
+        self.rmdup_fastq_single(inFastq1, outFastq1)
+        self.rmdup_fastq_single(inFastq2, outFastq2)
+        return
+	    # remove duplicate reads and reads with multiple Ns
+	    if not outFastq.endswith('.fastq'):
+	        raise Exception()
+	    if os.path.getsize(inFastq) == 0:
+	        # prinseq-lite fails on empty file input (which can happen in real life
+	        # if no reads match the refDbs) so handle this scenario specially
+	        log.info("output is empty: no reads in input match refDb")
+	        shutil.copyfile(inFastq, outFastq)
+	    else:
+	        cmd = [
+	            'perl', self.install_and_get_path(), '-ns_max_n', '1', '-derep', '1', '-fastq',
+	            inFastq, '-out_bad', 'null', '-line_width', '0', '-out_good', outFastq[:-6]
+	        ]
+	        log.debug(' '.join(cmd))
+	        subprocess.check_call(cmd)

--- a/util/file.py
+++ b/util/file.py
@@ -430,7 +430,7 @@ def count_str_in_file(in_file, query_str, starts_with=False):
         n = 0
         with gzip.open(in_file, 'rt') as inf:
             if starts_with:
-                n = sum(1 for line in inf if line[0]==query_str)
+                n = sum(1 for line in inf if line.startswith(query_str))
             else:
                 n = sum(1 for line in inf if query_str in line)
         return n

--- a/util/file.py
+++ b/util/file.py
@@ -448,7 +448,20 @@ def count_fastq_reads(inFastq):
     '''
         Count number of reads in fastq file
     '''
-    return count_str_in_file(inFastq, '@', starts_with=True)
+    n = line_count(inFastq)
+    if n % 4 != 0:
+        raise Exception("cannot count reads in a fastq with wrapped lines")
+    return n // 4
+    # unfortunately, both @ and + are potential quality characters and cannot be used in a
+    # fastq counting approach....
+    #return count_str_in_file(inFastq, '@', starts_with=True)
+
+def line_count(infname):
+    n = 0
+    with open_or_gzopen(infname, 'rt') as inf:
+        for line in inf:
+            n += 1
+    return n
 
 def touch(fname, times=None):
     with open(fname, 'a'):


### PR DESCRIPTION
This PR adjusts a number of behaviors in the various read filters that are applied prior to Trinity de novo assembly:

- skip prinseq duplicate removal if read count is below subsample threshold
- skip purge of unmated reads if read count is below subsample threshold
- utilize prinseq paired end invocation (instead of running it in single-end mode on each fastq)
- bugfix: read counts of fastqs files were incorrect when reads started with a quality score of "@"
- bugfix: util.file.count_str_in_file failed on gzip files where the line was shorter than the query_str in starts_with mode

Also added more thorough test coverage to the pre-trinity filtration steps as well as the content of the output of the trinity unit test. Also moved most of the prinseq-related code to tools.prinseq.