### PR TITLE
added a util to check that paths passed to a command can be read/writen as required

### DIFF
--- a/test/unit/test_util_file.py
+++ b/test/unit/test_util_file.py
@@ -4,7 +4,6 @@ __author__ = "ilya@broadinstitute.org"
 
 import os, os.path
 import pytest
-import tempfile
 import util.file
 
 def testTempFiles():

--- a/test/unit/test_util_file.py
+++ b/test/unit/test_util_file.py
@@ -4,6 +4,7 @@ __author__ = "ilya@broadinstitute.org"
 
 import os, os.path
 import pytest
+import tempfile
 import util.file
 
 def testTempFiles():
@@ -47,4 +48,28 @@ def testTempFiles():
             util.file.slurp_file(my_tmp_fn, maxSizeMb=1)
 
     assert not os.path.isfile(my_tmp_fn)
+
+def test_check_paths():
+    '''Test the util.file.check_paths()'''
+    from os.path import join
+    from util.file import check_paths
+    inDir = util.file.get_test_input_path()
+    def test_f(f):
+        return join(inDir, f)
+    check_paths(read=test_f('empty.bam'))
+    check_paths(read=[test_f('empty.bam')])
+    with pytest.raises(Exception):
+        check_paths(read=test_f('non_existent_file'))
+    with pytest.raises(Exception):
+        check_paths(write='/non/writable/dir/file.txt')
+    with tempfile.TemporaryDirectory() as writable_dir:
+        check_paths(write=(join(writable_dir, 'mydata1.txt'),
+                           join(writable_dir, 'mydata2.txt')))
+        with pytest.raises(Exception):
+            check_paths(write=writable_dir)
+            
+        util.file.make_empty(join(writable_dir, 'myempty.dat'))
+        check_paths(read_and_write=join(writable_dir, 'myempty.dat'))
+        
+
 

--- a/test/unit/test_util_file.py
+++ b/test/unit/test_util_file.py
@@ -49,7 +49,7 @@ def testTempFiles():
 
     assert not os.path.isfile(my_tmp_fn)
 
-def test_check_paths():
+def test_check_paths(tmpdir):
     '''Test the util.file.check_paths()'''
     from os.path import join
     from util.file import check_paths
@@ -62,14 +62,15 @@ def test_check_paths():
         check_paths(read=test_f('non_existent_file'))
     with pytest.raises(Exception):
         check_paths(write='/non/writable/dir/file.txt')
-    with tempfile.TemporaryDirectory() as writable_dir:
-        check_paths(write=(join(writable_dir, 'mydata1.txt'),
-                           join(writable_dir, 'mydata2.txt')))
-        with pytest.raises(Exception):
-            check_paths(write=writable_dir)
-            
-        util.file.make_empty(join(writable_dir, 'myempty.dat'))
-        check_paths(read_and_write=join(writable_dir, 'myempty.dat'))
+    writable_dir = str(tmpdir)
+    check_paths(write=(join(writable_dir, 'mydata1.txt'),
+                       join(writable_dir, 'mydata2.txt')))
+    with pytest.raises(Exception):
+        check_paths(write=writable_dir)
+
+    util.file.make_empty(join(writable_dir, 'myempty.dat'))
+    check_paths(read_and_write=join(writable_dir, 'myempty.dat'))
+
         
 
 

--- a/util/file.py
+++ b/util/file.py
@@ -82,6 +82,28 @@ def get_resources():
         resources = json.load(inf)
     return resources
 
+def check_paths(read=(), write=(), read_and_write=()):
+    '''Check that we can read and write the specified files, throw an exception if not.  Useful for checking
+    error conditions early in the execution of a command.  Each arg can be a filename or iterable of filenames.
+    '''
+    read, write, read_and_write = map(util.misc.make_seq, (read, write, read_and_write))
+    assert not (set(read) & set(write))
+    assert not (set(read) & set(read_and_write))
+    assert not (set(write) & set(read_and_write))
+    
+    for fname in read+read_and_write:
+        with open(fname):
+            pass
+
+    for fname in write+read_and_write:
+        if not os.path.exists(fname):
+            with open(fname, 'w'):
+                pass
+            os.unlink(fname)
+        else:
+            if not (os.path.isfile(fname) and os.access(fname, os.W_OK)):
+                raise PermissionError('Cannot write ' + fname)
+
 
 def mkstempfname(suffix='', prefix='tmp', directory=None, text=False):
     ''' There's no other one-liner way to securely ask for a temp file by


### PR DESCRIPTION
Added a util to check that paths passed to a command can be read/writen as required.  ( This was part of PR #656 is-spades-2, but orthogonal to that PR so factoring it out here.)