### PR TITLE
change reports.rules to use conda-supplied fastqc

### DIFF
--- a/pipes/rules/reports.rules
+++ b/pipes/rules/reports.rules
@@ -30,8 +30,10 @@ rule fastqc_report:
             makedirs(config["reports_dir"])
             shutil.rmtree(output[0], ignore_errors=True)
             makedirs(os.path.join(config["reports_dir"], 'fastqc'))
-            shell("/idi/sabeti-scratch/kandersen/bin/fastqc/fastqc -f bam {input} -o {config[reports_dir]}/fastqc")
+            shell("fastqc -f bam {input} -o {config[reports_dir]}/fastqc")
+            shell("unzip {config[reports_dir]}/fastqc/{wildcards.sample}_fastqc.zip -d {config[reports_dir]}/fastqc")
             os.unlink(output[0]+'.zip')
+            os.unlink(output[0]+'.html')
 
 rule consolidate_fastqc:
     input:

--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -5,6 +5,7 @@ diamond=0.7.10=boost1.60_1
 kraken-all=0.10.6_eaf8fb68
 krona=2.7
 last=719
+fastqc=0.11.5
 mafft=7.221
 mummer=3.23
 muscle=3.8.1551


### PR DESCRIPTION
change reports.rules to use conda-supplied fastqc; update rule to reflect newer fastqc output (need to unzip).
This addresses #437. 