### PR TITLE
Fix bug in calculating coverage when mapped bam has no reads

### DIFF
--- a/reports.py
+++ b/reports.py
@@ -112,11 +112,12 @@ def get_assembly_stats(sample,
     if os.path.isfile(bam_fname):
         with pysam.AlignmentFile(bam_fname, 'rb') as bam:
             coverages = list([pcol.nsegments for pcol in bam.pileup()])
-        out['aln2self_cov_median'] = median(coverages)
-        out['aln2self_cov_mean'] = "%0.3f" % mean(coverages)
-        out['aln2self_cov_mean_non0'] = "%0.3f" % mean([n for n in coverages if n > 0])
-        for thresh in cov_thresholds:
-            out['aln2self_cov_%dX' % thresh] = sum(1 for n in coverages if n >= thresh)
+        if coverages:
+            out['aln2self_cov_median'] = median(coverages)
+            out['aln2self_cov_mean'] = "%0.3f" % mean(coverages)
+            out['aln2self_cov_mean_non0'] = "%0.3f" % mean([n for n in coverages if n > 0])
+            for thresh in cov_thresholds:
+                out['aln2self_cov_%dX' % thresh] = sum(1 for n in coverages if n >= thresh)
 
     return (header, out)
 


### PR DESCRIPTION
If a genome assembles but there are no reads mapped to it (e.g.,
because the unambiguous stretches are so short), then reports.py
would give an error when calculating median coverage. This fixes
that by only reporting coverage quantiles when there are mapped
reads.