### PR TITLE
Fix bug in calculating number of threads for blastn depletion

### DIFF
--- a/taxon_filter.py
+++ b/taxon_filter.py
@@ -804,7 +804,7 @@ def blastn_chunked_fasta(fasta, db, chunkSize=1000000, threads=1):
     blastnPath = tools.blast.BlastnTool().install_and_get_path()
 
     # clamp threadcount to number of CPUs minus one
-    threads = min(util.misc.available_cpu_count() - 1, threads)
+    threads = max(min(util.misc.available_cpu_count() - 1, threads), 1)
 
     # determine size of input data; records in fasta file
     number_of_reads = util.file.fasta_length(fasta)


### PR DESCRIPTION
If 'util.misc.available_cpu_count()' is equal to 1, then the
number of threads to use would be set to 0 and would result
in a division by zero. This ensures that 'threads' is at least
1.