### PR TITLE
Raise exception if inputs cannot be found for merge_one_per_sample

### DIFF
--- a/pipes/rules/hs_deplete.rules
+++ b/pipes/rules/hs_deplete.rules
@@ -63,6 +63,11 @@ rule filter_to_taxon:
             logid="{sample}"
     shell:  "{config[bin_dir]}/taxon_filter.py filter_lastal_bam {input[0]} {params.lastalDb} {output}"
 
+
+class MergeInputException(Exception):
+    '''Cannot find merging multiplexed sample inputs'''
+
+
 def merge_one_per_sample_inputs(wildcards):
     if 'seqruns_demux' not in config or not os.path.isfile(config['seqruns_demux']):
         if wildcards.adjective == 'raw':
@@ -79,7 +84,12 @@ def merge_one_per_sample_inputs(wildcards):
               else:
                  runs.add(os.path.join(config["data_dir"], config["subdirs"]["depletion"],
                     get_run_id(well) +'.'+ lane['flowcell'] +'.'+ lane['lane'] +'.'+ wildcards.adjective + '.bam'))
+    if not runs:
+        raise MergeInputException(
+            "Cannot find inputs to merge into '{}.{}.bam'. Make sure to check 'flowcells.txt' and 'barcodes.txt' "
+            "to ensure they match up with the sample bams.".format(wildcards.sample, wildcards.adjective))
     return sorted(runs)
+
 rule merge_one_per_sample:
     ''' All of the above depletion steps are run once per flowcell per lane per
         multiplexed sample.  This reduces recomputation on the same data when
@@ -102,4 +112,3 @@ rule merge_one_per_sample:
             else:
                 shell("{config[bin_dir]}/read_utils.py merge_bams {input} {params.tmpf_bam} --picardOptions SORT_ORDER=queryname")
                 shell("{config[bin_dir]}/read_utils.py rmdup_mvicuna_bam {params.tmpf_bam} {output} --JVMmemory 8g")
-


### PR DESCRIPTION
Previously would try to execute with empty input.