### PR TITLE
Add pytest-logging to requirements-tests

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,5 +3,6 @@ coveralls==1.1
 pycodestyle
 mock==2.0.0
 six<2
-pytest-xdist==1.14
 pytest-cov==2.2.1
+pytest-logging==2015.11.4
+pytest-xdist==1.14


### PR DESCRIPTION
Otherwise there is no logging handler setup because we're not running
through main_argparse.