### PR TITLE
Update pytest version to conda-available verison

### DIFF
--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -27,6 +27,6 @@ pysam=0.9.1
 pycodestyle
 mock==2.0.0
 six<2
-pytest=2.9.1
-pytest-cov=2.2.1
-pytest-xdist=1.14
+pytest=3.0.5
+pytest-cov=2.4.0
+pytest-xdist=1.15.0

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,8 +1,8 @@
-pytest==2.9.1
+pytest==3.0.5
 coveralls==1.1
 pycodestyle
 mock==2.0.0
 six<2
-pytest-cov==2.2.1
+pytest-cov==2.4.0
 pytest-logging==2015.11.4
-pytest-xdist==1.14
+pytest-xdist==1.15.0


### PR DESCRIPTION
Necessary to support fixture executions plugin but 2.9.3 is not in conda channels