### PR TITLE
restored redundant testing where unit tests get run for a pull request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,8 @@ install:
   - travis/install-pip.sh
 
 script:
-  - travis/tests-unit.sh
   - travis/tests-long.sh
+  - travis/tests-unit.sh
 
 after_success:
   - coveralls

--- a/travis/tests-unit.sh
+++ b/travis/tests-unit.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 #set -e
 
-if [ $TRAVIS_PULL_REQUEST == "false" ]; then
+UNIT_TESTS_ALWAYS=1
+
+if [ $UNIT_TESTS_ALWAYS ] || [ $TRAVIS_PULL_REQUEST == "false" ]; then
     export PYTEST_ADDOPTS="-rsxX -n 2 --durations=50 --fixture-durations=20 --junit-xml=pytest.xml --cov-report= --cov broad_utils --cov illumina --cov assembly --cov interhost --cov intrahost --cov metagenomics --cov ncbi --cov read_utils --cov reports --cov taxon_filter --cov tools --cov util"
     py.test test/unit
 else


### PR DESCRIPTION
restored redundant testing where unit tests get run for a pull request even though they have already been run for the corresponding branch, until we figure out how to avoid doing that without confusing coveralls coverage metrics.  changed long integration tests to run first on a pull request so failures do not take longer to report than before.