### PR TITLE
Depletion databases in config.yaml are now lists of full paths

### DIFF
--- a/pipes/config.yaml
+++ b/pipes/config.yaml
@@ -16,20 +16,18 @@ email_point_of_contact_for_ncbi: "someone@example.com"
 #  - https://storage.googleapis.com/sabeti-public/depletion_dbs/GRCh37.68_ncRNA-GRCh37.68_transcripts-HS_rRNA_mitRNA.tar.gz
 #  - https://storage.googleapis.com/sabeti-public/depletion_dbs/hg19.tar.gz
 #  - https://storage.googleapis.com/sabeti-public/depletion_dbs/metagenomics_contaminants_v3.tar.gz
-bmtagger_db_dir: "/idi/sabeti-scratch/kandersen/references/depletion_databases"
 bmtagger_dbs_remove:
-  - "hg19"
-  - "GRCh37.68_ncRNA-GRCh37.68_transcripts-HS_rRNA_mitRNA"
-  - "metagenomics_contaminants_v3"
+  - "/idi/sabeti-scratch/kandersen/references/depletion_databases/hg19"
+  - "/idi/sabeti-scratch/kandersen/references/depletion_databases/GRCh37.68_ncRNA-GRCh37.68_transcripts-HS_rRNA_mitRNA"
+  - "/idi/sabeti-scratch/kandersen/references/depletion_databases/metagenomics_contaminants_v3"
 
 # Path for the directory containing blast databases used for additional depletion
 # See: ftp://ftp.ncbi.nih.gov/blast/documents/formatdb.html
 #      http://www.compbio.ox.ac.uk/analysis_tools/BLAST/formatdb.shtml
 # For pre-built hosted databases, you may download:
 #  - https://storage.googleapis.com/sabeti-public/depletion_dbs/metag_v3.ncRNA.mRNA.mitRNA.consensus.tar.gz
-blast_db_dir: "/idi/sabeti-scratch/kandersen/references/depletion_databases"
-# Within blast_db_dir, the prefix of the database containing sequences to remove during depletion
-blast_db_remove: "metag_v3.ncRNA.mRNA.mitRNA.consensus"
+blast_db_remove: 
+  - "/idi/sabeti-scratch/kandersen/references/depletion_databases/metag_v3.ncRNA.mRNA.mitRNA.consensus"
 
 # A fasta file containing sequences of adapters/primers/barcodes to be removed via Trimmomatic
 # For pre-built hosted databases, you may download:

--- a/pipes/rules/hs_deplete.rules
+++ b/pipes/rules/hs_deplete.rules
@@ -30,8 +30,8 @@ rule depletion:
     resources: mem=15
     params: LSF=config.get('LSF_queues', {}).get('long', '-q forest'),
             UGER=config.get('UGER_queues', {}).get('long', '-q long'),
-            bmtaggerDbs = " ".join(expand("{dbdir}/{db}", dbdir=config["bmtagger_db_dir"], db=config["bmtagger_dbs_remove"])),
-            blastDbs = " ".join(expand("{dbdir}/{db}", dbdir=config["blast_db_dir"], db=config["blast_db_remove"])),
+            bmtaggerDbs = " ".join(expand("{db}", db=config["bmtagger_dbs_remove"])),
+            blastDbs = " ".join(expand("{db}", db=config["blast_db_remove"])),
             revert_bam = config["tmp_dir"] +'/'+config["subdirs"]["depletion"]+'/{sample}.raw.bam',
             logid="{sample}",
             threads=int(config.get("number_of_threads", 1))


### PR DESCRIPTION
Rather than list depletion databases as a single containing directory and a list of database prefixes, the config file (and hs_deplete.rules) is changed to accept a list of full paths. This allows users to specify databases that reside in different directories. This addresses #470. Note: Users will need to update old config.yaml files in their project directories.