### PR TITLE
Handle coverage_lca for references with missing taxids

### DIFF
--- a/metagenomics.py
+++ b/metagenomics.py
@@ -328,7 +328,7 @@ def coverage_lca(query_ids, parents, lca_percent=100):
         path = []
         while query_id != 1:
             path.append(query_id)
-            if parents[query_id] == 0:
+            if parents.get(query_id, 0) == 0:
                 log.warn('Parent for query id: {} missing'.format(query_id))
                 break
             query_id = parents[query_id]

--- a/test/unit/test_metagenomics.py
+++ b/test/unit/test_metagenomics.py
@@ -292,3 +292,11 @@ def test_kraken_dfs_report(taxa_db):
     report = metagenomics.kraken_dfs_report(taxa_db, hits)
     text_report = '\n'.join(list(report)) + '\n'
     assert text_report == expected
+
+
+def test_coverage_lca(taxa_db):
+    assert metagenomics.coverage_lca([10, 11, 12], taxa_db.parents) == 6
+    assert metagenomics.coverage_lca([1, 3], taxa_db.parents) == 1
+    assert metagenomics.coverage_lca([6, 7, 8], taxa_db.parents) == 6
+    assert metagenomics.coverage_lca([10, 11, 12], taxa_db.parents, 50) == 7
+    assert metagenomics.coverage_lca([9], taxa_db.parents) is None


### PR DESCRIPTION
Some reference sequences may be set to `taxid: 0`