### PR TITLE
config : fixed handling of empty subtrees

### DIFF
--- a/test/input/TestUtilMisc/cfg1.yaml
+++ b/test/input/TestUtilMisc/cfg1.yaml
@@ -12,6 +12,8 @@ std_methods:
   - b
   - c
 
+empty_subtree:
+
 stage1:
   stage2:
     step_num: 3

--- a/test/input/TestUtilMisc/cfg2.yaml
+++ b/test/input/TestUtilMisc/cfg2.yaml
@@ -17,3 +17,6 @@ stage1:
       - 3
       - 33
 
+empty_subtree:
+  x: 1
+

--- a/test/unit/test_util_misc.py
+++ b/test/unit/test_util_misc.py
@@ -229,6 +229,7 @@ class TestConfigIncludes(unittest.TestCase):
         with self.assertRaises(KeyError): cfg2["var_A"]
         self.assertFalse(cfg2["paramZ"])
         self.assertTrue(cfg1["paramZ"])
+        self.assertEqual(cfg2["empty_subtree"]["x"], 1)
 
         self.assertEqual(cfg2["std_methods"], ['a','b','c'])
         self.assertEqual(cfg2["stage1"]["stage2"]["step_num"],3)
@@ -239,11 +240,4 @@ class TestConfigIncludes(unittest.TestCase):
         self.assertEqual(cfg2["std_param_A_new"], 111)  # specified as std_param_A_old in cfg1.yaml
 
         self.assertEqual(util.misc.load_config(test_fn('empty.yaml')), {})
-
-
-
-
-
-        
-
 

--- a/util/misc.py
+++ b/util/misc.py
@@ -513,14 +513,18 @@ def load_config(cfg, include_directive='include', std_includes=(), param_renamin
         base_dir_for_includes = os.path.dirname(cfg_fname)
         cfg = load_yaml_or_json(cfg_fname)
 
+    def flatten_cfg_dict(cfg):
+        '''Flatten a config mapping, filtering out None values representing empty subtrees.'''
+        return dict((k, v) for (k, v) in flatten_dict(cfg).items() if v is not None)
+
     includes = make_seq(std_includes) + make_seq(cfg.get(include_directive, []))
     for included_cfg_fname in includes:
         if (not os.path.isabs(included_cfg_fname)) and base_dir_for_includes:
             included_cfg_fname = os.path.join(base_dir_for_includes, included_cfg_fname)
-        result.update(flatten_dict(load_config(cfg=included_cfg_fname, include_directive=include_directive,
-                                               param_renamings=param_renamings)))
+        result.update(flatten_cfg_dict(load_config(cfg=included_cfg_fname, include_directive=include_directive,
+                                                   param_renamings=param_renamings)))
 
-    cfg_flat = flatten_dict(cfg)
+    cfg_flat = flatten_cfg_dict(cfg)
 
     # load any params specified under legacy names, for backwards compatibility
     param_renamings_seq = dict(map(lambda kv: map(make_seq, kv), param_renamings.items()))


### PR DESCRIPTION
Fixed handling of empty subtrees in yaml config files.  These were being read as None values rather than as empty dicts by the yaml parser.