### PR TITLE
Novoalign parameter strings for Snakemake rules refine_assembly_[1|2]  and map_reads_to_self exposed in config.yaml

### DIFF
--- a/pipes/config.yaml
+++ b/pipes/config.yaml
@@ -128,6 +128,13 @@ assembly_min_length_fraction_of_reference: 0.50
 # sequence must have to be considered acceptable quality.
 assembly_min_unambig: 0.50
 
+# parameters passed to Novoalign during the assembly refinement stages
+refine_assembly_1_novoalign_params: "-r Random -l 30 -g 40 -x 20 -t 502"
+refine_assembly_2_novoalign_params: "-r Random -l 40 -g 40 -x 20 -t 100"
+
+# parameters passed to Novoalign for mapping reads back to the consensus
+map_reads_to_self_novoalign_params: "-r Random -l 40 -g 40 -x 20 -t 100 -k"
+
 # Alignment parameters for nucmer (MUMmer) during the scaffolding step.
 # Shown below are defaults.
 #assembly_nucmer_max_gap:     200

--- a/pipes/rules/assembly.rules
+++ b/pipes/rules/assembly.rules
@@ -124,7 +124,7 @@ rule refine_assembly_1:
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             UGER=config.get('UGER_queues', {}).get('long', '-q long'),
             logid="{sample}",
-            novoalign_options = "-r Random -l 30 -g 40 -x 20 -t 502",
+            novoalign_options = config.get("refine_assembly_1_novoalign_params", "-r Random -l 30 -g 40 -x 20 -t 502"),
             min_coverage = "2",
             numThreads=str(config.get("number_of_threads", 1))
     shell:  "{config[bin_dir]}/assembly.py refine_assembly {input} {output[0]} --outVcf {output[1]} --min_coverage {params.min_coverage} --novo_params '{params.novoalign_options}' --threads {params.numThreads}"
@@ -148,7 +148,7 @@ rule refine_assembly_2:
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             UGER=config.get('UGER_queues', {}).get('long', '-q long'),
             logid="{sample}",
-            novoalign_options = "-r Random -l 40 -g 40 -x 20 -t 100",
+            novoalign_options = config.get("refine_assembly_2_novoalign_params", "-r Random -l 40 -g 40 -x 20 -t 100"),
             min_coverage = "3",
             numThreads=str(config.get("number_of_threads", 1))
     shell:  "{config[bin_dir]}/assembly.py refine_assembly {input} {output[0]} --outVcf {output[1]} --min_coverage {params.min_coverage} --novo_params '{params.novoalign_options}' --threads {params.numThreads}"
@@ -170,7 +170,7 @@ rule map_reads_to_self:
     params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),
             UGER=config.get('UGER_queues', {}).get('long', '-q long'),
             logid="{sample}",
-            novoalign_options = "-r Random -l 40 -g 40 -x 20 -t 100 -k",
+            novoalign_options = config.get('map_reads_to_self_novoalign_params', "-r Random -l 40 -g 40 -x 20 -t 100 -k"),
             numThreads=str(config.get("number_of_threads", 1))
     run:
             makedirs([os.path.join(config["data_dir"], config["subdirs"]["align_self"]),


### PR DESCRIPTION
Novoalign parameter strings for Snakemake rules refine_assembly_[1|2] and map_reads_to_self exposed in config.yaml. This addresses #418. 