### PR TITLE
updated links to contaminants.fasta.tar.gz in docs and config.yaml

### DIFF
--- a/docs/pipeuse.rst
+++ b/docs/pipeuse.rst
@@ -243,7 +243,7 @@ contaminents from reads:
 
 Pre-built databases for Trimmomatic:
 
--  `contaminants.fasta.tar.gz <https://console.cloud.google.com/m/cloudstorage/b/sabeti-public/o/depletion_dbs/contaminants.fasta.tar.gz>`__ (`*.lz4 <https://console.cloud.google.com/m/cloudstorage/b/sabeti-public/o/depletion_dbs/contaminants.fasta.lz4>`__)
+-  `contaminants.fasta.tar.gz <https://storage.googleapis.com/sabeti-public/depletion_dbs/contaminants.fasta.tar.gz>`__ (`*.lz4 <https://storage.googleapis.com/sabeti-public/depletion_dbs/contaminants.fasta.lz4>`__)
 
 A FASTA file containing spike-ins to be reported:
 

--- a/pipes/config.yaml
+++ b/pipes/config.yaml
@@ -33,7 +33,7 @@ blast_db_remove:
 
 # A fasta file containing sequences of adapters/primers/barcodes to be removed via Trimmomatic
 # For pre-built hosted databases, you may download:
-#  - https://console.cloud.google.com/m/cloudstorage/b/sabeti-public/o/depletion_dbs/contaminants.fasta.tar.gz
+#  - https://storage.googleapis.com/sabeti-public/depletion_dbs/contaminants.fasta.tar.gz
 trim_clip_db: "/idi/sabeti-scratch/shared-resources/depletion-databases/contaminants.fasta"
 
 # a fasta file containing sequences to report downstream as spike-ins


### PR DESCRIPTION
along with this the contaminants.fasta file has been updated to include NexteraXT adapters