### PR TITLE
modify illumina_demux to support simplex sequencing runs

### DIFF
--- a/illumina.py
+++ b/illumina.py
@@ -80,8 +80,8 @@ def parser_illumina_demux(parser=argparse.ArgumentParser()):
 
 
 def main_illumina_demux(args):
-    ''' Read Illumina runs & produce BAM files, demultiplexing to one bam per sample.
-        For simplex samples, a single bam will be produced bearing the flowcell ID.
+    ''' Read Illumina runs & produce BAM files, demultiplexing to one bam per sample, or 
+        for simplex runs, a single bam will be produced bearing the flowcell ID.
         Wraps together Picard's ExtractBarcodes (for multiplexed samples) and IlluminaBasecallsToSam
         while handling the various required input formats. Also can
         read Illumina BCL directories, tar.gz BCL directories.

--- a/illumina.py
+++ b/illumina.py
@@ -522,14 +522,16 @@ class RunInfo(object):
 
     def get_flowcell(self):
         fc = self.root[0].find('Flowcell').text
-        # do not slice in the iSeq/Firefly case
-        if not self.get_machine().startswith("FF"):
+        # slice in the case where the ID has a prefix of zeros
+        if re.match(r"^0+-", fc):
             if '-' in fc:
                 # miseq often adds a bunch of leading zeros and a dash in front
-                fc = fc.split('-')[1]
+                fc = "-".join(fc.split('-')[1:])
         # >=5 to avoid an exception here: https://github.com/broadinstitute/picard/blob/2.17.6/src/main/java/picard/illumina/IlluminaBasecallsToSam.java#L510
         # <= 15 to limit the bytes added to each bam record
-        assert 5 <= len(fc) <= 15
+        assert len(fc) >= 5,"The flowcell ID must be five or more characters in length"
+        if len(fc) > 15:
+            log.warn("The provided flowcell ID is longer than 15 characters. Is that correct?")
         return fc
 
     def get_rundate_american(self):

--- a/illumina.py
+++ b/illumina.py
@@ -150,6 +150,12 @@ def main_illumina_demux(args):
             )
 
     multiplexed_samples = True if 'B' in read_structure else False            
+    
+    if multiplexed_samples:
+        assert samples is not None, "This looks like a multiplexed run since 'B' is in the read_structure: a SampleSheet must be given."
+    else:
+        assert samples==None, "A SampleSheet may not be provided unless 'B' is present in the read_structure"
+        assert not args.commonBarcodes, "--commonBarcodes may not be specified unless 'B' is present in the read_structure"
 
     # B in read structure indicates barcoded multiplexed samples
     if multiplexed_samples:

--- a/tools/picard.py
+++ b/tools/picard.py
@@ -513,7 +513,7 @@ class IlluminaBasecallsToSamTool(PicardTools):
     def execute(self, 
         basecalls_dir,
         barcodes_dir,
-        run_barcode,
+        read_group_id_precursor,
         lane, library_params,
         picardOptions=None,
         JVMmemory=None
@@ -533,20 +533,22 @@ class IlluminaBasecallsToSamTool(PicardTools):
                     opts.append('='.join((k.upper(), str(v))))
         opts += [
             'BASECALLS_DIR=' + basecalls_dir, 'BARCODES_DIR=' + barcodes_dir, 'LANE=' + str(lane),
-            'RUN_BARCODE=' + run_barcode, 'LIBRARY_PARAMS=' + library_params
+            'RUN_BARCODE=' + read_group_id_precursor, 'LIBRARY_PARAMS=' + library_params
         ]
         PicardTools.execute(self, self.subtoolName, opts, JVMmemory)
 
     def execute_single_sample(self, 
         basecalls_dir,
         output_file,
-        run_barcode, # this is a run-specific ID, ex. the flowcell ID
+        read_group_id_precursor, # this is a run-specific ID, ex. the flowcell ID
         lane,
         sample_alias,
         picardOptions=None,
         JVMmemory=None
     ):
         picardOptions = picardOptions or {}
+
+        assert len(read_group_id_precursor) >= 5, "read_group_id_precursor must be >=5 chars per https://github.com/broadinstitute/picard/blob/2.17.6/src/main/java/picard/illumina/IlluminaBasecallsToSam.java#L510"
 
         opts_dict = self.defaults.copy()
         for k, v in picardOptions.items():
@@ -563,8 +565,9 @@ class IlluminaBasecallsToSamTool(PicardTools):
             'OUTPUT=' + output_file,
             'BASECALLS_DIR=' + basecalls_dir, 
             'LANE=' + str(lane),
-            'RUN_BARCODE=' + run_barcode, #must be >=5 chars per https://github.com/broadinstitute/picard/blob/2.17.6/src/main/java/picard/illumina/IlluminaBasecallsToSam.java#L510
-            'SAMPLE_ALIAS=' + sample_alias
+            'RUN_BARCODE=' + read_group_id_precursor, #
+            'SAMPLE_ALIAS=' + sample_alias,
+            'LIBRARY_NAME=' + sample_alias
         ]
         PicardTools.execute(self, self.subtoolName, opts, JVMmemory)
     # pylint: enable=W0221

--- a/tools/picard.py
+++ b/tools/picard.py
@@ -510,8 +510,8 @@ class IlluminaBasecallsToSamTool(PicardTools):
     )
 
     # pylint: disable=W0221
-    def execute(
-        self, basecalls_dir,
+    def execute(self, 
+        basecalls_dir,
         barcodes_dir,
         run_barcode,
         lane, library_params,
@@ -534,6 +534,37 @@ class IlluminaBasecallsToSamTool(PicardTools):
         opts += [
             'BASECALLS_DIR=' + basecalls_dir, 'BARCODES_DIR=' + barcodes_dir, 'LANE=' + str(lane),
             'RUN_BARCODE=' + run_barcode, 'LIBRARY_PARAMS=' + library_params
+        ]
+        PicardTools.execute(self, self.subtoolName, opts, JVMmemory)
+
+    def execute_single_sample(self, 
+        basecalls_dir,
+        output_file,
+        run_barcode, # this is a run-specific ID, ex. the flowcell ID
+        lane,
+        sample_alias,
+        picardOptions=None,
+        JVMmemory=None
+    ):
+        picardOptions = picardOptions or {}
+
+        opts_dict = self.defaults.copy()
+        for k, v in picardOptions.items():
+            opts_dict[k] = v
+        opts = []
+        for k, v in opts_dict.items():
+            if v is not None:
+                if type(v) in (list, tuple):
+                    for x in v:
+                        opts.append('='.join((k.upper(), str(x))))
+                else:
+                    opts.append('='.join((k.upper(), str(v))))
+        opts += [
+            'OUTPUT=' + output_file,
+            'BASECALLS_DIR=' + basecalls_dir, 
+            'LANE=' + str(lane),
+            'RUN_BARCODE=' + run_barcode, #must be >=5 chars per https://github.com/broadinstitute/picard/blob/2.17.6/src/main/java/picard/illumina/IlluminaBasecallsToSam.java#L510
+            'SAMPLE_ALIAS=' + sample_alias
         ]
         PicardTools.execute(self, self.subtoolName, opts, JVMmemory)
     # pylint: enable=W0221


### PR DESCRIPTION
This modifies `illumina_demux` (which should perhaps be renamed) to read Illumina runs & produce BAM files, resulting in one bam per sample for multiplexed runs, or a single bam file bearing the flowcell ID for simplex runs.

This will be helpful for creating an output `.bam` file from raw basecall data where a single sample is sequenced in a run without any barcodes (so no samplesheet is provided).

This addresses #759. 