### PR TITLE
harden samplesheet input

### DIFF
--- a/illumina.py
+++ b/illumina.py
@@ -477,7 +477,16 @@ class SampleSheet(object):
                         miseq_skip = True
                     elif header is None:
                         header = row
-                        if 'Sample_ID' in header:
+                        if all(x in header for x in ['Sample_ID','Index']):
+                            # this is a Broad Platform MiSeq-generated SampleSheet.csv
+                            keymapper = {
+                                'Sample_ID': 'sample',
+                                'Index': 'barcode_1',
+                                'Index2': 'barcode_2',
+                                'Sample_Name': 'sample_name'
+                            }
+                            header = list(map(keymapper.get, header))
+                        elif 'Sample_ID' in header:
                             # this is a MiSeq-generated SampleSheet.csv
                             keymapper = {
                                 'Sample_ID': 'sample',
@@ -487,7 +496,7 @@ class SampleSheet(object):
                             }
                             header = list(map(keymapper.get, header))
                         elif 'SampleID' in header:
-                            # this is a Broad Platform generated SampleSheet.csv
+                            # this is a Broad Platform HiSeq-generated SampleSheet.csv
                             keymapper = {
                                 'SampleID': 'sample',
                                 'Index': 'barcode_1',

--- a/test/input/TestSampleSheet/SampleSheet-in-Broad-MiSeq-Format_with_Picard_Block.csv
+++ b/test/input/TestSampleSheet/SampleSheet-in-Broad-MiSeq-Format_with_Picard_Block.csv
@@ -1,0 +1,45 @@
+[Header],,,,
+Investigator Name,Lisa,,,
+Project Name,WUS lmf 2,,,
+Experiment Name,General,,,
+Date,1/10/2017,,,
+Workflow,Resequencing,,,
+Chemistry,Amplicon,,,
+,,,,
+[Reads],,,,
+150,,,,
+Index,,,,
+Index,,,,
+150,,,,
+,,,,
+[Manifests],,,,
+A,ManifestNameHere,,,
+,,,,
+[Settings],,,,
+FilterPCRDuplicates,1,,,
+OnlyGenerateFastq,0,,,
+,,,,
+[Data],,,,
+Sample_ID,Sample_Name,GenomeFolder,Index,Index2
+123618_MGH015B_repeat(Lisa),MGH015B_repeat(Lisa),,AGGCAGAA,TATCCTCT
+123617_WB-MF-1e4,WB-MF-1e4,,GGACTCCT,TATCCTCT
+123616_WB-1e4,WB-1e4,,TCCTGAGC,CTCTCTAT
+123615_WB-MF-1e6,WB-MF-1e6,,AGGCAGAA,CTCTCTAT
+123614_WB-1e6,WB-1e6,,CGTACTAG,CTCTCTAT
+123613_Plasma-MF-1e6,Plasma-MF-1e6,,TAAGGCGA,CTCTCTAT
+123612_Plasma-1e6,Plasma-1e6,,GGACTCCT,TAGATCGC
+123611_Plasma-MF-1e4,Plasma-MF-1e4,,TCCTGAGC,TAGATCGC
+123610_Plasma-1e4,Plasma-1e4,,AGGCAGAA,TAGATCGC
+123609_Plasma-MF-1e2,Plasma-MF-1e2,,CGTACTAG,TAGATCGC
+123608_Plasma-1e2,Plasma-1e2,,TAAGGCGA,TAGATCGC
+,,,,
+[Picard],,,,
+analysisType,WholeGenomeShotgun.AssemblyWithoutReference,,,
+referenceSequence,,,,
+referenceVersion,0,,,
+baitSetName,,,,
+enzyme,Mspl,,,
+fragSizeRange,,,,
+projectManagerEmail,someone@example.com,,,
+walkupNotes,Walk Up Sequencing,,,
+libraryName,EVSpikeins,,,

--- a/test/unit/test_illumina.py
+++ b/test/unit/test_illumina.py
@@ -72,6 +72,12 @@ class TestSampleSheet(TestCaseWithTmp):
         self.assertEqual(samples.num_indexes(), 2)
         self.assertEqual(len(samples.get_rows()), 12)
 
+    def test_blank_line_in_tabular_section(self):
+        inDir = util.file.get_test_input_path(self)
+        samples = illumina.SampleSheet(os.path.join(inDir, 'SampleSheet-in-Broad-MiSeq-Format_with_Picard_Block.csv'))
+        self.assertEqual(samples.num_indexes(), 2)
+        self.assertEqual(len(samples.get_rows()), 11)
+
 
 class TestRunInfo(TestCaseWithTmp):
 


### PR DESCRIPTION
Samplesheets from Broad walkup MiSeqs can be formatted slightly
differently from Broad HiSeq sheets (underscore in “Sample_ID”), and
different still from OEM MiSeq sheets (“Index” is capitalized). This
adds an extra conditional to handle them, along with a test case.