### PR TITLE
Avoid exception when two sequences do not overlap

### DIFF
--- a/interhost.py
+++ b/interhost.py
@@ -289,15 +289,16 @@ class CoordMapper2Seqs(object):
                 finalPos1 = baseCount1  # Last pair of aligned real bases so far
             else:
                 gapSinceLast = True
-        if len(self.mapArrays[0]) == 0:
-            raise Exception('CoordMapper2Seqs: no aligned bases.')
-        if self.mapArrays[0][-1] != finalPos0:
-            self.mapArrays[0].append(finalPos0)
-            self.mapArrays[1].append(finalPos1)
+        if len(self.mapArrays[0]) > 0:
+            if self.mapArrays[0][-1] != finalPos0:
+                self.mapArrays[0].append(finalPos0)
+                self.mapArrays[1].append(finalPos1)
 
     def __call__(self, fromPos, fromWhich):
         """ fromPos: 1-based coordinate
             fromWhich: if 0, map from 1st sequence to 2nd, o.w. 2nd to 1st."""
+        if len(self.mapArrays[0]) == 0:
+            raise Exception('CoordMapper2Seqs: no aligned bases.')
         if fromPos != int(fromPos):
             raise TypeError('CoordMapper2Seqs: pos %s is not an integer' % fromPos)
         fromArray = self.mapArrays[fromWhich]

--- a/test/unit/test_interhost.py
+++ b/test/unit/test_interhost.py
@@ -224,13 +224,15 @@ class TestSpecificAlignments(test.TestCaseWithTmp):
     def test_no_real_bases_in_sample(self):
         alignment1 = makeTempFasta([('s1', 'AA'), ('s2', '--'),])
         cm = interhost.CoordMapper()
+        cm.load_alignments([alignment1])
         with self.assertRaises(Exception):
-            cm.load_alignments([alignment1])
+            cm.mapChr('s1', 's2', 1)
 
         alignment2 = makeTempFasta([('s1', '--'), ('s2', 'AA'), ('s3', 'TT'),])
         cm = interhost.CoordMapper()
+        cm.load_alignments([alignment2])
         with self.assertRaises(Exception):
-            cm.load_alignments([alignment2])
+            cm.mapChr('s2', 's1', 1)
 
     def test_no_real_bases_at_position(self):
         alignment = makeTempFasta([('s1', 'AT-G'), ('s2', 'AC-G'), ('s3', 'AG-T'),])


### PR DESCRIPTION
CoordMapper does not work when there are two sequences that do not overlap.
For example, consider an alignment of length 7 in which there are many
sequences, two of which are:
  --at----
  -----cg-
In this case, CoordMapper2Seqs cannot be instantiated on these
sequences; it raises Exception('CoordMapper2Seqs: no aligned bases.')
because there are no 'real' bases that overlap in the alignment.

This commit allows the object to be created by moving the check from
`__init__()` to `__call__()`. Since the sequences do not overlap,
`__call__()` should not be invoked and, therefore, an exception will
not be raised.