### PR TITLE
WDL workflow updates and additions

### DIFF
--- a/pipes/WDL/dx-defaults-assemble_denovo_with_deplete.json
+++ b/pipes/WDL/dx-defaults-assemble_denovo_with_deplete.json
@@ -1,6 +1,6 @@
 {
-  "assemble_denovo_with_deplete.deplete_taxa.bmtaggerDbs": [
-    "dx://file-BYF8y0Q06PJ7G1fPvkB9q3fK"
+  "assemble_denovo_with_deplete.deplete_taxa.bwaDbs": [
+    "dx://file-F9k7Bx00Z3ybJjvY3ZVj7Z9P"
   ],
   "assemble_denovo_with_deplete.deplete_taxa.blastDbs": [
     "dx://file-F8B3B6Q09y3bZg3j1FqK7bJ9",

--- a/pipes/WDL/dx-defaults-contigs.json
+++ b/pipes/WDL/dx-defaults-contigs.json
@@ -1,0 +1,14 @@
+{
+  "contigs.deplete.bwaDbs": [
+    "dx://file-F9k7Bx00Z3ybJjvY3ZVj7Z9P"
+  ],
+  "contigs.deplete.blastDbs": [
+    "dx://file-F8B3B6Q09y3bZg3j1FqK7bJ9",
+    "dx://file-F8BjgXj09y3gkfZGPPQZbZkK",
+    "dx://file-F8B3Pp809y3jBpXq7xjxbq94",
+    "dx://file-F8B3B6809y3kK1JP5X8Pg361"
+  ],
+
+  "contigs.spades.trim_clip_db":
+    "dx://file-BXF0vYQ0QyBF509G9J12g927"
+}

--- a/pipes/WDL/dx-defaults-demux_plus.json
+++ b/pipes/WDL/dx-defaults-demux_plus.json
@@ -2,8 +2,8 @@
   "demux_plus.spikein.spikein_db":
     "dx://file-F6PXkF00Yqp3zVXq14fF98Kz",
 
-  "demux_plus.deplete.bmtaggerDbs": [
-    "dx://file-BYF8y0Q06PJ7G1fPvkB9q3fK"
+  "demux_plus.deplete.bwaDbs": [
+    "dx://file-F9k7Bx00Z3ybJjvY3ZVj7Z9P"
   ],
   "demux_plus.deplete.blastDbs": [
     "dx://file-F8B3B6Q09y3bZg3j1FqK7bJ9",

--- a/pipes/WDL/dx-defaults-deplete_only.json
+++ b/pipes/WDL/dx-defaults-deplete_only.json
@@ -1,6 +1,6 @@
 {
-  "deplete_only.deplete_taxa.bmtaggerDbs": [
-    "dx://file-BYF8y0Q06PJ7G1fPvkB9q3fK"
+  "deplete_only.deplete_taxa.bwaDbs": [
+    "dx://file-F9k7Bx00Z3ybJjvY3ZVj7Z9P"
   ],
   "deplete_only.deplete_taxa.blastDbs": [
     "dx://file-F8B3B6Q09y3bZg3j1FqK7bJ9",

--- a/pipes/WDL/dx-defaults-spikein.json
+++ b/pipes/WDL/dx-defaults-spikein.json
@@ -1,0 +1,4 @@
+{
+  "demux_plus.spikein.spikein_db":
+    "dx://file-F6PXkF00Yqp3zVXq14fF98Kz"
+}

--- a/pipes/WDL/dx-defaults-spikein.json
+++ b/pipes/WDL/dx-defaults-spikein.json
@@ -1,4 +1,4 @@
 {
-  "demux_plus.spikein.spikein_db":
+  "spikein.spikein.spikein_db":
     "dx://file-F6PXkF00Yqp3zVXq14fF98Kz"
 }

--- a/pipes/WDL/workflows/contigs.wdl
+++ b/pipes/WDL/workflows/contigs.wdl
@@ -1,0 +1,17 @@
+import "tasks/metagenomics.wdl" as metagenomics
+import "tasks/taxon_filter.wdl" as taxon_filter
+import "tasks/assembly.wdl" as assembly
+
+workflow contigs {
+
+  call taxon_filter.deplete_taxa as deplete
+
+  call assembly.assemble as spades {
+    input:
+      assembler = "spades",
+      reads_unmapped_bam = deplete.cleaned_bam
+  }
+
+  # TO DO: taxonomic classification of contigs
+
+}

--- a/pipes/WDL/workflows/spikein.wdl
+++ b/pipes/WDL/workflows/spikein.wdl
@@ -1,0 +1,7 @@
+import "tasks/reports.wdl" as reports
+
+workflow spikein {
+
+  call reports.spikein_report as spikein
+
+}

--- a/pipes/WDL/workflows/tasks/reports.wdl
+++ b/pipes/WDL/workflows/tasks/reports.wdl
@@ -50,7 +50,8 @@ task plot_coverage {
     samtools flagstat ${sample_name}.bam | tee ${sample_name}.bam.flagstat.txt
     grep properly ${sample_name}.bam.flagstat.txt | cut -f 1 -d ' ' | tee read_pairs_aligned
     samtools view ${sample_name}.mapped.bam | cut -f10 | tr -d '\n' | wc -c | tee bases_aligned
-    echo $(( $(cat bases_aligned) / $(cat assembly_length) )) | tee mean_coverage
+    #echo $(( $(cat bases_aligned) / $(cat assembly_length) )) | tee mean_coverage
+    python -c "print (float("`cat bases_aligned`")/"`cat assembly_length`") if "`cat assembly_length`">0 else 0" > mean_coverage
 
     # fastqc mapped bam
     reports.py fastqc ${sample_name}.mapped.bam ${sample_name}.mapped_fastqc.html
@@ -81,7 +82,7 @@ task plot_coverage {
     Int reads_aligned               = read_int("reads_aligned")
     Int read_pairs_aligned          = read_int("read_pairs_aligned")
     Int bases_aligned               = read_int("bases_aligned")
-    Int mean_coverage               = read_int("mean_coverage")
+    Float mean_coverage             = read_float("mean_coverage")
   }
 
   runtime {


### PR DESCRIPTION
A number of tweaks on the WDL workflows:
 - all DNAnexus workflows that invoke human depletion tasks now default to use an hg19 BWA database instead of an hg19 bmtagger database (intended to avoid the non-deterministic memory failures in bmtagger)
 - add a new `spikein` WDL workflow that just runs the reports.spikein_report step
 - add a new `contigs` WDL workflow that runs depletion, SPAdes, and has a placeholder for future contig-based taxonomic classification steps to be added later
 - assembly.scaffold: change name of final output file from {sample_name}.scaffold.fasta to {sample_name}.scaffolded_imputed.fasta in order to be more explicit to the user about which fastas contain imputed bases (only this one does)
 - assembly.scaffold: add a new String output called `scaffolding_chosen_ref_name` that contains the concatenated fasta headers of the File `scaffolding_chosen_ref` (for easier mass-reporting).
 - assembly.refine_2x_and_plot and reports.plot_coverage: change the `mean_coverage` output from an Int to a Float. Also add defense against divide-by-zero by emitting 0 if the assembly is empty.