### PR TITLE
Broad UGER change m_mem_free to h_vmem to support 9/6/16 change

### DIFF
--- a/pipes/Broad_UGER/cluster-submitter.py
+++ b/pipes/Broad_UGER/cluster-submitter.py
@@ -23,7 +23,7 @@ cmdline += "-o {logdir} -e {logdir} ".format(logdir=LOGDIR)
 # pass memory resource request to cluster
 mem = props.get('resources', {}).get('mem')
 if mem:
-    cmdline += ' -l m_mem_free={}G,h_rss={}G '.format(mem, round(1.2 * float(int(mem)), 2))
+    cmdline += ' -l h_vmem={}G,h_rss={}G '.format(mem, round(1.2 * float(int(mem)), 2))
     if mem >= 15:
         cmdline += ' -R y '
 


### PR DESCRIPTION
This should be merged in and released on 9/5/16.
BITS:
“””We will be applying the following change on 9/6/2016.

Currently, UGER uses m_mem_free (mfree) as its default memory request.
M_mem_free is the recommended resource request used by many other
institutes.  This resource has a built in buffer in that if a job
exceeds its requested memory limit, it will overflow into swap.  Jobs
overflowing into swap have been beneficial to some users who are unsure
of the exact memory requirements of their jobs.  However, we have
recently run into an issue where malformed jobs that did not request
the appropriate amount of memory would overflow into swap and cause the
exec host to start thrashing.  Thrashing degrades the performance of a
host and can impact other jobs on that exec host.

The appropriate solution to this issue is to change the default memory
request from m_mem_free to h_vmem.

Our version of Univa Grid Engine now allows us to control the resource
h_vmem with cgroups.  This is different from previous iterations of
h_vmem in that it is controlled at the exec host level with cgroups
rather than by the scheduler.  With this level of control the host will
not run out of memory while waiting for the scheduler to issue the kill
order on the out-of-bounds job.

This change will have the following impact:
First, there is no memory buffer for jobs. If your job hits its
requested memory limit, it will be killed.
The second is that any user wrappers or scripts that are set to use
m_mem_free will have to be re-written to use h_vmem.

Example:

Previous way to submit a job requesting 10g memory:
qsub -l m_mem_free=10g script
New way to submit job requesting 10g memory:
qsub -l h_vmem=10g script

You can test this new request now by adding “-l h_vmem=Xg” to your
jobs.  Until this change is in production you will still need to
request additional memory with “-l m_mem_free=Xg”.  Once this change is
in production you will no longer need to add the m_mem_free request.”””