### PR TITLE
tools.bwa.align_mem_one_rg() should only remove the bam if it's a temp file

### DIFF
--- a/tools/bwa.py
+++ b/tools/bwa.py
@@ -121,6 +121,7 @@ class Bwa(tools.Tool):
 
         headerFile = util.file.mkstempfname('.{}.header.txt'.format(rgid))
         # Strip inBam to just one RG (if necessary)
+        removeInput = False
         if len(rgs) == 1:
             one_rg_inBam = inBam
             tools.samtools.SamtoolsTool().dumpHeader(one_rg_inBam, headerFile)
@@ -133,6 +134,7 @@ class Bwa(tools.Tool):
                 return
             # simplify BAM header otherwise Novoalign gets confused
             one_rg_inBam = util.file.mkstempfname('.{}.in.bam'.format(rgid))
+            removeInput = True
             
             with open(headerFile, 'wt') as outf:
                 for row in samtools.getHeader(inBam):
@@ -159,7 +161,12 @@ class Bwa(tools.Tool):
         # rather than reheader the alignment bam file later so it has the readgroup information
         # from the original bam file, we'll pass the RG line to bwa to write out
         self.mem(one_rg_inBam, refDb, aln_bam_prefilter, opts=options+['-R', readgroup_line.rstrip("\n").rstrip("\r")], min_qual=min_qual, threads=threads)
-        os.unlink(one_rg_inBam)
+        
+        # if there was more than one RG in the input, we had to create a temporary file with the one RG specified
+        # and we can safely delete it this file
+        # if there was only one RG in the input, we used it directly and should not delete it
+        if removeInput:
+            os.unlink(one_rg_inBam)
 
         # @haydenm says: 
         # For some reason (particularly when the --sensitive option is on), bwa


### PR DESCRIPTION
If there was more than one RG in the input, we had to create a temporary file with the one RG specified and we can safely delete the bam. If there was only one RG in the input, we used it directly and should not delete it.