### PR TITLE
work around tbl2asn out-of-date quirk

### DIFF
--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -16,6 +16,7 @@ picard=2.5.0
 prinseq=0.20.4
 samtools=1.3.1
 snpeff=4.1l
+tbl2asn
 trimmomatic=0.36
 trinity=date.2011_11_26
 vphaser2=2.0

--- a/tools/tbl2asn.py
+++ b/tools/tbl2asn.py
@@ -14,7 +14,6 @@ import subprocess
 import gzip
 
 TOOL_NAME = "tbl2asn"
-TOOL_VERSION = "25.3"
 TOOL_URL = 'ftp://ftp.ncbi.nih.gov/toolbox/ncbi_tools/converters/by_program/tbl2asn/{os}.tbl2asn.gz'
 
 log = logging.getLogger(__name__)
@@ -25,7 +24,7 @@ class Tbl2AsnTool(tools.Tool):
     def __init__(self, install_methods=None):
         if install_methods is None:
             install_methods = []
-            install_methods.append(tools.CondaPackage(TOOL_NAME, version=TOOL_VERSION))
+            install_methods.append(tools.CondaPackage(TOOL_NAME))
             install_methods.append(DownloadGzipBinary(TOOL_URL.format(os=get_bintype()), 'tbl2asn'))
         tools.Tool.__init__(self, install_methods=install_methods)
 
@@ -68,7 +67,20 @@ class Tbl2AsnTool(tools.Tool):
             tool_cmd += ['-X', 'C']
 
         log.debug(' '.join(tool_cmd))
-        subprocess.check_call(tool_cmd)
+
+        # tbl2asn has a fun quirk where if the build is more than a year old
+        # it exits with a non-zero code and tells you to upgrade
+        # See: https://www.ncbi.nlm.nih.gov/IEB/ToolBox/C_DOC/lxr/source/demo/tbl2asn.c#L9674
+        # We can try to work around this by examining the output for the upgrade message
+        try:
+            subprocess.check_output(tool_cmd)
+        except subprocess.CalledProcessError as e:
+            old_version_expected_output = "This copy of tbl2asn is more than a year old.  Please download the current version."
+            if old_version_expected_output in e.output:
+                pass
+            else:
+                raise
+
     # pylint: enable=W0221
 
 


### PR DESCRIPTION
tbl2asn has a fun quirk where if the build is more than a year old it exits with a non-zero code and tells you to upgrade. we attempt to work around that by examining its output. also add tbl2asn to requirements-conda.txt and omit the version pin for tbl2asn so we always install the latest version available on bioconda