### PR TITLE
fix conda package travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,7 +153,7 @@ jobs:
         - source travis/install-conda.sh
         - travis/install-conda-build.sh
       script:
-        - travis_wait travis/build-conda.sh
+        - travis/build-conda.sh
       before_cache:
         - conda clean --all --yes
 


### PR DESCRIPTION
Remove travis_wait from conda package build--it appears to be doing more harm than good!