### PR TITLE
add —notemp to snakemake call with —immediate-submit

### DIFF
--- a/pipes/Broad_UGER/run-pipe.sh
+++ b/pipes/Broad_UGER/run-pipe.sh
@@ -34,7 +34,7 @@ export PATH="$MINICONDADIR/bin:$PATH"
 source activate "$CONDAENVDIR"
 
 ARGS=""
-[[ $IMMEDIATE_SUBMIT -eq 1 ]] && ARGS+=" --immediate-submit "
+[[ $IMMEDIATE_SUBMIT -eq 1 ]] && ARGS+=" --immediate-submit --notemp "
 # invoke Snakemake in cluster mode with custom wrapper scripts
 snakemake --timestamp --rerun-incomplete --keep-going --nolock \
           $ARGS \


### PR DESCRIPTION
—notemp is now required when —immediate-submit is specified; see: https://bitbucket.org/snakemake/snakemake/commits/5624a7eb1ca6f637df779110407279b67e9220ef