### PR TITLE
Blacklist problematic UGER nodes

### DIFF
--- a/pipes/Broad_UGER/cluster-submitter.py
+++ b/pipes/Broad_UGER/cluster-submitter.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import re
+import getpass
 from snakemake.utils import read_job_properties
 
 LOGDIR = sys.argv[-2]
@@ -10,6 +11,15 @@ mo = re.match(r'(\S+)/snakejob\.\S+\.(\d+)\.sh', jobscript)
 assert mo
 sm_tmpdir, sm_jobid = mo.groups()
 props = read_job_properties(jobscript)
+
+# Blacklist problematic nodes; this list is stored as filenames
+# in /broad/hptmp/[username]/blacklisted-nodes/
+whoami = getpass.getuser()
+blacklisted_node_dir = os.path.join("/broad/hptmp", whoami, "blacklisted-nodes")
+if os.path.isdir(blacklisted_node_dir):
+    blacklisted_nodes = os.listdir(blacklisted_node_dir)
+else:
+    blacklisted_nodes = []
 
 # set up job name, project name
 jobname = "{rule}-{jobid}".format(rule=props["rule"], jobid=sm_jobid)
@@ -27,9 +37,17 @@ cores = cores or 1
 if mem:
     # on UGER, memory requests are per-core (according to BITS as of Sept. 6, 2016)
     mem_per_core = round((int(mem)*1024)/int(cores), 2)
-    cmdline += ' -l h_vmem={}M,h_rss={}M '.format(  mem_per_core, round(1.2 * mem_per_core, 2)  )
+    if blacklisted_nodes:
+        cmdline += " -l h_vmem={}M,h_rss={}M,h='!({})' ".format(
+            mem_per_core, round(1.2 * mem_per_core, 2),
+            '|'.join(blacklisted_nodes))
+    else:
+        cmdline += " -l h_vmem={}M,h_rss={}M ".format(
+            mem_per_core, round(1.2 * mem_per_core, 2))
     if mem >= 15 or (cores and cores >= 4):
         cmdline += ' -R y '
+elif blacklisted_nodes:
+    cmdline += " -l h='!({})' ".format('|'.join(blacklisted_nodes))
 
 if cores:
     cmdline += ' -pe smp {} -binding linear:{} '.format(int(cores), int(cores))

--- a/pipes/Broad_UGER/cluster-submitter.py
+++ b/pipes/Broad_UGER/cluster-submitter.py
@@ -38,6 +38,8 @@ if mem:
     # on UGER, memory requests are per-core (according to BITS as of Sept. 6, 2016)
     mem_per_core = round((int(mem)*1024)/int(cores), 2)
     if blacklisted_nodes:
+        # Pass h= as the hostname parameter; it accepts a regex, so
+        # invert the match to blacklist hostnames
         cmdline += " -l h_vmem={}M,h_rss={}M,h='!({})' ".format(
             mem_per_core, round(1.2 * mem_per_core, 2),
             '|'.join(blacklisted_nodes))
@@ -47,6 +49,8 @@ if mem:
     if mem >= 15 or (cores and cores >= 4):
         cmdline += ' -R y '
 elif blacklisted_nodes:
+    # Pass h= as the hostname parameter; it accepts a regex, so
+    # invert the match to blacklist hostnames
     cmdline += " -l h='!({})' ".format('|'.join(blacklisted_nodes))
 
 if cores:

--- a/pipes/Broad_UGER/jobscript.sh
+++ b/pipes/Broad_UGER/jobscript.sh
@@ -29,12 +29,14 @@ find $BLACKLISTED_NODES -name "*" -type f -mmin +2880 -delete
 if ! ls "$DATADIR"; then
     # Listing the data directory fails since the node does not have the
     # NFS share mounted
+    echo "Host '$(hostname)' does not have NFS share mounted. Retrying.." 1>&2
     touch "$BLACKLISTED_NODES/$(hostname)"
     exit 99
 fi
 if [ $(df -k /dev/shm | tail -n 1 | awk '{{print $4}}') -lt 1000000 ]; then
     # There is too little shared memory available; snakemake needs a little
     # for its use of multiprocessing.Lock() to setup logging
+    echo "Host '$(hostname)' has full or near-full /dev/shm. Retrying.." 1>&2
     touch "$BLACKLISTED_NODES/$(hostname)"
     exit 99
 fi

