### PR TITLE
WDL: provide bmtagger more RAM and parallelize krona

### DIFF
--- a/pipes/WDL/workflows/tasks/metagenomics.wdl
+++ b/pipes/WDL/workflows/tasks/metagenomics.wdl
@@ -52,16 +52,16 @@ task kraken {
     wait # for krona_taxonomy_db_tgz to download and extract
 
     # run single-threaded krona on up to nproc samples at once
-    parallel \
+    parallel -I ,, \
       "metagenomics.py krona \
-        {}.txt.gz \
+        ,,.txt.gz \
         taxonomy \
-        {}.html \
+        ,,.html \
         --noRank --noHits \
         --loglevel=DEBUG" \
       ::: `cat $OUT_BASENAME`
     # run single-threaded gzip on up to nproc samples at once
-    parallel "tar czf {}.krona.tar.gz {}.html*" ::: `cat $OUT_BASENAME`
+    parallel -I ,, "tar czf ,,.krona.tar.gz ,,.html*" ::: `cat $OUT_BASENAME`
   }
 
   output {

--- a/pipes/WDL/workflows/tasks/metagenomics.wdl
+++ b/pipes/WDL/workflows/tasks/metagenomics.wdl
@@ -115,9 +115,9 @@ task krona {
 
   runtime {
     docker: "quay.io/broadinstitute/viral-ngs"
-    memory: "2 GB"
+    memory: "4 GB"
     cpu: 1
-    dx_instance_type: "mem1_ssd1_x4"
+    dx_instance_type: "mem2_hdd2_x2"
   }
 }
 

--- a/pipes/WDL/workflows/tasks/metagenomics.wdl
+++ b/pipes/WDL/workflows/tasks/metagenomics.wdl
@@ -33,12 +33,15 @@ task kraken {
     # prep input and output file names
     OUT_READS=fnames_outreads.txt
     OUT_REPORTS=fnames_outreports.txt
+    OUT_BASENAME=basenames_reads.txt
     for bam in ${sep=' ' reads_unmapped_bam}; do
+      echo "$(basename $bam .bam).kraken-reads" >> $OUT_BASENAME
       echo "$(basename $bam .bam).kraken-reads.txt.gz" >> $OUT_READS
       echo "$(basename $bam .bam).kraken-summary_report.txt" >> $OUT_REPORTS
     done
 
-    # execute on all inputs and outputs at once
+    # execute on all inputs and outputs serially, but with a single
+    # database load into ram
     metagenomics.py kraken \
       $DB_DIR \
       ${sep=' ' reads_unmapped_bam} \
@@ -47,16 +50,18 @@ task kraken {
       --loglevel=DEBUG
 
     wait # for krona_taxonomy_db_tgz to download and extract
-    for bam in ${sep=' ' reads_unmapped_bam}; do
-      report_basename="$(basename $bam .bam).kraken-reads"
-      metagenomics.py krona \
-        $report_basename.txt.gz \
+
+    # run single-threaded krona on up to nproc samples at once
+    parallel \
+      "metagenomics.py krona \
+        {}.txt.gz \
         taxonomy \
-        $report_basename.html \
+        {}.html \
         --noRank --noHits \
-        --loglevel=DEBUG
-      tar czf $report_basename.krona.tar.gz $report_basename.html*
-    done
+        --loglevel=DEBUG" \
+      ::: `cat $OUT_BASENAME`
+    # run single-threaded gzip on up to nproc samples at once
+    parallel "tar czf {}.krona.tar.gz {}.html*" ::: `cat $OUT_BASENAME`
   }
 
   output {

--- a/pipes/WDL/workflows/tasks/taxon_filter.wdl
+++ b/pipes/WDL/workflows/tasks/taxon_filter.wdl
@@ -20,8 +20,9 @@ task deplete_taxa {
       TMPDIR=/mnt/tmp
     fi
 
-    # find 50% memory
-    mem_in_mb=`/opt/viral-ngs/source/docker/mem_in_mb_50.sh`
+    # find memory thresholds
+    mem_in_mb_50=`/opt/viral-ngs/source/docker/mem_in_mb_50.sh`
+    mem_in_mb_90=`/opt/viral-ngs/source/docker/mem_in_mb_90.sh`
 
     # bmtagger and blast db args
     DBS_BMTAGGER="${sep=' ' bmtaggerDbs}"
@@ -49,8 +50,8 @@ task deplete_taxa {
       $DBS_BMTAGGER $DBS_BLAST $DBS_BWA \
       ${'--chunkSize=' + query_chunk_size} \
       $TAGS_TO_CLEAR \
-      --JVMmemory="$mem_in_mb"m \
-      --srprismMemory=$mem_in_mb \
+      --JVMmemory="$mem_in_mb_50"m \
+      --srprismMemory=$mem_in_mb_90 \
       --loglevel=DEBUG
 
     samtools view -c ${raw_reads_unmapped_bam} | tee depletion_read_count_pre

--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -17,6 +17,7 @@ mummer4=4.0.0beta2
 muscle=3.8.1551 
 mvicuna=1.0
 novoalign=3.07.00
+parallel=20160622
 picard=2.17.6
 pigz=2.3.4
 prinseq=0.20.4

--- a/travis/install-tools.sh
+++ b/travis/install-tools.sh
@@ -12,16 +12,16 @@ export CONDA_ENVS_PATH=tools/conda-cache:tools/conda-tools/default
 PYVER=`echo $TRAVIS_PYTHON_VERSION | cut -c 1`
 
 if [ ! -d $CONDA_ENV ]; then
-	conda create -y -m -p $CONDA_ENV python="$TRAVIS_PYTHON_VERSION"
+	conda create -y -m --quiet -p $CONDA_ENV python="$TRAVIS_PYTHON_VERSION"
 fi
 
-conda install -y --override-channels \
+conda install -y --quiet --override-channels \
 	-c broad-viral -c r -c bioconda -c conda-forge -c defaults \
 	--file requirements-conda.txt \
 	--file requirements-conda-tests.txt \
 	--file requirements-py$PYVER.txt \
 	-p $CONDA_ENV
 
-conda list -p $CONDA_ENV
-
 conda clean --all --yes # clean temp/cache files to reduce Travis cache size
+
+conda list -p $CONDA_ENV


### PR DESCRIPTION
This PR:
1. Increases bmtagger (srprism) RAM limit in the WDL invocation to 90% RAM, up from 50% (since it never runs simultaneously with Java or anything else). [Fixes #780] Bug was non-deterministic, but recent assemblies using this branch seem to have cleared it up.
2. Uses GNU Parallel to parallelize up to `nproc` invocations of single-threaded Krona in the kraken WDL task. Addresses the observation that the Krona for loop was sometimes taking several times longer than Kraken itself. Also parallelizes the single-threaded tar/gzip calls after Krona. This is currently being [tested here](https://platform.dnanexus.com/projects/F95x4j80Z3ygZgQB0v92Gfyz/monitor/analysis/F9p7yV00Z3ypbB5pF5xzjY08), please wait a couple hours for this to succeed before merging the PR.
3. Adds `--quiet` back to `conda create` and `conda install` invocations in Travis to deal with log length limits.