### PR TITLE
Docker tweaks

### DIFF
--- a/docker/env_wrapper.sh
+++ b/docker/env_wrapper.sh
@@ -11,7 +11,7 @@ GROUP_ID=${RUN_GROUP_ID:-$USER_ID}
 USER_NAME=user
 GROUP_NAME=viral-ngs
 
-echo "Starting with UID : $USER_ID, GID : $GROUP_ID"
+echo "Starting with UID : $USER_ID, GID : $GROUP_ID" >&2
 groupadd --gid $GROUP_ID $GROUP_NAME
 useradd --shell /bin/bash --uid $USER_ID --gid $GROUP_ID -o -c "" -m $USER_NAME
 

--- a/easy-deploy-script/easy-deploy-viral-ngs.sh
+++ b/easy-deploy-script/easy-deploy-viral-ngs.sh
@@ -171,9 +171,9 @@ fi
 
 function prepend_miniconda(){
     if [ -d "$MINICONDA_PATH/bin" ]; then
-        echo "Miniconda installed."
+        echo "Miniconda installed." >&2
 
-        echo "Prepending miniconda to PATH..."
+        echo "Prepending miniconda to PATH..." >&2
         PATH="$MINICONDA_PATH/bin:$PATH"
         export PATH=$(puniq $PATH)
         hash -r
@@ -185,7 +185,7 @@ function prepend_miniconda(){
         #    conda update -y conda
         #fi
     else
-        echo "Miniconda directory not found."
+        echo "Miniconda directory not found." >&2
         if [[ $sourced -eq 0 ]]; then
             exit 1
         else
@@ -357,7 +357,7 @@ function create_project(){
 
 function activate_env(){
     if [ -d "$INSTALL_PATH" ]; then
-        echo "viral-ngs parent directory found"
+        echo "viral-ngs parent directory found" >&2
     else
         echo "viral-ngs parent directory not found: $INSTALL_PATH not found."
         echo "Have you run the setup?"
@@ -374,7 +374,7 @@ function activate_env(){
 
     if [ -d "$VIRAL_CONDA_ENV_PATH" ]; then
         if [ -z "$CONDA_DEFAULT_ENV" ]; then
-            echo "Activating viral-ngs environment..."
+            echo "Activating viral-ngs environment..." >&2
             prepend_miniconda
 
             source activate $(absolute_path "$VIRAL_CONDA_ENV_PATH")

--- a/travis/deploy-docker.sh
+++ b/travis/deploy-docker.sh
@@ -17,18 +17,19 @@ if [[ -n "$DOCKER_PASS" && -n "$DOCKER_USER" ]]; then
 		# this is a PR build (TRAVIS_BRANCH=master, TRAVIS_PULL_REQUEST_BRANCH=source of PR)
 		DOCKER_REPO="broadinstitute/viral-ngs-dev"
 		BRANCH_NAME="$TRAVIS_PULL_REQUEST_BRANCH"
-		DOCKER_LONG_TAG="$(git describe --tags --always | sed 's/^v//' | perl -lape 's/(\d+.\d+.\d+)-/$1-beta-/')_$(echo $BRANCH_NAME | sed 's/-/_/g')"
+		DOCKER_SHORT_TAG="$(echo $BRANCH_NAME | sed 's/-/_/g')-pull_request"
+		#DOCKER_LONG_TAG="$(git describe --tags --always | sed 's/^v//' | perl -lape 's/(\S+)-(\d+)-g\S+/$1-beta-$2/')_$(echo $BRANCH_NAME | sed 's/-/_/g')"
 	elif [[ "$TRAVIS_BRANCH" == "master" ]]; then
 		# this is a master branch commit (e.g. merged pull request)
 		DOCKER_REPO="broadinstitute/viral-ngs"
 		DOCKER_SHORT_TAG="latest"
-		DOCKER_LONG_TAG="$(git describe --tags --always | sed 's/^v//' | perl -lape 's/(\d+.\d+.\d+)-/$1-rc-/')"
+		DOCKER_LONG_TAG="$(git describe --tags --always | sed 's/^v//' | perl -lape 's/(\S+)-(\d+)-g\S+/$1-rc$2/')"
 	else
 		# this is an normal non-master branch commit
 		DOCKER_REPO="broadinstitute/viral-ngs-dev"
 		BRANCH_NAME="$TRAVIS_BRANCH"
 		DOCKER_SHORT_TAG="$(echo $BRANCH_NAME | sed 's/-/_/g')"
-		DOCKER_LONG_TAG="$(git describe --tags --always | sed 's/^v//' | perl -lape 's/(\d+.\d+.\d+)-/$1-dev-/')_$(echo $DOCKER_SHORT_TAG)"
+		#DOCKER_LONG_TAG="$(git describe --tags --always | sed 's/^v//' | perl -lape 's/(\d+.\d+.\d+)-/$1-dev-/')_$(echo $DOCKER_SHORT_TAG)"
 	fi
 
 	# tag and deploy


### PR DESCRIPTION
This PR:

- Moves a number of status messages in `easy-deploy-viral-ngs.sh` and `env_wrapper.sh` from stdout to stderr (in some steps of the pipeline, these were the only messages showing up on stdout).
- No longer pushing versioned tags of docker images on branch commits to `broadinstitute/viral-ngs-dev` and instead just pushing only the short tag (as previously) `broadinstitute/viral-ngs-dev:BRANCH_NAME`. Seemed unnecessarily noisy to retain versioned copies of the non-HEAD commits for branch builds. The old string is retained in a commented out line if we change our build/test/deploy process in the future.
- Similarly, pull request builds for branches are also simplified to `broadinstitute/viral-ngs-dev:BRANCH_NAME-pull_request` (instead of the full git describe version string).
- Untagged master branch builds are shortened to `broadinstitute/viral-ngs:LAST_TAG-rcX` where X is the number of commits since LAST_TAG. This was formerly `broadinstitute/viral-ngs:LAST_TAG-rc-X-gCOMMIT_SHA`. Since our master branch is protected and requires formally merged PRs (and all non-master branch builds are in a different repo altogether), it seems that `LAST_TAG-rcX` should be sufficiently uniquely identifying without the commit SHA, and it better follows the spirit of PEP440.