### PR TITLE
pass JVMmemory to SamToFastqTool().per_read_group() call in rmdup_mvicuna_bam()

### DIFF
--- a/read_utils.py
+++ b/read_utils.py
@@ -755,7 +755,7 @@ def rmdup_mvicuna_bam(inBam, outBam, JVMmemory=None):
 
     # Convert BAM -> FASTQ pairs per read group and load all read groups
     tempDir = tempfile.mkdtemp()
-    tools.picard.SamToFastqTool().per_read_group(inBam, tempDir, picardOptions=['VALIDATION_STRINGENCY=LENIENT'])
+    tools.picard.SamToFastqTool().per_read_group(inBam, tempDir, picardOptions=['VALIDATION_STRINGENCY=LENIENT'], JVMmemory=JVMmemory)
     read_groups = [x[1:] for x in tools.samtools.SamtoolsTool().getHeader(inBam) if x[0] == '@RG']
     read_groups = [dict(pair.split(':', 1) for pair in rg) for rg in read_groups]
 


### PR DESCRIPTION
Without passing JVMmemory to the `tools.picard.SamToFastqTool().per_read_group()` call in `rmdup_mvicuna_bam()`, picard uses the default of `-Xmx2g`, which can cause a `java.lang.OutOfMemoryError: GC overhead limit exceeded` error with particularly large input bam files (>~25GB)