### PR TITLE
downgrade matplotlib

### DIFF
--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -20,7 +20,7 @@ trinity=date.2011_11_26
 vphaser2=2.0
 # Python packages below
 biopython=1.68
-matplotlib=1.5.3
+matplotlib=1.5.1
 future>=0.15.2
 PyYAML=3.11
 pysam=0.9.1


### PR DESCRIPTION
matplotlib 1.5.3 vanished from the defaults conda channel, so we will
downgrade until bioconda depends on conda-forge, then we can upgrade
again