### PR TITLE
bump viral-baseimage from 0.1.6 (zesty) to 0.1.7 (artful)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/broadinstitute/viral-baseimage:0.1.6
+FROM quay.io/broadinstitute/viral-baseimage:0.1.7
 
 LABEL maintainer "viral-ngs@broadinstitute.org"
 


### PR DESCRIPTION
More details [here](https://github.com/broadinstitute/viral-baseimage/pull/3).