### PR TITLE
Add --wait-submit option to run-pipe

### DIFF
--- a/pipes/Broad_UGER/jobscript.sh
+++ b/pipes/Broad_UGER/jobscript.sh
@@ -65,6 +65,7 @@ echo $JOB_ID
 echo "=============================="
 
 {exec_job}
+EXIT_STATUS=$?
 
 # Report resource consumption because it's not reported by default
 echo "------------------------------"
@@ -75,4 +76,13 @@ qstat -j $JOB_ID | grep '^usage'
 # an error code of 100 is needed since UGER only prevents execution of dependent jobs if the preceding
 # job exits with error code 100
 
-cat $1 &>/dev/null && exit 0 || exit 100
+cat $1 &>/dev/null
+if [[ $? -eq 0 ]]; then
+    exit 0
+else
+    if [[ "{immediate_submit}" -eq "True" ]]; then
+        exit 100
+    else
+        exit $EXIT_STATUS
+    fi
+fi

--- a/pipes/Broad_UGER/jobscript.sh
+++ b/pipes/Broad_UGER/jobscript.sh
@@ -80,7 +80,7 @@ cat $1 &>/dev/null
 if [[ $? -eq 0 ]]; then
     exit 0
 else
-    if [[ "{immediate_submit}" -eq "True" ]]; then
+    if [[ "{workflow.immediate_submit}" -eq "True" ]]; then
         exit 100
     else
         exit $EXIT_STATUS

--- a/requirements-pipes.txt
+++ b/requirements-pipes.txt
@@ -1,3 +1,3 @@
 boto==2.38.0
-snakemake==3.8.2
+snakemake==3.9.0
 PyYAML==3.11


### PR DESCRIPTION
This results in not submitting all jobs to the cluster scheduler with
dependencies right away, instead letting snakemake take control of
submitting jobs. Useful because the errored jobs in Eqw count against
your quota even though snakemake is unaware of this.

Will need to wait on snakemake update as well.
