### PR TITLE
fixes to align_and_plot workflow

### DIFF
--- a/pipes/WDL/workflows/align_and_plot.wdl
+++ b/pipes/WDL/workflows/align_and_plot.wdl
@@ -1,5 +1,8 @@
 import "tasks/reports.wdl" as reports
 
 workflow align_and_plot {
-  call reports.plot_coverage
+  call reports.plot_coverage {
+    input:
+      aligner_options = "-r Random -l 30 -g 40 -x 20 -t 502"
+  }
 }

--- a/pipes/WDL/workflows/tasks/assembly.wdl
+++ b/pipes/WDL/workflows/tasks/assembly.wdl
@@ -317,8 +317,11 @@ task refine_2x_and_plot {
     samtools view ${sample_name}.mapped.bam | cut -f10 | tr -d '\n' | wc -c | tee bases_aligned
     echo $(( $(cat bases_aligned) / $(cat assembly_length) )) | tee mean_coverage
 
+    # fastqc mapped bam
+    reports.py fastqc ${sample_name}.mapped.bam ${sample_name}.mapped_fastqc.html
+
+    # plot coverage
     if [ $(cat reads_aligned) != 0 ]; then
-      # plot coverage
       reports.py plot_coverage \
         ${sample_name}.mapped.bam \
         ${sample_name}.coverage_plot.pdf \
@@ -327,8 +330,6 @@ task refine_2x_and_plot {
         --plotHeight 850 \
         --plotDPI 100 \
         --loglevel=DEBUG
-      # fastqc mapped bam
-      reports.py fastqc ${sample_name}.mapped.bam ${sample_name}.mapped_fastqc.html
     else
       touch ${sample_name}.coverage_plot.pdf ${sample_name}.mapped_fastqc.html
     fi

--- a/pipes/WDL/workflows/tasks/assembly.wdl
+++ b/pipes/WDL/workflows/tasks/assembly.wdl
@@ -315,10 +315,23 @@ task refine_2x_and_plot {
     samtools flagstat ${sample_name}.bam | tee ${sample_name}.bam.flagstat.txt
     grep properly ${sample_name}.bam.flagstat.txt | cut -f 1 -d ' ' | tee read_pairs_aligned
     samtools view ${sample_name}.mapped.bam | cut -f10 | tr -d '\n' | wc -c | tee bases_aligned
-    expr $(cat bases_aligned) / $(cat assembly_length) | tee mean_coverage
+    echo $(( $(cat bases_aligned) / $(cat assembly_length) )) | tee mean_coverage
 
-    # fastqc mapped bam
-    reports.py fastqc ${sample_name}.mapped.bam ${sample_name}.mapped_fastqc.html
+    if [ $(cat reads_aligned) != 0 ]; then
+      # plot coverage
+      reports.py plot_coverage \
+        ${sample_name}.mapped.bam \
+        ${sample_name}.coverage_plot.pdf \
+        --plotFormat pdf \
+        --plotWidth 1100 \
+        --plotHeight 850 \
+        --plotDPI 100 \
+        --loglevel=DEBUG
+      # fastqc mapped bam
+      reports.py fastqc ${sample_name}.mapped.bam ${sample_name}.mapped_fastqc.html
+    else
+      touch ${sample_name}.coverage_plot.pdf ${sample_name}.mapped_fastqc.html
+    fi
   }
 
   output {

--- a/pipes/WDL/workflows/tasks/reports.wdl
+++ b/pipes/WDL/workflows/tasks/reports.wdl
@@ -52,8 +52,11 @@ task plot_coverage {
     samtools view ${sample_name}.mapped.bam | cut -f10 | tr -d '\n' | wc -c | tee bases_aligned
     echo $(( $(cat bases_aligned) / $(cat assembly_length) )) | tee mean_coverage
 
+    # fastqc mapped bam
+    reports.py fastqc ${sample_name}.mapped.bam ${sample_name}.mapped_fastqc.html
+
+    # plot coverage
     if [ $(cat reads_aligned) != 0 ]; then
-      # plot coverage
       reports.py plot_coverage \
         ${sample_name}.mapped.bam \
         ${sample_name}.coverage_plot.pdf \
@@ -62,8 +65,6 @@ task plot_coverage {
         --plotHeight 850 \
         --plotDPI 100 \
         --loglevel=DEBUG
-      # fastqc mapped bam
-      reports.py fastqc ${sample_name}.mapped.bam ${sample_name}.mapped_fastqc.html
     else
       touch ${sample_name}.coverage_plot.pdf ${sample_name}.mapped_fastqc.html
     fi

--- a/pipes/WDL/workflows/tasks/reports.wdl
+++ b/pipes/WDL/workflows/tasks/reports.wdl
@@ -43,15 +43,6 @@ task plot_coverage {
 
     samtools index ${sample_name}.mapped.bam
 
-    reports.py plot_coverage \
-      ${sample_name}.mapped.bam \
-      ${sample_name}.coverage_plot.pdf \
-      --plotFormat pdf \
-      --plotWidth 1100 \
-      --plotHeight 850 \
-      --plotDPI 100 \
-      --loglevel=DEBUG
-
     # collect figures of merit
     grep -v '^>' assembly.fasta | tr -d '\n' | wc -c | tee assembly_length
     grep -v '^>' assembly.fasta | tr -d '\nNn' | wc -c | tee assembly_length_unambiguous
@@ -59,8 +50,23 @@ task plot_coverage {
     samtools flagstat ${sample_name}.bam | tee ${sample_name}.bam.flagstat.txt
     grep properly ${sample_name}.bam.flagstat.txt | cut -f 1 -d ' ' | tee read_pairs_aligned
     samtools view ${sample_name}.mapped.bam | cut -f10 | tr -d '\n' | wc -c | tee bases_aligned
-    expr $(cat bases_aligned) / $(cat assembly_length) | tee mean_coverage
-    reports.py fastqc ${sample_name}.mapped.bam ${sample_name}.mapped_fastqc.html
+    echo $(( $(cat bases_aligned) / $(cat assembly_length) )) | tee mean_coverage
+
+    if [ $(cat reads_aligned) != 0 ]; then
+      # plot coverage
+      reports.py plot_coverage \
+        ${sample_name}.mapped.bam \
+        ${sample_name}.coverage_plot.pdf \
+        --plotFormat pdf \
+        --plotWidth 1100 \
+        --plotHeight 850 \
+        --plotDPI 100 \
+        --loglevel=DEBUG
+      # fastqc mapped bam
+      reports.py fastqc ${sample_name}.mapped.bam ${sample_name}.mapped_fastqc.html
+    else
+      touch ${sample_name}.coverage_plot.pdf ${sample_name}.mapped_fastqc.html
+    fi
   }
 
   output {


### PR DESCRIPTION
 - Previous WDL shell code was failing if mean coverage (an integer) was below 1x
 - plot_coverage fails if zero mapped reads: protect its invocations with conditionals and output empty PDF if this is the case
 - change standalone invocation of align_and_plot to use sensitive Novoalign params by default