### PR TITLE
assert_md5_equal_to_line_in_file now accepts msg

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -52,7 +52,7 @@ def assert_equal_bam_reads(testCase, bam_filename1, bam_filename2):
             if os.path.exists(fname):
                 os.unlink(fname)
 
-def assert_md5_equal_to_line_in_file(testCase, filename, checksum_file):
+def assert_md5_equal_to_line_in_file(testCase, filename, checksum_file, failure_message=None):
     ''' Compare the checksum of a test file with the expected checksum
         stored in a second file
           compare md5(test_output.bam) with expected_output.bam.md5:1
@@ -71,7 +71,7 @@ def assert_md5_equal_to_line_in_file(testCase, filename, checksum_file):
 
     assert len(expected_checksum) > 0
 
-    testCase.assertEqual(hash_md5.hexdigest(), expected_checksum)
+    testCase.assertEqual(hash_md5.hexdigest(), expected_checksum, msg=failure_message)
 
 class TestCaseWithTmp(unittest.TestCase):
     'Base class for tests that use tempDir'

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -52,7 +52,7 @@ def assert_equal_bam_reads(testCase, bam_filename1, bam_filename2):
             if os.path.exists(fname):
                 os.unlink(fname)
 
-def assert_md5_equal_to_line_in_file(testCase, filename, checksum_file, failure_message=None):
+def assert_md5_equal_to_line_in_file(testCase, filename, checksum_file, msg=None):
     ''' Compare the checksum of a test file with the expected checksum
         stored in a second file
           compare md5(test_output.bam) with expected_output.bam.md5:1
@@ -71,7 +71,7 @@ def assert_md5_equal_to_line_in_file(testCase, filename, checksum_file, failure_
 
     assert len(expected_checksum) > 0
 
-    testCase.assertEqual(hash_md5.hexdigest(), expected_checksum, msg=failure_message)
+    testCase.assertEqual(hash_md5.hexdigest(), expected_checksum, msg=msg)
 
 class TestCaseWithTmp(unittest.TestCase):
     'Base class for tests that use tempDir'


### PR DESCRIPTION
The test assertion `test.assert_md5_equal_to_line_in_file()` now accepts `failure_message`