### PR TITLE
perform pre-Trinity subsampling in bam space

### DIFF
--- a/assembly.py
+++ b/assembly.py
@@ -132,7 +132,7 @@ def trim_rmdup_subsamp_reads(inBam, clipDb, outBam, n_reads=100000):
     # convert paired reads to bam
     # stub out an empty file if the input fastqs are empty
     tmp_bam_paired = util.file.mkstempfname('.paired.bam')
-    if all(util.file.count_fastq_reads(x) > 0 for x in  purgefq) > 0:
+    if all(os.path.getsize(x) > 0 for x in  purgefq):
         tools.picard.FastqToSamTool().execute(purgefq[0], purgefq[1],
                                           'Dummy', tmp_bam_paired)
     else:

--- a/easy-deploy-script/easy-deploy-viral-ngs.sh
+++ b/easy-deploy-script/easy-deploy-viral-ngs.sh
@@ -181,7 +181,7 @@ function create_project(){
 
 function activate_env(){
     if [ -d "$SCRIPTPATH/$CONTAINING_DIR" ]; then
-        cd $SCRIPTPATH
+        echo "viral-ngs parent directory found"
     else
         echo "viral-ngs parent directory not found: $CONTAINING_DIR not found."
         echo "Have you run the setup?"

--- a/pipes/Broad_LSF/run-pipe.sh
+++ b/pipes/Broad_LSF/run-pipe.sh
@@ -5,7 +5,7 @@
 SCRIPT_DIRECTORY=$(dirname $(readlink --canonicalize-existing $0))
 
 # load necessary Broad dotkits
-source /broad/software/scripts/useuse 
+source /broad/software/scripts/useuse
 reuse -q LSF
 
 reuse -q Python-3.4

--- a/pipes/Broad_UGER/run-pipe.sh
+++ b/pipes/Broad_UGER/run-pipe.sh
@@ -5,7 +5,7 @@
 SCRIPT_DIRECTORY=$(dirname $(readlink --canonicalize-existing $0))
 
 # load necessary Broad dotkits
-source /broad/software/scripts/useuse 
+source /broad/software/scripts/useuse
 reuse -q UGER
 
 reuse -q Python-3.4

--- a/test/unit/test_assembly.py
+++ b/test/unit/test_assembly.py
@@ -88,7 +88,7 @@ class TestTrimRmdupSubsamp(TestCaseWithTmp):
         outBam = util.file.mkstempfname('.out.bam')
         read_stats = assembly.trim_rmdup_subsamp_reads(inBam, clipDb, outBam, n_reads=50)
         os.unlink(outBam)
-        self.assertEqual(read_stats, (100,99,99,86,50))
+        self.assertEqual(read_stats, (100,99,86,86,50))
 
     def test_subsamp_small_90(self):
         inDir = util.file.get_test_input_path()
@@ -97,7 +97,7 @@ class TestTrimRmdupSubsamp(TestCaseWithTmp):
         outBam = util.file.mkstempfname('.out.bam')
         read_stats = assembly.trim_rmdup_subsamp_reads(inBam, clipDb, outBam, n_reads=90)
         os.unlink(outBam)
-        self.assertEqual(read_stats, (100,99,99,86,86))
+        self.assertEqual(read_stats, (100,99,86,86,90))
 
     def test_subsamp_small_200(self):
         inDir = util.file.get_test_input_path()
@@ -106,7 +106,7 @@ class TestTrimRmdupSubsamp(TestCaseWithTmp):
         outBam = util.file.mkstempfname('.out.bam')
         read_stats = assembly.trim_rmdup_subsamp_reads(inBam, clipDb, outBam, n_reads=200)
         os.unlink(outBam)
-        self.assertEqual(read_stats, (100,99,99,99,99))
+        self.assertEqual(read_stats, (100,99,99,99,112))
 
     def test_subsamp_big_500(self):
         inDir = util.file.get_test_input_path()
@@ -115,7 +115,7 @@ class TestTrimRmdupSubsamp(TestCaseWithTmp):
         outBam = util.file.mkstempfname('.out.bam')
         read_stats = assembly.trim_rmdup_subsamp_reads(inBam, clipDb, outBam, n_reads=500)
         os.unlink(outBam)
-        self.assertEqual(read_stats, (9355,9275,9251,8155,500))
+        self.assertEqual(read_stats, (9355,9275,8155,8155,500))
 
 
 class TestAmbiguityBases(unittest.TestCase):

--- a/tools/samtools.py
+++ b/tools/samtools.py
@@ -16,16 +16,19 @@
 '''
 
 import logging
-import tools
-import util.file
+import shutil
 import os
 import os.path
 import subprocess
 import tempfile
 from collections import OrderedDict
-import util.misc
-#import pysam
 from decimal import *
+
+#import pysam
+
+import tools
+import util.file
+import util.misc
 
 TOOL_NAME = 'samtools'
 TOOL_VERSION = '1.3.1'
@@ -144,8 +147,13 @@ class SamtoolsTool(tools.Tool):
     def downsample_to_approx_count(self, inBam, outBam, read_count):
         total_read_count = self.count(inBam)
         probability = Decimal(int(read_count)) / Decimal(total_read_count)
+        probability = 1 if probability > 1 else probability
 
-        self.downsample(inBam, outBam, probability)
+        if probability < 1:
+            self.downsample(inBam, outBam, probability)
+        else:
+            _log.info("Requested downsample count exceeds number of reads. Including all reads in output.")
+            shutil.copyfile(inBam, outBam)
 
     def getHeader(self, inBam):
         ''' fetch BAM header as a list of tuples (already split on tabs) '''


### PR DESCRIPTION
Perform pre-Trinity subsampling in bam space. If the number of paired reads (after purge, or not) is lower than the Trinity subsampling threshold, subsample the unpaired reads to try to reach the total. Otherwise, if the post-purge paired read count is greater than the Trinity input, downsample to reach it. A few small improvements to the samtools and Picard downsample functions. This addresses #407.