### PR TITLE
update licensed tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,10 @@ env:
   - CACHE_DIR="$HOME/misc_cache"
   - MINICONDA_DIR="$HOME/miniconda"
   - PIP_DIR="$HOME/virtualenv"
-  - GATK_PATH="$CACHE_DIR/bin_bundles/GenomeAnalysisTK-3.3-0-g37228af"
+  - GATK_PATH="$CACHE_DIR/GenomeAnalysisTK-3.6"
   - NOVOALIGN_PATH="$CACHE_DIR/bin_bundles/novocraft_v3"
   - PYTHONIOENCODING=UTF8
-  - secure: l9tLtFKGNhaRdRN2N7Fiks63VatVCOtDUG7FI/pi7JNJu/EriTwDRlncoVCRCJZKOdxG8OrwC1BLX6CNqpVjJISEPGV/djsf2wCV9vi6oa+OsvMymsJAjOYkLezwRLVZp/0l/sGumPGz+q+XIM8VnkOZezIvZjGaaAtBpRTHdmA=
+  - secure: KX7DwKRD85S7NgspxevgbulTtV+jHQIiM6NBus2/Ur/P0RMdpt0EQQ2wDq79qGN70bvvkw901N7EjSYd+GWCAM7StXtaxnLRrrZ3XI1gX7KMk8E3QzPf0zualLDs7cuQmL6l6WiElUAEqumLc7WGpLZZLdSPzNqFSg+CBKCmTI8=
 
 git:
   depth: 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ env:
   - MINICONDA_DIR="$HOME/miniconda"
   - PIP_DIR="$HOME/virtualenv"
   - GATK_PATH="$CACHE_DIR/GenomeAnalysisTK-3.6"
-  - NOVOALIGN_PATH="$CACHE_DIR/bin_bundles/novocraft_v3"
   - PYTHONIOENCODING=UTF8
   - secure: KX7DwKRD85S7NgspxevgbulTtV+jHQIiM6NBus2/Ur/P0RMdpt0EQQ2wDq79qGN70bvvkw901N7EjSYd+GWCAM7StXtaxnLRrrZ3XI1gX7KMk8E3QzPf0zualLDs7cuQmL6l6WiElUAEqumLc7WGpLZZLdSPzNqFSg+CBKCmTI8=
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 
+jdk:
+  - oraclejdk8
+
 matrix:
     include:
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: python
 
-jdk:
-  - oraclejdk8
-
 matrix:
     include:
         - os: linux
@@ -19,6 +16,11 @@ matrix:
 #          env:
 #              - TRAVIS_OSX_PYTHON_VERSION=py35
 #              - TRAVIS_PYTHON_VERSION=3.5.1
+
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
 
 cache:
  directories:

--- a/travis/install-conda.sh
+++ b/travis/install-conda.sh
@@ -9,7 +9,7 @@ if [ -d "$MINICONDA_DIR" ] && [ -e "$MINICONDA_DIR/bin/conda" ]; then
         # so conda has a higher precedence
         export PATH="$MINICONDA_DIR/bin:$PATH"
     else
-        export PATH="$PATH:$MINICONDA_DIR/bin"
+        export PATH="$MINICONDA_DIR/bin:$PATH"
     fi
     hash -r
 else # if it does not exist, we need to install miniconda

--- a/travis/install-conda.sh
+++ b/travis/install-conda.sh
@@ -36,7 +36,7 @@ else # if it does not exist, we need to install miniconda
         # so conda has a higher precedence
         export PATH="$MINICONDA_DIR/bin:$PATH"
     else
-        export PATH="$PATH:$MINICONDA_DIR/bin"
+        export PATH="$MINICONDA_DIR/bin:$PATH"
     fi
     hash -r
     conda config --set always_yes yes --set changeps1 no

--- a/travis/install-conda.sh
+++ b/travis/install-conda.sh
@@ -43,6 +43,7 @@ else # if it does not exist, we need to install miniconda
     conda config --add channels bioconda
     conda config --add channels r
     conda update -y -q conda
+    conda install java-jdk==8.0.92
 fi
 
 conda info -a # for debugging

--- a/travis/install-tools.sh
+++ b/travis/install-tools.sh
@@ -7,11 +7,12 @@ if [ ! -d $GATK_PATH ]; then
     exit 1
 
   else
-    echo "Fetching encrypted Novoalign & GATK bundle for Travis"
+    echo "Fetching encrypted GATK bundle for Travis"
     pwd
-    wget http://www.broadinstitute.org/~dpark/viral_ngs-gatk_novoalign-encrypted_for_travis.tar.gz.enc
-    openssl aes-256-cbc -d -k "$BUNDLE_SECRET" -in viral_ngs-gatk_novoalign-encrypted_for_travis.tar.gz.enc -out bin_bundles.tar.gz
-    tar -xzpvf bin_bundles.tar.gz -C "$CACHE_DIR"
+    wget https://storage.googleapis.com/sabeti-public/software_testing/GenomeAnalysisTK-3.6.tar.gz.enc
+    openssl aes-256-cbc -d -k "$BUNDLE_SECRET" -in GenomeAnalysisTK-3.6.tar.gz.enc -out GenomeAnalysisTK-3.6.tar.gz
+    md5sum GenomeAnalysisTK-3.6.tar.gz
+    tar -xzpvf GenomeAnalysisTK-3.6.tar.gz -C "$CACHE_DIR"
 
   fi
 fi


### PR DESCRIPTION
remove novoalign from the encrypted tarball used by Travis during tests and update GATK to v3.6 (which requires java8 on the host, now provided by the miniconda root env). 