### PR TITLE
fix bwamem_idxstats call

### DIFF
--- a/pipes/rules/reports.rules
+++ b/pipes/rules/reports.rules
@@ -58,7 +58,7 @@ if config.get("spikeins_db"):
         run:
                 makedirs(os.path.join(config["reports_dir"], 'spike_count'))
                 makedirs(os.path.join(config["tmp_dir"], config["subdirs"]["depletion"]))
-                shell("{config[bin_dir]}/read_utils.py bwamem_and_idxstats {input} {params.spikeins_db} {output}")
+                shell("{config[bin_dir]}/read_utils.py bwamem_idxstats {input} {params.spikeins_db} --outStats {output}")
 
     rule consolidate_spike_count:
         input:  expand("{{dir}}/spike_count/{sample}.spike_count.txt", \

--- a/read_utils.py
+++ b/read_utils.py
@@ -1161,6 +1161,9 @@ __commands__.append(('align_and_fix', parser_align_and_fix))
 def bwamem_idxstats(inBam, refFasta, outBam=None, outStats=None):
     ''' Take reads, align to reference with BWA-MEM and perform samtools idxstats.
     '''
+
+    assert outBam or outStats, "Either outBam or outStats must be specified"
+
     if outBam is None:
         bam_aligned = mkstempfname('.aligned.bam')
     else:
@@ -1181,8 +1184,8 @@ def bwamem_idxstats(inBam, refFasta, outBam=None, outStats=None):
 def parser_bwamem_idxstats(parser=argparse.ArgumentParser()):
     parser.add_argument('inBam', help='Input unaligned reads, BAM format.')
     parser.add_argument('refFasta', help='Reference genome, FASTA format, pre-indexed by Picard and Novoalign.')
-    parser.add_argument('outBam', help='Output aligned, indexed BAM file', default=None)
-    parser.add_argument('outStats', help='Output idxstats file', default=None)
+    parser.add_argument('--outBam', help='Output aligned, indexed BAM file', default=None)
+    parser.add_argument('--outStats', help='Output idxstats file', default=None)
     util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, bwamem_idxstats, split_args=True)
     return parser

--- a/test/unit/test_read_utils.py
+++ b/test/unit/test_read_utils.py
@@ -82,6 +82,14 @@ class TestBwamemIdxstats(TestCaseWithTmp):
         self.assertEqual(actual_count, self.samtools.count(outBam, opts=['-F', '4']))
         self.assertGreater(actual_count, 18000)
 
+    def test_bwamem_idxstats_no_bam_output(self):
+        inBam = os.path.join(util.file.get_test_input_path(), 'G5012.3.testreads.bam')
+        outStats = util.file.mkstempfname('.stats.txt', directory=self.tempDir)
+        read_utils.bwamem_idxstats(inBam, self.ebolaRef, None, outStats)
+        with open(outStats, 'rt') as inf:
+            actual_count = int(inf.readline().strip().split('\t')[2])
+        self.assertGreater(actual_count, 18000)
+
 class TestFastqToFasta(TestCaseWithTmp):
 
     def test_fastq_to_fasta(self):


### PR DESCRIPTION
The rule spikein_report in reports.rules calls bwamem_and_idxstats() but the function is named bwamem_idxstats(). This corrects that and makes outBam and outStats optional, though having one or the other is required.

This addresses #460. 