### PR TITLE
docker improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM broadinstitute/viral-baseimage:0.1.3
+FROM broadinstitute/viral-baseimage:0.1.4
 
 LABEL maintainer "Chris Tomkins-Tinch <tomkinsc@broadinstitute.org>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,37 +4,31 @@ LABEL maintainer "Chris Tomkins-Tinch <tomkinsc@broadinstitute.org>"
 
 # to build:
 #   docker build --rm .
+#
 # to run:
+#   docker run --rm <image_ID> "<command>.py subcommand"
+#
+# to run interactively:
+#   docker run --rm -it <image_ID> bash
+#
+# to run with GATK and/or Novoalign:
 #   Download licensed copies of GATK and Novoalign to the host machine (for Linux-64)
 #   export GATK_PATH=/path/to/gatk/
 #   export NOVOALIGN_PATH=/path/to/novoalign/
-#   docker run --rm -v $GATK_PATH:/gatk -v $NOVOALIGN_PATH:/novoalign -v /path/to/dir/on/host:/user-data -t -i <image_ID> "<command>.py subcommand"
-# if you receive a "no space on device" error:
-#   docker kill $(docker ps -a -q)
-#   docker rm $(docker ps -a -q)
-#   docker rmi $(docker images -q)
-#   docker volume rm $(docker volume ls -qf dangling=true)
+#   docker run --rm -v $GATK_PATH:/gatk -v $NOVOALIGN_PATH:/novoalign -v /path/to/dir/on/host:/user-data <image_ID> "<command>.py subcommand"
 
