### PR TITLE
Keep unpaired trimmomatic output

### DIFF
--- a/taxon_filter.py
+++ b/taxon_filter.py
@@ -125,6 +125,8 @@ def trimmomatic(
     pairedOutFastq1,
     pairedOutFastq2,
     clipFasta,
+    unpairedOutFastq1=None,
+    unpairedOutFastq2=None,
     leading_q_cutoff=15,
     trailing_q_cutoff=15,
     minlength_to_keep=30,
@@ -133,8 +135,8 @@ def trimmomatic(
 ):
     '''Trim read sequences with Trimmomatic.'''
     trimmomaticPath = tools.trimmomatic.TrimmomaticTool().install_and_get_path()
-    tmpUnpaired1 = mkstempfname()
-    tmpUnpaired2 = mkstempfname()
+    unpairedFastq1 = unpairedOutFastq1 or mkstempfname()
+    unpairedFastq2 = unpairedOutFastq2 or mkstempfname()
 
     javaCmd = []
 
@@ -152,7 +154,7 @@ def trimmomatic(
 
     javaCmd.extend(
         [
-            inFastq1, inFastq2, pairedOutFastq1, tmpUnpaired1, pairedOutFastq2, tmpUnpaired2,
+            inFastq1, inFastq2, pairedOutFastq1, unpairedFastq1, pairedOutFastq2, unpairedFastq2,
             'LEADING:{leading_q_cutoff}'.format(leading_q_cutoff=leading_q_cutoff),
             'TRAILING:{trailing_q_cutoff}'.format(trailing_q_cutoff=trailing_q_cutoff),
             'SLIDINGWINDOW:{sliding_window_size}:{sliding_window_q_cutoff}'.format(
@@ -166,8 +168,11 @@ def trimmomatic(
 
     log.debug(' '.join(javaCmd))
     util.misc.run_and_print(javaCmd, check=True)
-    os.unlink(tmpUnpaired1)
-    os.unlink(tmpUnpaired2)
+
+    if not unpairedOutFastq1:
+        os.unlink(unpairedFastq1)
+    if not unpairedOutFastq2:
+        os.unlink(unpairedFastq2)
 
 
 def parser_trim_trimmomatic(parser=argparse.ArgumentParser()):
@@ -175,6 +180,8 @@ def parser_trim_trimmomatic(parser=argparse.ArgumentParser()):
     parser.add_argument("inFastq2", help="Input reads 2")
     parser.add_argument("pairedOutFastq1", help="Paired output 1")
     parser.add_argument("pairedOutFastq2", help="Paired output 2")
+    parser.add_argument("--unpairedOutFastq1", help="Unpaired output 1 (default: write to temp and discard)")
+    parser.add_argument("--unpairedOutFastq2", help="Unpaired output 2 (default: write to temp and discard)")
     parser.add_argument(
         '--leadingQCutoff',
         dest="leading_q_cutoff",

--- a/test/unit/test_assembly.py
+++ b/test/unit/test_assembly.py
@@ -47,7 +47,7 @@ class TestAssembleTrinity(TestCaseWithTmp):
         assembly.assemble_trinity(inBam, clipDb, outFasta, threads=4)
         self.assertGreater(os.path.getsize(outFasta), 0)
         contig_lens = list(sorted(len(seq.seq) for seq in Bio.SeqIO.parse(outFasta, 'fasta')))
-        self.assertEqual(contig_lens, [328, 328, 376])
+        self.assertEqual(contig_lens, [328, 348, 376, 381])
         os.unlink(outFasta)
 
     def test_empty_input_succeed(self):
@@ -88,7 +88,7 @@ class TestTrimRmdupSubsamp(TestCaseWithTmp):
         outBam = util.file.mkstempfname('.out.bam')
         read_stats = assembly.trim_rmdup_subsamp_reads(inBam, clipDb, outBam, n_reads=50)
         os.unlink(outBam)
-        self.assertEqual(read_stats, (100,86,86,86,50))
+        self.assertEqual(read_stats, (100,99,99,86,50))
 
     def test_subsamp_small_90(self):
         inDir = util.file.get_test_input_path()
@@ -97,7 +97,7 @@ class TestTrimRmdupSubsamp(TestCaseWithTmp):
         outBam = util.file.mkstempfname('.out.bam')
         read_stats = assembly.trim_rmdup_subsamp_reads(inBam, clipDb, outBam, n_reads=90)
         os.unlink(outBam)
-        self.assertEqual(read_stats, (100,86,86,86,86))
+        self.assertEqual(read_stats, (100,99,99,86,86))
 
     def test_subsamp_small_200(self):
         inDir = util.file.get_test_input_path()
@@ -106,7 +106,7 @@ class TestTrimRmdupSubsamp(TestCaseWithTmp):
         outBam = util.file.mkstempfname('.out.bam')
         read_stats = assembly.trim_rmdup_subsamp_reads(inBam, clipDb, outBam, n_reads=200)
         os.unlink(outBam)
-        self.assertEqual(read_stats, (100,86,86,86,86))
+        self.assertEqual(read_stats, (100,99,99,99,99))
 
     def test_subsamp_big_500(self):
         inDir = util.file.get_test_input_path()
@@ -115,7 +115,7 @@ class TestTrimRmdupSubsamp(TestCaseWithTmp):
         outBam = util.file.mkstempfname('.out.bam')
         read_stats = assembly.trim_rmdup_subsamp_reads(inBam, clipDb, outBam, n_reads=500)
         os.unlink(outBam)
-        self.assertEqual(read_stats, (9355,8155,8155,8155,500))
+        self.assertEqual(read_stats, (9355,9275,9251,8155,500))
 
 
 class TestAmbiguityBases(unittest.TestCase):


### PR DESCRIPTION
Trimmomatic can output single-end reads if mates are dropped. Previously, its single-end output was stored in tmp files and trashed. This PR keeps its unpaired output and allows those reads to be used as input for Trinity assembly.

This is particularly useful for low quality and quantity samples. In these samples, often the second mate of a pair has a drop in quality (at least on MiSeq sequencing) and is tossed by Trimmomatic; this PR would allow the first mate of the pair to be used in assembly.