### PR TITLE
Fix bug in Trimmomatic on samples with few reads

### DIFF
--- a/taxon_filter.py
+++ b/taxon_filter.py
@@ -150,6 +150,9 @@ def trimmomatic(
     else:
         javaCmd.extend([trimmomaticPath, "PE"])
 
+    # Explicitly use Phred-33 quality scores
+    javaCmd.extend(['-phred33'])
+
     javaCmd.extend(
         [
             inFastq1, inFastq2, pairedOutFastq1, tmpUnpaired1, pairedOutFastq2, tmpUnpaired2,


### PR DESCRIPTION
When Trimmomatic is not given a base for Phred quality scores, it tries to determine that base using its method `determinePhredOffset()`. See [here](https://github.com/timflutre/trimmomatic/blob/3694641a92d4dd9311267fed85b05c7a11141e7c/src/org/usadellab/trimmomatic/TrimmomaticPE.java#L264) for the calls and [here](https://github.com/timflutre/trimmomatic/blob/3694641a92d4dd9311267fed85b05c7a11141e7c/src/org/usadellab/trimmomatic/fastq/FastqParser.java#L102) for the definition. Phred-33 ranges from ASCII 33 to 75, and Phred-64 ranges from ASCII 64 to 106. Perhaps because of the overlap, Trimmomatic considers only a subset of the range for Phred-33 and Phred-64 when deciding which base the quality scores fall into. But all of the bases in all of the reads might have quality scores that fall between the upper limit of the chosen Phred-33 range (58) and the lower limit of the chosen Phred-64 range (80). For example, this can happen when most of the Phred quality scores are around the ASCII character 'H' (72). When this happens, Trimmomatic is unable to determine a base, so `determinePhredOffset()` returns 0 and Trimmomatic gives the error "Error: Unable to detect quality encoding".

This error generally happens in samples with a small number of reads passing taxonomic filtering because it means the input to Trimmomatic is small, and it is therefore more likely for the above scenario to happen. This PR prevents this error.