-# DEBIAN_FRONTEND: Silence some warnings about Readline. Read more over here:
-# https://github.com/phusion/baseimage-docker/issues/58
-ENV DEBIAN_FRONTEND=noninteractive INSTALL_PATH="/opt/viral-ngs" VIRAL_NGS_PATH="/opt/viral-ngs/source"
-
-# copy basic files
-COPY docker/env_wrapper.sh docker/install-viral-ngs.sh easy-deploy-script/easy-deploy-viral-ngs.sh $INSTALL_PATH/
-RUN chmod a+x $INSTALL_PATH/*.sh
+ENV INSTALL_PATH="/opt/viral-ngs" VIRAL_NGS_PATH="/opt/viral-ngs/source"
 
 # Prepare viral-ngs user and installation directory
 COPY . $VIRAL_NGS_PATH/
 WORKDIR $INSTALL_PATH
-RUN ./install-viral-ngs.sh
+RUN $VIRAL_NGS_PATH/docker/install-viral-ngs.sh
 
 # Volume setup: make external tools and data available within the container
 VOLUME ["/gatk", "/novoalign", "/user-data"]
-# DEBIAN_FRONTEND: Silence some warnings about Readline. Read more over here:
-# https://github.com/phusion/baseimage-docker/issues/58
-ENV GATK_PATH="/gatk" NOVOALIGN_PATH="/novoalign" VIRAL_NGS_DOCKER_DATA_PATH="/user-data" DEBIAN_FRONTEND=teletype
+ENV GATK_PATH="/gatk" NOVOALIGN_PATH="/novoalign" VIRAL_NGS_DOCKER_DATA_PATH="/user-data"
 
 # It's a wrapper script to load the viral-ngs environment via the easy-deploy script
 # and then run any commands desired
-ENTRYPOINT ["/opt/viral-ngs/env_wrapper.sh"]
+ENTRYPOINT ["/opt/viral-ngs/source/docker/env_wrapper.sh"]
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM broadinstitute/viral-baseimage:0.1.2
+FROM broadinstitute/viral-baseimage:0.1.3
 
 LABEL maintainer "Chris Tomkins-Tinch <tomkinsc@broadinstitute.org>"
 

--- a/docker/install-viral-ngs.sh
+++ b/docker/install-viral-ngs.sh
@@ -10,6 +10,7 @@ export VIRAL_CONDA_ENV_PATH=/opt/miniconda
 mkdir -p $INSTALL_PATH/viral-ngs-etc
 ln -s $VIRAL_NGS_PATH $INSTALL_PATH/viral-ngs-etc/viral-ngs
 ln -s $VIRAL_CONDA_ENV_PATH $INSTALL_PATH/viral-ngs-etc/conda-env
+ln $VIRAL_NGS_PATH/easy-deploy-script/easy-deploy-viral-ngs.sh $INSTALL_PATH
 
 # setup/install viral-ngs
 sync

--- a/easy-deploy-script/easy-deploy-viral-ngs.sh
+++ b/easy-deploy-script/easy-deploy-viral-ngs.sh
@@ -374,12 +374,10 @@ function activate_env(){
 
     if [ -d "$VIRAL_CONDA_ENV_PATH" ]; then
         if [ -z "$CONDA_DEFAULT_ENV" ]; then
+            echo "Activating viral-ngs environment..."
             prepend_miniconda
 
-            if [[ "$CONDA_DEFAULT_ENV" != "$VIRAL_CONDA_ENV_PATH" ]]; then
-                echo "Activating viral-ngs environment..."
-                source activate $VIRAL_CONDA_ENV_PATH
-            fi
+            source activate $(absolute_path "$VIRAL_CONDA_ENV_PATH")
 
             # unset JAVA_HOME if set, so we can use the conda-supplied version
             if [ -n "$JAVA_HOME" ]; then

--- a/easy-deploy-script/easy-deploy-viral-ngs.sh
+++ b/easy-deploy-script/easy-deploy-viral-ngs.sh
@@ -261,7 +261,11 @@ function install_viral_ngs_git(){
 }
 
 function install_viral_ngs_conda_dependencies() {
-    conda install -q $CONDA_CHANNEL_STRING --override-channels -y -p $VIRAL_CONDA_ENV_PATH --file "$VIRAL_NGS_PATH/requirements-conda.txt" --file "$VIRAL_NGS_PATH/requirements-py3.txt" --file "$VIRAL_NGS_PATH/requirements-conda-tests.txt" || exit 1
+    if [[ $(absolute_path "$VIRAL_CONDA_ENV_PATH") == $(absolute_path "$MINICONDA_PATH") ]]; then
+        conda install -q $CONDA_CHANNEL_STRING --override-channels -y --file "$VIRAL_NGS_PATH/requirements-conda.txt" --file "$VIRAL_NGS_PATH/requirements-py3.txt" --file "$VIRAL_NGS_PATH/requirements-conda-tests.txt" || exit 1
+    else
+        conda install -q $CONDA_CHANNEL_STRING --override-channels -y -p $VIRAL_CONDA_ENV_PATH --file "$VIRAL_NGS_PATH/requirements-conda.txt" --file "$VIRAL_NGS_PATH/requirements-py3.txt" --file "$VIRAL_NGS_PATH/requirements-conda-tests.txt" || exit 1
+    fi
 }
 
 

--- a/easy-deploy-script/easy-deploy-viral-ngs.sh
+++ b/easy-deploy-script/easy-deploy-viral-ngs.sh
@@ -370,10 +370,10 @@ function activate_env(){
 
     if [ -d "$VIRAL_CONDA_ENV_PATH" ]; then
         if [ -z "$CONDA_DEFAULT_ENV" ]; then
-            echo "Activating viral-ngs environment..."
             prepend_miniconda
 
             if [[ "$CONDA_DEFAULT_ENV" != "$VIRAL_CONDA_ENV_PATH" ]]; then
+                echo "Activating viral-ngs environment..."
                 source activate $VIRAL_CONDA_ENV_PATH
             fi
 


### PR DESCRIPTION
This updates the viral-baseimage to one that supports gsutil backed with crcmod (earlier versions neglected to install this apt package). This also fixes the `source activate` invocation in `env_wrapper.sh` (the Docker image's entrypoint) so that it no longer clobbers certain binaries in the conda environment with recursive symlinks.