### PR TITLE
common barcodes and other fixes

### DIFF
--- a/easy-deploy-script/easy-deploy-viral-ngs.sh
+++ b/easy-deploy-script/easy-deploy-viral-ngs.sh
@@ -106,6 +106,23 @@ else
     set_locale "en_US.utf8"
 fi
 
+function prepend_miniconda(){
+    if [ -d "$MINICONDA_PATH/bin" ]; then
+        echo "Miniconda installed."
+
+        echo "Prepending miniconda to PATH..."
+        export PATH="$MINICONDA_PATH/bin:$PATH"
+        hash -r
+
+        # update to the latest conda this way, since the shell script 
+        # is often months out of date
+        conda update -y conda
+    else
+        echo "Miniconda directory not found."
+        exit 1
+    fi
+}
+
 function install_miniconda(){
     if [ -d "$MINICONDA_PATH/bin" ]; then
         echo "Miniconda directory exists."
@@ -135,15 +152,7 @@ function install_miniconda(){
     fi
 
     if [ -d "$MINICONDA_PATH/bin" ]; then
-        echo "Miniconda installed."
-
-        echo "Prepending miniconda to PATH..."
-        export PATH="$MINICONDA_PATH/bin:$PATH"
-        hash -r
-
-        # update to the latest conda this way, since the shell script 
-        # is often months out of date
-        conda update -y conda
+        prepend_miniconda
     else
         echo "It looks like the Miniconda installation failed"
         exit 1
@@ -177,6 +186,8 @@ function create_project(){
 }
 
 function activate_env(){
+    prepend_miniconda
+    
     if [ -d "$SCRIPTPATH/$CONTAINING_DIR" ]; then
         cd $SCRIPTPATH
     else

--- a/illumina.py
+++ b/illumina.py
@@ -462,7 +462,7 @@ class SampleSheet(object):
                 row_num = 0
                 for line in inf:
                     csv.register_dialect('samplesheet', quoting=csv.QUOTE_MINIMAL, escapechar='\\')
-                    row = next(csv.reader([line.rstrip('\n')], dialect="samplesheet"))
+                    row = next(csv.reader([line.strip().rstrip('\n')], dialect="samplesheet"))
                     row = [item.strip() for item in row] # remove leading/trailing whitespace from each item
                     if miseq_skip:
                         if line.startswith('[Data]'):

--- a/illumina.py
+++ b/illumina.py
@@ -193,7 +193,7 @@ def parser_common_barcodes(parser=argparse.ArgumentParser()):
 
     parser.add_argument('--JVMmemory',
                         help='JVM virtual memory size (default: %(default)s)',
-                        default=tools.picard.IlluminaBasecallsToSamTool.jvmMemDefault)
+                        default=tools.picard.ExtractIlluminaBarcodesTool.jvmMemDefault)
     util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, main_common_barcodes)
     return parser

--- a/pipes/rules/common.rules
+++ b/pipes/rules/common.rules
@@ -15,9 +15,15 @@ def set_env_vars():
 
 def read_tab_file(fname):
     with open(fname, 'rt') as inf:
-        header = [item.strip() for item in inf.readline().rstrip('\n').split('\t')]
+        header = [item.strip() for item in inf.readline().strip().rstrip('\n').split('\t')]
         for line in inf:
-            yield dict(zip(header, [item.strip() for item in line.rstrip('\n').split('\t')] ))
+            row = [item.strip() for item in line.rstrip('\n').split('\t')]
+            if len(row) > len(header):
+                # truncate the row to the header length, and only include extra items if they are not spaces 
+                # (takes care of the case where the user may enter an extra space at the end of a row)
+                row = row[:len(header)] + [item for item in row[len(header):] if len(item)]
+            assert len(header) == len(row)
+            yield dict(zip(header, row))
 
 def read_samples_file(fname, number_of_chromosomes=1, append_chrom_num=False):
     if fname==None:

--- a/pipes/rules/demux.rules
+++ b/pipes/rules/demux.rules
@@ -91,7 +91,7 @@ def illumina_demux_inputs(wildcards):
 rule illumina_demux:
     input:  illumina_demux_inputs
     output: config['tmp_dir']+'/'+config['subdirs']['demux']+'/bams_per_lane/{flowcell}.{lane}/Unmatched.bam',
-            config['reports_dir']+'/barcodes/barcodes-metrics-{flowcell}.{lane}.txt'
+            config['reports_dir']+'/barcodes/barcodes-metrics-{flowcell}.{lane}.txt',
             config['reports_dir']+'/barcodes/common-barcodes-{flowcell}.{lane}.txt'
     resources: mem=60
     params: LSF=config.get('LSF_queues', {}).get('bigmem', '-q flower'),
@@ -107,7 +107,7 @@ rule illumina_demux:
             for opt in ('minimum_base_quality', 'max_mismatches', 'min_mismatch_delta', 'max_no_calls', 'read_structure', 'minimum_quality', 'run_start_date'):
                 if lane.get(opt):
                     opts += ' --%s=%s' % (opt, lane[opt])
-            shell("{config[bin_dir]}/illumina.py illumina_demux {input[0]} {wildcards.lane} {outdir} --sampleSheet={input[1]} --sequencing_center={params.center} --outMetrics={output[1]} --commonBarcodes {output[2]} --flowcell={wildcards.flowcell} {opts}")
+            shell("{config[bin_dir]}/illumina.py illumina_demux {input[0]} {wildcards.lane} {outdir} --sampleSheet={input[1]} --sequencing_center={params.center} --outMetrics={output[1]} --commonBarcodes={output[2]} --flowcell={wildcards.flowcell} {opts}")
 
 
 def demux_move_bams_inputs(wildcards):

--- a/pipes/rules/demux.rules
+++ b/pipes/rules/demux.rules
@@ -92,6 +92,7 @@ rule illumina_demux:
     input:  illumina_demux_inputs
     output: config['tmp_dir']+'/'+config['subdirs']['demux']+'/bams_per_lane/{flowcell}.{lane}/Unmatched.bam',
             config['reports_dir']+'/barcodes/barcodes-metrics-{flowcell}.{lane}.txt'
+            config['reports_dir']+'/barcodes/common-barcodes-{flowcell}.{lane}.txt'
     resources: mem=60
     params: LSF=config.get('LSF_queues', {}).get('bigmem', '-q flower'),
             UGER=config.get('UGER_queues', {}).get('long', '-q long'),
@@ -106,7 +107,7 @@ rule illumina_demux:
             for opt in ('minimum_base_quality', 'max_mismatches', 'min_mismatch_delta', 'max_no_calls', 'read_structure', 'minimum_quality', 'run_start_date'):
                 if lane.get(opt):
                     opts += ' --%s=%s' % (opt, lane[opt])
-            shell("{config[bin_dir]}/illumina.py illumina_demux {input[0]} {wildcards.lane} {outdir} --sampleSheet={input[1]} --sequencing_center={params.center} --outMetrics={output[1]} --flowcell={wildcards.flowcell} {opts}")
+            shell("{config[bin_dir]}/illumina.py illumina_demux {input[0]} {wildcards.lane} {outdir} --sampleSheet={input[1]} --sequencing_center={params.center} --outMetrics={output[1]} --commonBarcodes {output[2]} --flowcell={wildcards.flowcell} {opts}")
 
 
 def demux_move_bams_inputs(wildcards):

--- a/util/file.py
+++ b/util/file.py
@@ -139,10 +139,15 @@ def read_tabfile_dict(inFile):
             row = [item.strip() for item in line.rstrip('\n').split('\t')]
             if line.startswith('#'):
                 row[0] = row[0][1:]
-                header = row
+                header = [item for item in row if len(item)]
             elif header is None:
-                header = row
+                header = [item for item in row if len(item)]
             else:
+                # if a row is longer than the header
+                if len(row) > len(header):
+                    # truncate the row to the header length, and only include extra items if they are not spaces 
+                    # (takes care of the case where the user may enter an extra space at the end of a row)
+                    row = row[:len(header)] + [item for item in row[len(header):] if len(item)]
                 assert len(header) == len(row)
                 yield dict((k, v) for k, v in zip(header, row) if v)
 


### PR DESCRIPTION
* —commonBarcodes is added to demux.rules invocation of illumina_demux
* better handling of rows with end-of-line spaces in samplesheets and barcode files
* common_barcodes now uses ExtractIlluminaBarcodesTool as source of jvmMemDefault 
* easy install now correctly prepends miniconda to PATH for environment loading