### PR TITLE
Fix regex in matching sample names

### DIFF
--- a/intrahost.py
+++ b/intrahost.py
@@ -1131,7 +1131,7 @@ def sampleIDMatch(inputString):
         Given a sample name in the form of [sample] or [sample]-#,
         return only [sample]
     """
-    idRegex = re.compile(r"(.*?)(?:-\d+|$)+")
+    idRegex = re.compile(r"(.*?)(?:-\d+)?$")
     m = idRegex.match(inputString)
 
     if m:


### PR DESCRIPTION
The current regex is non-greedy but should be greedy in
matching sample names. For example, given '[sample]-1-2'
it yields '[sample]', but should output '[sample]-1'. This
fixes that.