### PR TITLE
Fix usage of samples-runs.txt in reports.rules

### DIFF
--- a/pipes/rules/reports.rules
+++ b/pipes/rules/reports.rules
@@ -27,8 +27,11 @@ rule all_ref_guided_fastqc:
 #-----------FASTQC---------------------
 
 def fastqc_report_inputs(wildcards):
-    if wildcards.adjective in ['raw', 'cleaned', 'taxfilt']:
-        return os.path.join(config["data_dir"], config["subdirs"]["per_sample"],
+    if wildcards.adjective == 'raw':
+        return os.path.join(config["data_dir"], config["subdirs"]["source"],
+                            wildcards.sample + '.bam')
+    elif wildcards.adjective in ['cleaned', 'taxfilt']:
+        return os.path.join(config["data_dir"], config["subdirs"]["depletion"],
                             wildcards.sample + '.' + wildcards.adjective + '.bam')
     elif wildcards.adjective == 'align_to_self':
         return os.path.join(config["data_dir"], config["subdirs"]["align_self"],
@@ -80,7 +83,7 @@ rule consolidate_fastqc_on_all_assemblies:
 
 if config.get("spikeins_db"):
     rule spikein_report:
-        input:  config["data_dir"]+'/'+config["subdirs"]["per_sample"]+'/{sample}.cleaned.bam'
+        input:  config["data_dir"]+'/'+config["subdirs"]["depletion"]+'/{sample}.cleaned.bam'
         output: config["reports_dir"]+'/spike_count/{sample}.spike_count.txt'
         resources: mem=3
         params: LSF=config.get('LSF_queues', {}).get('short', '-W 4:00'),


### PR DESCRIPTION
Previously snakemake rules in reports.rules assumed that
samples-runs.txt would include only sample names. This
fix allows the correct usage of samples-runs.txt -- i.e.,
in which the lines include sample names and run info.