### PR TITLE
reduce output verbosity

### DIFF
--- a/pipes/Broad_UGER/jobscript.sh
+++ b/pipes/Broad_UGER/jobscript.sh
@@ -40,7 +40,7 @@ REQUIRE_AVAILABLE_SHARED_MEMORY=true
 REQUIRE_JAVA_TO_RUN=true
 
 # Perform checks on node and decide whether to blacklist
-if [[ "$REQUIRE_NFS_SHARE_MOUNTED" = true ]] && ! ls "$DATADIR"; then
+if [[ "$REQUIRE_NFS_SHARE_MOUNTED" = true ]] && ! $(ls "$DATADIR" &> /dev/null); then
     # Listing the data directory fails since the node does not have the
     # NFS share mounted
     echo "Host '$(hostname)' does not have NFS share mounted. Retrying.." 1>&2

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -421,9 +421,9 @@ class CondaPackage(InstallMethod):
     def _attempt_install(self):
         try:
             # check for presence of conda command
-            util.misc.run_and_print(["conda", "-V"], loglevel=logging.INFO, check=True, env=self.conda_env)
+            util.misc.run_and_print(["conda", "-V"], buffered=True, check=True, env=self.conda_env, silent=True)
         except:
-            _log.debug("conda NOT installed")
+            _log.warning("conda NOT installed")
             self._is_attempted = True
             self.installed = False
             return

--- a/util/cmd.py
+++ b/util/cmd.py
@@ -192,7 +192,7 @@ def main_argparse(commands, description):
         for e in ('LSB_JOBID', 'JOB_ID'): # LSB_JOBID is for LSF, JOB_ID is for UGER/GridEngine
             if e in os.environ:
                 proposed_dir = 'tmp-%s-%s-%s-%s' % (script_name(), args.command, os.environ[e],
-                                                    os.environ['LSB_JOBINDEX'])
+                                                    os.environ.get('LSB_JOBINDEX','0'))
                 break
         tempfile.tempdir = tempfile.mkdtemp(prefix='%s-' % proposed_dir, dir=args.tmp_dir)
         log.debug("using tempDir: %s", tempfile.tempdir)


### PR DESCRIPTION
This removes the frequent conda versions inserted into log files, as well as the ‘ls’ output that is part of the UGER blacklist check. It also corrects an issue with LSB_JOBINDEX on UGER systems