### PR TITLE
add Dockerfile

### DIFF
--- a/easy-deploy-docker/Dockerfile
+++ b/easy-deploy-docker/Dockerfile
@@ -1,0 +1,58 @@
+FROM ubuntu:15.04
+MAINTAINER Chris Tomkins-Tinch <tomkinsc@broadinstitute.org>
+
+# to build:
+#   docker build --rm .
+# to run:
+#   Download licensed copies of GATK and Novoalign to the host machine (for Linux-64)
+#   export GATK_PATH=/path/to/gatk/
+#   export NOVOALIGN_PATH=/path/to/novoalign/
+#   docker run --rm -v $GATK_PATH:/gatk -v $NOVOALIGN_PATH:/novoalign -v /path/to/dir/on/host:/user-data -t -i <image_ID> "<command>.py subcommand"
+# if you receive a "no space on device" error:
+#   docker kill $(docker ps -a -q)
+#   docker rm $(docker ps -a -q)
+#   docker rmi $(docker images -q)
+#   docker volume rm $(docker volume ls -qf dangling=true)
+
+# System packages 
+RUN apt-get update && apt-get upgrade
+RUN apt-get install -y curl bzip2 build-essential python wget 
+RUN apt-get install -y less nano
+
+# Set the locale
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+# add a new user
+ENV DOCKER_USER viral-ngs-user
+RUN useradd -ms /bin/bash $DOCKER_USER
+USER $DOCKER_USER
+WORKDIR /home/$DOCKER_USER
+
+# shared volumes to make external GATK available within the container
+VOLUME ["/gatk"]
+ENV GATK_PATH /gatk
+
+# shared volumes to make external Novoalign available within the container
+VOLUME ["/novoalign"]
+ENV NOVOALIGN_PATH /novoalign
+
+# shared volumes to make external Novoalign available within the container
+VOLUME ["/user-data"]
+ENV VIRAL_NGS_DOCKER_DATA_PATH /user-data
+
+RUN ln -s /user-data /home/$DOCKER_USER/data
+
+# download and use the viral-ngs easy deploy script to install viral-ngs
+RUN curl -LO https://raw.githubusercontent.com/broadinstitute/viral-ngs/master/easy-deploy-script/easy-deploy-viral-ngs.sh
+RUN chmod a+x easy-deploy-viral-ngs.sh
+RUN bash easy-deploy-viral-ngs.sh setup
+
+# source the viral-ngs conda environment in the .bashrc file so all
+# commands are always available for a bash seshion    
+RUN echo "source easy-deploy-viral-ngs.sh load &> /dev/null" >> /home/$DOCKER_USER/.bashrc
+
+# make the entrypoint bash with login (source .bashrc)
+ENTRYPOINT ["/bin/bash", "--login", "-i", "-c"]

--- a/easy-deploy-docker/README.md
+++ b/easy-deploy-docker/README.md
@@ -1,0 +1,44 @@
+## viral-ngs Docker container
+
+### Introduction
+This directory contains a `Dockerfile` suitable for building a containerized instance of viral-ngs capable of running on any platform that supports [Docker](https://www.docker.com/). 
+
+Detailed documentation for Docker is [available online](https://docs.docker.com/).
+
+### Considerations
+The `Dockerfile` relies on the [easy-install script](https://github.com/broadinstitute/viral-ngs/tree/master/easy-deploy-script), which means that any time a new Docker image is built, it will include the latest version of viral-ngs available via the [bioconda](https://bioconda.github.io/recipes/viral-ngs/README.html) channel of the [conda package manager](http://conda.pydata.org/docs/install/quick.html). 
+
+In order to use all features of the viral-ngs pipeline, it is necessary to manually [license and download GATK](https://software.broadinstitute.org/gatk/). To make a licensed copy of GATK available to the Docker container, set the `$GATK_PATH` environment variable on the host machine to the path containing an extracted copy of `GenomeAnalysisTK.jar`.
+
+By default, the pipeline will install a single-threaded version of [Novoalign](http://www.novocraft.com/products/novoalign/) from bioconda. It is possible to use a multi-threaded version to decrease compute time. To make a multi-threaded version of novoalign available to the Docker container, set the `$NOVOALIGN_PATH` environment variable on the host machine to the path containing the extracted Novocraft binaries, such as `novoalign`, `novoindex`, as well as the `novoalign.lic` license file. Note that the version of Novoalign used must support the 64-bit Linux platform of the viral-ngs Docker image, regardless of the platform hosting the Docker daemon.
+
+### To build
+  Navigate to the directory containing the `Dockerfile`, then run:
+  `docker build --rm .`
+  
+### To run
+  Download licensed copies of GATK and Novoalign to the host machine (for Linux-64), and run:
+```export GATK_PATH=/path/to/gatk/
+export NOVOALIGN_PATH=/path/to/novoalign/
+docker run --rm -v $NOVOALIGN_PATH:/novoalign -v $GATK_PATH:/gatk -v /path/to/dir/on/host:/user-data -t -i <image_ID> "<command>.py subcommand"
+```
+
+The Novoalign argument, `-v $NOVOALIGN_PATH:/novoalign`, can be omitted if single-threaded Novoalign is adequate.
+
+An arbitrary directory on the host system can be made available within the Docker container by setting a volume to mount a host directory to `/user-data` within the container. For example, to expose `~/Desktop`, add the argument: `-v ~/Desktop:/user-data`. Within the Docker container, this directory will be accessible via `/user-data`. For convenience, `/user-data` is also available via `~/data/` within the container. Other volumes from the host can be shared with the container with additional `-v` arguments.
+
+The `<command>.py subcommand` specified must match one of the [documented viral-ngs commands](https://viral-ngs.readthedocs.io/en/latest/cmdline.html).
+
+### Debugging
+
+#### Shell usage
+To use a shell within a viral-ngs Docker container, pass `/bin/bash` to the run command:
+`docker run --rm -v $GATK_PATH:/gatk -v $NOVOALIGN_PATH:/novoalign -t -i <image_ID> /bin/bash`
+
+#### Clean slate
+If you receive a "no space on device" error, sometimes a fresh start can be helpful. You can run these commands to remove **ALL** current docker images, containers, and volumes (be careful! the commands will also remove Docker items unrelated to viral-ngs):
+```docker kill $(docker ps -a -q)
+docker rm $(docker ps -a -q)
+docker rmi $(docker images -a -q)
+docker volume rm $(docker volume ls -qf dangling=true)
+```

--- a/easy-deploy-script/easy-deploy-viral-ngs.sh
+++ b/easy-deploy-script/easy-deploy-viral-ngs.sh
@@ -57,6 +57,16 @@ if [ $current_prefix_length -ge $CONDA_PREFIX_LENGTH_LIMIT ]; then
     exit 1
 fi
 
+python_check=$(hash python)
+if [ $? -ne 0 ]; then
+    echo "It looks like Python is not installed. Exiting."
+    if [[ $sourced -eq 0 ]]; then
+        exit 1
+    else
+        return 1
+    fi
+fi
+
 ram_check=$(python -c "bytearray(1024000000)" &> /dev/null)
 if [ $? -ne 0 ]; then
     echo ""


### PR DESCRIPTION
add a basic Dockerfile for viral-ngs, and a simple README. The Dockerfile uses the easy-install script to set up an install of viral-ngs within an Ubuntu Docker container. GATK, Novoalign, can be
accessed by the container via “-v” volume shares, and external data can be passed in similarly.

This addresses #311. 