### PR TITLE
update metagenomics memory spec to be total per-job, rather than per-core

### DIFF
--- a/pipes/rules/metagenomics.rules
+++ b/pipes/rules/metagenomics.rules
@@ -40,7 +40,7 @@ rule diamond:
     output: report=join(config["data_dir"], config["subdirs"]["metagenomics"], "{sample}.{adjective,raw|cleaned}.diamond.report"),
             lca=join(config["data_dir"], config["subdirs"]["metagenomics"], "{sample}.{adjective,raw|cleaned}.diamond.lca.gz")
     resources: cores=int(config.get("number_of_threads", 1)),
-               mem=15
+               mem=120
     params: numThreads=str(config.get("number_of_threads", 1)),
             UGER=config.get('UGER_queues', {}).get('long', '-q long')
     shell:
@@ -53,7 +53,7 @@ rule kraken:
     output: report=join(config["data_dir"], config["subdirs"]["metagenomics"], "{sample}.{adjective,raw|cleaned}.kraken.report"),
             reads=join(config["data_dir"], config["subdirs"]["metagenomics"], "{sample}.{adjective,raw|cleaned}.kraken.reads.gz")
     resources: cores=int(config.get("number_of_threads", 1)),
-               mem=15
+               mem=120
     params: numThreads=str(config.get("number_of_threads", 1)),
             UGER=config.get('UGER_queues', {}).get('long', '-q long')
     shell:
@@ -69,7 +69,7 @@ rule align_rna:
             lca=join(config["data_dir"], config["subdirs"]["metagenomics"], "{sample}.{adjective,raw|cleaned}.rna_bwa.lca.gz"),
             nodupes_lca=join(config["data_dir"], config["subdirs"]["metagenomics"], "{sample}.{adjective,raw|cleaned}.rna_bwa.lca_nodupes.gz")
     resources: cores=int(config.get("number_of_threads", 1)),
-               mem=8
+               mem=64
     params: numThreads=str(config.get("number_of_threads", 1)),
             UGER=config.get('UGER_queues', {}).get('long', '-q long')
     shell:
@@ -81,7 +81,7 @@ rule krona_import_taxonomy:
     input: lambda wildcards: join(config["data_dir"], config["subdirs"]["metagenomics"], \
            ".".join([wildcards.sample, wildcards.adjective, method_props[wildcards.method]['reads_ext']]))
     output: join(config["data_dir"], config["subdirs"]["metagenomics"], "{sample}.{adjective,raw|cleaned}.{method,kraken|diamond|rna_bwa|rna_bwa_nodupes}.krona.html")
-    resources: mem=4
+    resources: mem=32
     shell:
         """
         {config[bin_dir]}/metagenomics.py krona {input} {config[krona_db]} {output} --noRank


### PR DESCRIPTION
update metagenomics memory spec to be total per-job, rather than per-core, since cluster-submitter.py handles the adjustment to account for UGER per-core spec