--- a/pipes/Broad_UGER/jobscript.sh
+++ b/pipes/Broad_UGER/jobscript.sh
@@ -34,6 +34,10 @@ REQUIRE_NFS_SHARE_MOUNTED=true
 # use of multiprocessing.Lock() to setup logging)
 REQUIRE_AVAILABLE_SHARED_MEMORY=true
 
+# Specify whether to require that a node can run java without
+# error (e.g., for some time the node 'sgi1' could not run java)
+REQUIRE_JAVA_TO_RUN=true
+
 # Perform checks on node and decide whether to blacklist
 if [[ "$REQUIRE_NFS_SHARE_MOUNTED" = true ]] && ! ls "$DATADIR"; then
     # Listing the data directory fails since the node does not have the
@@ -45,6 +49,12 @@ fi
 if [[ "$REQUIRE_AVAILABLE_SHARED_MEMORY" = true ]] && [[ $(df -k /dev/shm | tail -n 1 | awk '{{print $4}}') -lt 1000000 ]]; then
     # There is too little shared memory available
     echo "Host '$(hostname)' has full or near-full /dev/shm. Retrying.." 1>&2
+    touch "$BLACKLISTED_NODES/$(hostname)"
+    exit 99
+fi
+if [[ "$REQUIRE_JAVA_TO_RUN" = true ]] && ! java -version; then
+    # Java does not run successfully
+    echo "Host '$(hostname)' cannot run java. Retrying.." 1>&2
     touch "$BLACKLISTED_NODES/$(hostname)"
     exit 99
 fi

--- a/pipes/Broad_UGER/jobscript.sh
+++ b/pipes/Broad_UGER/jobscript.sh
@@ -38,6 +38,11 @@ if [ $(df -k /dev/shm | tail -n 1 | awk '{{print $4}}') -lt 1000000 ]; then
     touch "$BLACKLISTED_NODES/$(hostname)"
     exit 99
 fi
+if ! python3 -c 'from Bio import SeqIO'; then
+    # This sporadically fails, perhaps due to NFS lag; it may be
+    # available on a retry
+    exit 99
+fi
 
 
 echo $JOB_ID

--- a/pipes/Broad_UGER/jobscript.sh
+++ b/pipes/Broad_UGER/jobscript.sh
@@ -38,11 +38,6 @@ if [ $(df -k /dev/shm | tail -n 1 | awk '{{print $4}}') -lt 1000000 ]; then
     touch "$BLACKLISTED_NODES/$(hostname)"
     exit 99
 fi
-if ! python3 -c 'from Bio import SeqIO'; then
-    # This sporadically fails, perhaps due to NFS lag; it may be
-    # available on a retry
-    exit 99
-fi
 
 
 echo $JOB_ID

--- a/pipes/Broad_UGER/jobscript.sh
+++ b/pipes/Broad_UGER/jobscript.sh
@@ -20,7 +20,7 @@ source activate "$CONDAENVDIR"
 # nodes. When a node fails a check, add its hostname to the list and exit 99
 # to reschedule the job. Blacklist these nodes via qsub
 # Maintain the list of blacklisted nodes as filenames in /broad/hptmp/$(whoami)/blacklisted-nodes
-BLACKLISTED_NODES="/broad/hptmp/$(whoami)/blacklisted-nodes/"
+BLACKLISTED_NODES="/broad/hptmp/$(whoami)/blacklisted-nodes"
 mkdir -p $BLACKLISTED_NODES
 
 # Cleanup blacklisted nodes if they have not been touched in a day
@@ -29,13 +29,13 @@ find $BLACKLISTED_NODES -name "*" -type f -mmin +2880 -delete
 if ! ls "$DATADIR"; then
     # Listing the data directory fails since the node does not have the
     # NFS share mounted
-    touch "$BLACKLISTED_NODES$(hostname)"
+    touch "$BLACKLISTED_NODES/$(hostname)"
     exit 99
 fi
 if [ $(df -k /dev/shm | tail -n 1 | awk '{{print $4}}') -lt 1000000 ]; then
     # There is too little shared memory available; snakemake needs a little
-    # for its use of multiprocessing.Lock()
-    touch "$BLACKLISTED_NODES$(hostname)"
+    # for its use of multiprocessing.Lock() to setup logging
+    touch "$BLACKLISTED_NODES/$(hostname)"
     exit 99
 fi
 


### PR DESCRIPTION
To bypass transient issues on a set of UGER nodes, maintain a
list of nodes that should be blacklisted. This list is maintained
by jobscript.sh and used in calls to qsub by cluster-submitter.py.