### PR TITLE
cmd.py should check for UGER job ID as well as LSF job ID

### DIFF
--- a/util/file.py
+++ b/util/file.py
@@ -98,9 +98,10 @@ def set_tmp_dir(name):
     proposed_prefix = ['tmp']
     if name:
         proposed_prefix.append(name)
-    for e in ('LSB_JOBID', 'LSB_JOBINDEX'):
+    for e in ('LSB_JOBID', 'LSB_JOBINDEX', 'JOB_ID'):
         if e in os.environ:
             proposed_prefix.append(os.environ[e])
+            break
     tempfile.tempdir = tempfile.mkdtemp(prefix='-'.join(proposed_prefix) + '-', dir=util.cmd.find_tmp_dir())
     return tempfile.tempdir
 


### PR DESCRIPTION
We go out of our way to use `/local/scratch` as the temp location if we are running on an LSF node (detectable via `LSB_JOBID`). This extends the cluster check to include UGER/GridEngine’s `JOB_ID`