### PR TITLE
Broad UGER include linear cpu binding in cluster submitter

### DIFF
--- a/pipes/Broad_UGER/cluster-submitter.py
+++ b/pipes/Broad_UGER/cluster-submitter.py
@@ -24,12 +24,12 @@ cmdline += "-o {logdir} -e {logdir} ".format(logdir=LOGDIR)
 mem = props.get('resources', {}).get('mem')
 if mem:
     cmdline += ' -l m_mem_free={}G,h_rss={}G '.format(mem, round(1.2 * float(int(mem)), 2))
-    if mem >= 15:
+    if mem >= 15 or cores>4:
         cmdline += ' -R y '
 
 cores = props.get('resources', {}).get('cores')
 if cores:
-    cmdline += ' -pe smp {} '.format(int(cores))
+    cmdline += ' -pe smp {} -binding linear:{} '.format(int(cores), int(cores))
 
 # rule-specific UGER parameters (e.g. queue)
 cmdline += props["params"].get("UGER", "") + " "

--- a/pipes/Broad_UGER/cluster-submitter.py
+++ b/pipes/Broad_UGER/cluster-submitter.py
@@ -24,7 +24,7 @@ cmdline += "-o {logdir} -e {logdir} ".format(logdir=LOGDIR)
 mem = props.get('resources', {}).get('mem')
 if mem:
     cmdline += ' -l m_mem_free={}G,h_rss={}G '.format(mem, round(1.2 * float(int(mem)), 2))
-    if mem >= 15 or cores>4:
+    if mem >= 15 or cores >= 4:
         cmdline += ' -R y '
 
 cores = props.get('resources', {}).get('cores')


### PR DESCRIPTION
This should be merged and released on 8/29/16.

BITS:
“””
We will be applying the following change on 8/30/2016.

We have noticed that some of the execution hosts’ cpus in UGER have
been heavily taxed, causing jobs to be starved for cpu time on those
hosts. We have identified the most likely cause and will be
implementing a config change to remedy it.

Currently, the default request with no modifiers is for a single core.
If you do not request additional cores with "-pe smp X" then you will
not be allocated additional cores from the scheduler. However, the
current config does not then prevent a job from using more cores than
they requested on that exec host.

To resolve the issue, we will be introducing core bindings to the
default request. Core bindings will limit a job to the number of cores
requested on the execution host.  The default binding request will be
the same single core request as is currently in place.

This change will have the following impact:
Users will need to add an additional flag when requesting more than a
single core.  The flag is “-binding linear:X” where X is the number of
cores desired.

Example:

Previous way to submit a job requesting 4 cores:
qsub -pe smp 4 script
New way to submit job requesting 4 cores:
qsub -pe smp 4 -binding linear:4 script

You can test your jobs now by adding the flag "-binding linear:1".
This can be tested with: “qsub -b y -pe smp X -binding linear:X nproc”.
If X is 1 then it will return 1.  If X is 4 it will return 4.

Remember, if you are requesting four or more cores to add the flag "-R
y". This will apply reservations to your job to prevent it being
starved out by smaller core count jobs.  We recommend not adding this
flag if you have 3 or fewer cores because the scheduler can only handle
a limited number of reservations at a time and you may actually be
hurting your dispatch time.

You can read more about core binding here:
http://www.gridengine.eu/grid-engine-internals/87-exploiting-the-grid-en
gine-core-binding-feature
“””