### PR TITLE
Add novoalign as an option for reports.py::align_and_plot_coverage

### DIFF
--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -31,3 +31,5 @@ six<2
 pytest=3.0.5
 pytest-cov=2.4.0
 pytest-xdist=1.15.0
+bedtools=2.26.0
+pybedtools=0.7.8


### PR DESCRIPTION
Add novoalign as an option for reports.py::align_and_plot_coverage,
with the same default parameters we use in map_reads_to_self. Also
change the plot default dimensions to print to an 11x8.5 ratio (print
aspect ratio, rather than screen). bedtools is now used for coverage
depth where duplicates are desired, and samtools is used where
duplicates should be excluded. former ignores marked duplicates from
its depth count while bedtools includes them