### PR TITLE
Set a threshold on alignment score when generating spike-in reports

### DIFF
--- a/pipes/rules/reports.rules
+++ b/pipes/rules/reports.rules
@@ -93,7 +93,7 @@ if config.get("spikeins_db"):
         run:
                 makedirs(os.path.join(config["reports_dir"], 'spike_count'))
                 makedirs(os.path.join(config["tmp_dir"], config["subdirs"]["depletion"]))
-                shell("{config[bin_dir]}/read_utils.py bwamem_idxstats {input} {params.spikeins_db} --outStats {output}")
+                shell("{config[bin_dir]}/read_utils.py bwamem_idxstats {input} {params.spikeins_db} --outStats {output} --minScoreToFilter 60")
 
     rule consolidate_spike_count:
         input:  expand("{{dir}}/spike_count/{sample}.spike_count.txt", \

--- a/reports.py
+++ b/reports.py
@@ -844,7 +844,7 @@ def parser_align_and_plot_coverage(parser=argparse.ArgumentParser()):
               "filter bwa's output)")
     )
     parser.add_argument('--aligner', choices=['novoalign', 'bwa'], default='bwa', help='aligner (default: %(default)s)')
-    parser.add_argument('--aligner_options', default=None, help='aligner options (default for novoalign: "-r Random -l 40 -g 40 -x 20 -t 100 -k", bwa: "-T 30"')
+    parser.add_argument('--aligner_options', default=None, help='aligner options (default for novoalign: "-r Random -l 40 -g 40 -x 20 -t 100 -k", bwa: bwa defaults')
     parser.add_argument(
         '--NOVOALIGN_LICENSE_PATH',
         default=None,


### PR DESCRIPTION
The spike-in reports uses bwa to align reads to spike-in sequences,
but bwa does not set a threshold on alignment score when reporting
alignments given paired-end data. As a result, many spike-ins can
be reported as hits but are false positives (for example, some
spike-in sequences have a polyA tail and reads with a polyA stretch
can map to these spike-in sequences). Setting a threshold on which
alignments are reported alleviates this problem.