### PR TITLE
update to latest viral-baseimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM broadinstitute/viral-baseimage:0.1.4
+FROM broadinstitute/viral-baseimage:0.1.5
 
 LABEL maintainer "Chris Tomkins-Tinch <tomkinsc@broadinstitute.org>"
 


### PR DESCRIPTION
this adds an apt package for `make` which is apparently required by krona, but doesn't really make sense to add to our conda dependencies.