### PR TITLE
genbank annotation updates

### DIFF
--- a/ncbi.py
+++ b/ncbi.py
@@ -176,7 +176,7 @@ def tbl_transfer_prealigned(inputFasta, refFasta, refAnnotTblFiles, outputDir, o
         # identify the correct feature table as the one that has an ID that is
         # part of the ref seq ID
         fileAccession = util.genbank.get_feature_table_id(tblFilename)
-        if fileAccession in matchingRefSeq.id:
+        if fileAccession == matchingRefSeq.id.split('|')[0]:
             ref_tbl = tblFilename
             break
     if ref_tbl == "":

--- a/ncbi.py
+++ b/ncbi.py
@@ -396,7 +396,7 @@ def make_structured_comment_file(cmt_fname, name=None, seq_tech=None, coverage=N
 
 def prep_genbank_files(templateFile, fasta_files, annotDir,
                        master_source_table=None, comment=None, sequencing_tech=None,
-                       coverage_table=None, biosample_map=None):
+                       coverage_table=None, biosample_map=None, organism=None):
     ''' Prepare genbank submission files.  Requires .fasta and .tbl files as input,
         as well as numerous other metadata files for the submission.  Creates a
         directory full of files (.sqn in particular) that can be sent to GenBank.
@@ -451,7 +451,11 @@ def prep_genbank_files(templateFile, fasta_files, annotDir,
 
     # run tbl2asn (relies on filesnames matching by prefix)
     tbl2asn = tools.tbl2asn.Tbl2AsnTool()
-    tbl2asn.execute(templateFile, annotDir, comment=comment, per_genome_comment=True)
+    source_quals = []
+    if organism:
+        source_quals = [('organism', organism)]
+    tbl2asn.execute(templateFile, annotDir, comment=comment,
+        per_genome_comment=True, source_quals=source_quals)
 
 
 def parser_prep_genbank_files(parser=argparse.ArgumentParser()):
@@ -462,6 +466,7 @@ def parser_prep_genbank_files(parser=argparse.ArgumentParser()):
     parser.add_argument('--comment', default=None, help='comment field')
     parser.add_argument('--sequencing_tech', default=None, help='sequencing technology (e.g. Illumina HiSeq 2500)')
     parser.add_argument('--master_source_table', default=None, help='source modifier table')
+    parser.add_argument('--organism', default=None, help='species name')
     parser.add_argument("--biosample_map",
                         help="""A file with two columns and a header: sample and BioSample.
         This file may refer to samples that are not included in this submission.""")

--- a/ncbi.py
+++ b/ncbi.py
@@ -51,7 +51,7 @@ def tbl_transfer_common(cmap, ref_tbl, out_tbl, alt_chrlens, oob_clip=False):
                     if not ((refID.startswith('gb|') or refID.startswith('ref|')) and refID.endswith('|') and
                                 len(refID) > 4):
                         raise Exception("reference annotation does not refer to a GenBank or RefSeq accession")
-                    refID = refID[refID.find("|") + 1:-1]
+                    refID = '|'.join(refID.split('|')[1:-1])
                     refSeqID = [x for x in cmap.keys() if refID in x][0]
                     #altid = cmap.mapChr(refSeqID, altid)
                     altid = list(set(cmap.keys()) - set([refSeqID]))[0]  # cmap.mapChr(refSeqID, altid)

--- a/ncbi.py
+++ b/ncbi.py
@@ -396,7 +396,7 @@ def make_structured_comment_file(cmt_fname, name=None, seq_tech=None, coverage=N
 
 def prep_genbank_files(templateFile, fasta_files, annotDir,
                        master_source_table=None, comment=None, sequencing_tech=None,
-                       coverage_table=None, biosample_map=None, organism=None):
+                       coverage_table=None, biosample_map=None, organism=None, mol_type=None):
     ''' Prepare genbank submission files.  Requires .fasta and .tbl files as input,
         as well as numerous other metadata files for the submission.  Creates a
         directory full of files (.sqn in particular) that can be sent to GenBank.
@@ -453,7 +453,9 @@ def prep_genbank_files(templateFile, fasta_files, annotDir,
     tbl2asn = tools.tbl2asn.Tbl2AsnTool()
     source_quals = []
     if organism:
-        source_quals = [('organism', organism)]
+        source_quals.append(('organism', organism))
+    if mol_type:
+        source_quals.append(('mol_type', mol_type))
     tbl2asn.execute(templateFile, annotDir, comment=comment,
         per_genome_comment=True, source_quals=source_quals)
 
@@ -467,6 +469,7 @@ def parser_prep_genbank_files(parser=argparse.ArgumentParser()):
     parser.add_argument('--sequencing_tech', default=None, help='sequencing technology (e.g. Illumina HiSeq 2500)')
     parser.add_argument('--master_source_table', default=None, help='source modifier table')
     parser.add_argument('--organism', default=None, help='species name')
+    parser.add_argument('--mol_type', default=None, help='molecule type')
     parser.add_argument("--biosample_map",
                         help="""A file with two columns and a header: sample and BioSample.
         This file may refer to samples that are not included in this submission.""")

--- a/pipes/WDL/dx-defaults-spikein.json
+++ b/pipes/WDL/dx-defaults-spikein.json
@@ -1,4 +1,4 @@
 {
-  "spikein.spikein.spikein_db":
+  "spikein.spikein_report.spikein_db":
     "dx://file-F6PXkF00Yqp3zVXq14fF98Kz"
 }

--- a/pipes/WDL/workflows/align_and_annot.wdl
+++ b/pipes/WDL/workflows/align_and_annot.wdl
@@ -24,7 +24,7 @@ workflow align_and_annot {
       input:
         assemblies_fasta = assemblies_fasta,
         annotations_tbl = annot.transferred_feature_tables,
-        out_prefix = basename(annotations_tbl, '.tbl')
+        out_prefix = basename(by_chr.right, '.tbl')
     }
   }
 }

--- a/pipes/WDL/workflows/align_and_annot.wdl
+++ b/pipes/WDL/workflows/align_and_annot.wdl
@@ -13,12 +13,12 @@ workflow align_and_annot {
       assemblies_fasta = assemblies_fasta
   }
 
-  scatter(aln_by_chr, ref_annot_by_chr in zip(mafft.alignments_by_chr, annotations_tbl)) {
+  scatter(by_chr in zip(mafft.alignments_by_chr, annotations_tbl)) {
     call ncbi.annot_transfer as annot {
       input:
-        chr_mutli_aln_fasta = aln_by_chr,
+        chr_mutli_aln_fasta = by_chr.left,
         reference_fasta = reference_fasta,
-        reference_feature_table = ref_annot_by_chr
+        reference_feature_table = by_chr.right
     }
     call ncbi.prepare_genbank as genbank {
       input:

--- a/pipes/WDL/workflows/align_and_annot.wdl
+++ b/pipes/WDL/workflows/align_and_annot.wdl
@@ -1,0 +1,29 @@
+import "tasks/interhost.wdl" as interhost
+import "tasks/ncbi.wdl" as ncbi
+import "tasks/reports.wdl" as reports
+
+
+workflow align_and_annot {
+
+  File        reference_fasta
+  Array[File] assemblies_fasta
+
+  call interhost.multi_align_mafft_ref as mafft {
+    input:
+      reference_fasta = reference_fasta,
+      assemblies_fasta = assemblies_fasta
+  }
+
+  scatter(mutli_aln_fasta in mafft.alignments_by_chr) {
+    call ncbi.annot_transfer as annot {
+      input:
+        chr_mutli_aln_fasta = mutli_aln_fasta,
+        reference_fasta = reference_fasta
+    }
+    call ncbi.prepare_genbank as genbank {
+      input:
+        assemblies_fasta = assemblies_fasta,
+        annotations_tbl = annot.featureTables # I'm worried that the order got messed up
+    }
+  }
+}

--- a/pipes/WDL/workflows/align_and_annot.wdl
+++ b/pipes/WDL/workflows/align_and_annot.wdl
@@ -1,5 +1,7 @@
-import "tasks/interhost.wdl" as interhost
-import "tasks/ncbi.wdl" as ncbi
+import "interhost.wdl" as interhost
+import "ncbi.wdl" as ncbi
+
+# DX_SKIP_WORKFLOW
 
 workflow align_and_annot {
 

--- a/pipes/WDL/workflows/align_and_annot.wdl
+++ b/pipes/WDL/workflows/align_and_annot.wdl
@@ -13,17 +13,18 @@ workflow align_and_annot {
       assemblies_fasta = assemblies_fasta
   }
 
-  scatter(chr_num in range(len(mafft.alignments_by_chr))) {
+  scatter(aln_by_chr, ref_annot_by_chr in zip(mafft.alignments_by_chr, annotations_tbl)) {
     call ncbi.annot_transfer as annot {
       input:
-        chr_mutli_aln_fasta = mafft.alignments_by_chr[chr_num],
+        chr_mutli_aln_fasta = aln_by_chr,
         reference_fasta = reference_fasta,
-        reference_feature_table = annotations_tbl[chr_num]
+        reference_feature_table = ref_annot_by_chr
     }
     call ncbi.prepare_genbank as genbank {
       input:
         assemblies_fasta = assemblies_fasta,
-        annotations_tbl = annot.featureTables # I'm worried that the order got messed up and we'll have to remap?
+        annotations_tbl = annot.transferred_feature_tables,
+        out_prefix = basename(annotations_tbl, '.tbl')
     }
   }
 }

--- a/pipes/WDL/workflows/align_and_annot.wdl
+++ b/pipes/WDL/workflows/align_and_annot.wdl
@@ -1,12 +1,11 @@
 import "tasks/interhost.wdl" as interhost
 import "tasks/ncbi.wdl" as ncbi
-import "tasks/reports.wdl" as reports
-
 
 workflow align_and_annot {
 
-  File        reference_fasta
-  Array[File] assemblies_fasta
+  File          reference_fasta
+  Array[File]+  assemblies_fasta
+  Array[File]+  annotations_tbl
 
   call interhost.multi_align_mafft_ref as mafft {
     input:
@@ -14,16 +13,17 @@ workflow align_and_annot {
       assemblies_fasta = assemblies_fasta
   }
 
-  scatter(mutli_aln_fasta in mafft.alignments_by_chr) {
+  scatter(chr_num in range(len(mafft.alignments_by_chr))) {
     call ncbi.annot_transfer as annot {
       input:
-        chr_mutli_aln_fasta = mutli_aln_fasta,
-        reference_fasta = reference_fasta
+        chr_mutli_aln_fasta = mafft.alignments_by_chr[chr_num],
+        reference_fasta = reference_fasta,
+        reference_feature_table = annotations_tbl[chr_num]
     }
     call ncbi.prepare_genbank as genbank {
       input:
         assemblies_fasta = assemblies_fasta,
-        annotations_tbl = annot.featureTables # I'm worried that the order got messed up
+        annotations_tbl = annot.featureTables # I'm worried that the order got messed up and we'll have to remap?
     }
   }
 }

--- a/pipes/WDL/workflows/align_and_plot.wdl
+++ b/pipes/WDL/workflows/align_and_plot.wdl
@@ -1,4 +1,4 @@
-import "tasks/reports.wdl" as reports
+import "reports.wdl" as reports
 
 workflow align_and_plot {
   call reports.plot_coverage {

--- a/pipes/WDL/workflows/assemble_denovo.wdl
+++ b/pipes/WDL/workflows/assemble_denovo.wdl
@@ -1,5 +1,5 @@
-import "tasks/taxon_filter.wdl" as taxon_filter
-import "tasks/assembly.wdl" as assembly
+import "taxon_filter.wdl" as taxon_filter
+import "assembly.wdl" as assembly
 
 workflow assemble_denovo {
   File reads_unmapped_bam

--- a/pipes/WDL/workflows/assemble_denovo_with_deplete.wdl
+++ b/pipes/WDL/workflows/assemble_denovo_with_deplete.wdl
@@ -1,5 +1,5 @@
-import "tasks/taxon_filter.wdl" as taxon_filter
-import "tasks/assembly.wdl" as assembly
+import "taxon_filter.wdl" as taxon_filter
+import "assembly.wdl" as assembly
 
 workflow assemble_denovo_with_deplete {
 

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -1,4 +1,4 @@
-import "tasks/assembly.wdl" as assembly
+import "assembly.wdl" as assembly
 
 workflow assemble_refbased {
   call assembly.refine_2x_and_plot

--- a/pipes/WDL/workflows/classify_kraken.wdl
+++ b/pipes/WDL/workflows/classify_kraken.wdl
@@ -1,4 +1,4 @@
-import "tasks/metagenomics.wdl" as metagenomics
+import "metagenomics.wdl" as metagenomics
 
 workflow classify_kraken {
   call metagenomics.kraken

--- a/pipes/WDL/workflows/contigs.wdl
+++ b/pipes/WDL/workflows/contigs.wdl
@@ -1,6 +1,6 @@
-import "tasks/metagenomics.wdl" as metagenomics
-import "tasks/taxon_filter.wdl" as taxon_filter
-import "tasks/assembly.wdl" as assembly
+import "metagenomics.wdl" as metagenomics
+import "taxon_filter.wdl" as taxon_filter
+import "assembly.wdl" as assembly
 
 workflow contigs {
 

--- a/pipes/WDL/workflows/demux_metag.wdl
+++ b/pipes/WDL/workflows/demux_metag.wdl
@@ -1,10 +1,10 @@
 #DX_SKIP_WORKFLOW
 
-import "tasks/demux.wdl" as demux
-import "tasks/metagenomics.wdl" as metagenomics
-import "tasks/taxon_filter.wdl" as taxon_filter
-import "tasks/assembly.wdl" as assembly
-import "tasks/reports.wdl" as reports
+import "demux.wdl" as demux
+import "metagenomics.wdl" as metagenomics
+import "taxon_filter.wdl" as taxon_filter
+import "assembly.wdl" as assembly
+import "reports.wdl" as reports
 
 workflow demux_metag {
   File krona_taxonomy_db_tgz

--- a/pipes/WDL/workflows/demux_only.wdl
+++ b/pipes/WDL/workflows/demux_only.wdl
@@ -1,4 +1,4 @@
-import "tasks/demux.wdl" as tasks_demux
+import "demux.wdl" as tasks_demux
 
 workflow demux_only {
   call tasks_demux.illumina_demux

--- a/pipes/WDL/workflows/demux_plus.wdl
+++ b/pipes/WDL/workflows/demux_plus.wdl
@@ -1,8 +1,8 @@
-import "tasks/demux.wdl" as demux
-import "tasks/metagenomics.wdl" as metagenomics
-import "tasks/taxon_filter.wdl" as taxon_filter
-import "tasks/assembly.wdl" as assembly
-import "tasks/reports.wdl" as reports
+import "demux.wdl" as demux
+import "metagenomics.wdl" as metagenomics
+import "taxon_filter.wdl" as taxon_filter
+import "assembly.wdl" as assembly
+import "reports.wdl" as reports
 
 workflow demux_plus {
 

--- a/pipes/WDL/workflows/deplete_only.wdl
+++ b/pipes/WDL/workflows/deplete_only.wdl
@@ -1,4 +1,4 @@
-import "tasks/taxon_filter.wdl" as taxon_filter
+import "taxon_filter.wdl" as taxon_filter
 
 workflow deplete_only {
   call taxon_filter.deplete_taxa

--- a/pipes/WDL/workflows/download_annotations.wdl
+++ b/pipes/WDL/workflows/download_annotations.wdl
@@ -1,4 +1,4 @@
-import "tasks/ncbi.wdl" as ncbi
+import "ncbi.wdl" as ncbi
 
 workflow download_annotations {
 

--- a/pipes/WDL/workflows/download_annotations.wdl
+++ b/pipes/WDL/workflows/download_annotations.wdl
@@ -2,6 +2,6 @@ import "ncbi.wdl" as ncbi
 
 workflow download_annotations {
 
-  call ncbi.download_annotations
+  call ncbi.download_annotations as download
 
 }

--- a/pipes/WDL/workflows/download_annotations.wdl
+++ b/pipes/WDL/workflows/download_annotations.wdl
@@ -1,0 +1,7 @@
+import "tasks/ncbi.wdl" as ncbi
+
+workflow download_annotations {
+
+  call ncbi.download_annotations
+
+}

--- a/pipes/WDL/workflows/fetch_annotations.wdl
+++ b/pipes/WDL/workflows/fetch_annotations.wdl
@@ -1,6 +1,6 @@
 import "ncbi.wdl" as ncbi
 
-workflow download_annotations {
+workflow fetch_annotations {
 
   call ncbi.download_annotations as download
 

--- a/pipes/WDL/workflows/scaffold_and_refine.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine.wdl
@@ -1,4 +1,4 @@
-import "tasks/assembly.wdl" as assembly
+import "assembly.wdl" as assembly
 
 workflow scaffold_and_refine {
   File reads_unmapped_bam

--- a/pipes/WDL/workflows/spikein.wdl
+++ b/pipes/WDL/workflows/spikein.wdl
@@ -2,6 +2,6 @@ import "reports.wdl" as reports
 
 workflow spikein {
 
-  call reports.spikein_report as spikein
+  call reports.spikein_report as spikein_report
 
 }

--- a/pipes/WDL/workflows/spikein.wdl
+++ b/pipes/WDL/workflows/spikein.wdl
@@ -1,4 +1,4 @@
-import "tasks/reports.wdl" as reports
+import "reports.wdl" as reports
 
 workflow spikein {
 

--- a/pipes/WDL/workflows/tasks/assembly.wdl
+++ b/pipes/WDL/workflows/tasks/assembly.wdl
@@ -333,8 +333,10 @@ task refine_2x_and_plot {
     File refine2_sites_vcf_gz        = "${sample_name}.refine2.pre_fasta.vcf.gz"
     File final_assembly_fasta        = "${sample_name}.fasta"
     File aligned_bam                 = "${sample_name}.all.bam"
+    File aligned_bam_idx             = "${sample_name}.all.bai"
     File aligned_bam_flagstat        = "${sample_name}.all.bam.flagstat.txt"
     File aligned_only_reads_bam      = "${sample_name}.mapped.bam"
+    File aligned_only_reads_bam_idx  = "${sample_name}.mapped.bai"
     File aligned_only_reads_fastqc   = "${sample_name}.mapped_fastqc.html"
     File coverage_plot               = "${sample_name}.coverage_plot.pdf"
     Int  assembly_length             = read_int("assembly_length")

--- a/pipes/WDL/workflows/tasks/interhost.wdl
+++ b/pipes/WDL/workflows/tasks/interhost.wdl
@@ -79,23 +79,22 @@ task multi_align_mafft {
   Array[File] inputAssemblies # fasta files, one per sample
   File referenceGenome # fasta
 
-  Int? threads
   Int? maxIters
   Int? ep
 
 
   command {
     interhost.py multichr_mafft \
-      "${referenceGenome}" \
-      "${sep=' ' inputAssemblies+}" \
-      "./" \
-      "${'--ep' + ep}" \
-      "${'--maxiters' + maxIters}" \
+      ${referenceGenome} \
+      ${sep=' ' inputAssemblies+} \
+      ./ \
+      ${'--ep' + ep} \
+      ${'--maxiters' + maxIters} \
       --preservecase \
       --localpair \
       --outFilePrefix aligned \
-      --sampleNameListFile "sampleNameList.txt" \
-      "${'--threads' + threads}"
+      --sampleNameListFile sampleNameList.txt \
+      --loglevel DEBUG
   }
 
   output {

--- a/pipes/WDL/workflows/tasks/interhost.wdl
+++ b/pipes/WDL/workflows/tasks/interhost.wdl
@@ -75,35 +75,68 @@ task ref_guided_consensus_aligned_with_dups {
 #  }
 #}
 
-task multi_align_mafft {
-  Array[File] inputAssemblies # fasta files, one per sample
-  File referenceGenome # fasta
-
-  Int? maxIters
-  Int? ep
-
+task multi_align_mafft_ref {
+  File           reference_fasta
+  Array[File]+   assemblies_fasta # fasta files, one per sample, multiple chrs per file okay
+  String?        out_prefix = basename(reference_fasta, '.fasta')
+  Int?           mafft_maxIters
+  Int?           mafft_ep
 
   command {
     interhost.py multichr_mafft \
-      ${referenceGenome} \
-      ${sep=' ' inputAssemblies+} \
-      ./ \
-      ${'--ep' + ep} \
-      ${'--maxiters' + maxIters} \
+      ${reference_fasta} ${sep=' ' assemblies_fasta} \
+      . \
+      ${'--ep' + mafft_ep} \
+      ${'--maxiters' + mafft_maxIters} \
+      --outFilePrefix ${out_prefix} \
       --preservecase \
       --localpair \
-      --outFilePrefix aligned \
-      --sampleNameListFile sampleNameList.txt \
+      --sampleNameListFile ${out_prefix}-sample_names.txt \
       --loglevel DEBUG
   }
 
   output {
-    File sampleNamesFile = "sampleNamesList.txt"
-    Array[File] chrAlignedFiles = glob("aligned_*.fasta")
+    File        sampleNamesFile   = "${out_prefix}-sample_names.txt"
+    Array[File] alignments_by_chr = glob("${out_prefix}*.fasta")
   }
+
   runtime {
-    memory: "8 GB"
     docker: "quay.io/broadinstitute/viral-ngs"
+    memory: "7 GB"
+    cpu: 4
+    dx_instance_type: "mem1_ssd1_x4"
+  }
+}
+
+task multi_align_mafft {
+  Array[File]+   assemblies_fasta # fasta files, one per sample, multiple chrs per file okay
+  String?        out_prefix = basename(select_first(assemblies_fasta), '.fasta')
+  Int?           mafft_maxIters
+  Int?           mafft_ep
+
+  command {
+    interhost.py multichr_mafft \
+      ${sep=' ' assemblies_fasta} \
+      . \
+      ${'--ep' + mafft_ep} \
+      ${'--maxiters' + mafft_maxIters} \
+      --outFilePrefix ${out_prefix} \
+      --preservecase \
+      --localpair \
+      --sampleNameListFile ${out_prefix}-sample_names.txt \
+      --loglevel DEBUG
+  }
+
+  output {
+    File        sampleNamesFile   = "${out_prefix}-sample_names.txt"
+    Array[File] alignments_by_chr = glob("${out_prefix}*.fasta")
+  }
+
+  runtime {
+    docker: "quay.io/broadinstitute/viral-ngs"
+    memory: "7 GB"
+    cpu: 4
+    dx_instance_type: "mem1_ssd1_x4"
   }
 }
 

--- a/pipes/WDL/workflows/tasks/interhost.wdl
+++ b/pipes/WDL/workflows/tasks/interhost.wdl
@@ -110,7 +110,7 @@ task multi_align_mafft_ref {
 
 task multi_align_mafft {
   Array[File]+   assemblies_fasta # fasta files, one per sample, multiple chrs per file okay
-  String?        out_prefix = basename(select_first(assemblies_fasta), '.fasta')
+  String         out_prefix
   Int?           mafft_maxIters
   Int?           mafft_ep
 

--- a/pipes/WDL/workflows/tasks/metagenomics.wdl
+++ b/pipes/WDL/workflows/tasks/metagenomics.wdl
@@ -117,7 +117,7 @@ task krona {
     docker: "quay.io/broadinstitute/viral-ngs"
     memory: "4 GB"
     cpu: 1
-    dx_instance_type: "mem2_hdd2_x2"
+    dx_instance_type: "mem1_ssd2_x2"
   }
 }
 

--- a/pipes/WDL/workflows/tasks/ncbi.wdl
+++ b/pipes/WDL/workflows/tasks/ncbi.wdl
@@ -87,11 +87,11 @@ task prepare_genbank {
   Array[File]+ assemblies_fasta
   Array[File]+ annotations_tbl
   File         authors_sbt
-  File         assemblySummary # summary.assembly.txt
-  File         genbankSourceTable
-  File         biosampleMap
-  String       sequencingTech
-  String       comment
+  File?        coverage_table # summary.assembly.txt
+  File?        genbankSourceTable
+  File?        biosampleMap
+  String?      sequencingTech
+  String?      comment
   String       out_prefix = "ncbi_package"
 
   command {
@@ -101,11 +101,11 @@ task prepare_genbank {
         ${authors_sbt} \
         ${sep=' ' assemblies_fasta} \
         . \
-        --master_source_table ${genbankSourceTable} \
-        --sequencing_tech ${sequencingTech} \
-        --biosample_map ${biosampleMap} \
-        --coverage_table ${assemblySummary} \
-        --comment ${comment} \
+        ${'--master_source_table=' + genbankSourceTable} \
+        ${'--sequencing_tech=' + sequencingTech} \
+        ${'--biosample_map=' + biosampleMap} \
+        ${'--coverage_table=' + coverage_table} \
+        ${'--comment=' + comment} \
         --loglevel DEBUG
     tar -czpvf ${out_prefix}.tar.gz *.val *.cmt *.fsa *.gbf *.sqn *.src *.tbl
   }

--- a/pipes/WDL/workflows/tasks/ncbi.wdl
+++ b/pipes/WDL/workflows/tasks/ncbi.wdl
@@ -97,7 +97,6 @@ task download_annotation {
   }
 
   output {
-    File        referenceFasta  = "${referenceName}.fasta"
     File        featureTable    = "${referenceName}.tbl"
     Array[File] featureTables   = glob("*.tbl")
   }

--- a/pipes/WDL/workflows/tasks/ncbi.wdl
+++ b/pipes/WDL/workflows/tasks/ncbi.wdl
@@ -26,7 +26,7 @@ task download_fasta {
 task download_annotations {
   Array[String]+ accessions
   String         emailAddress
-  String         combined_fasta
+  String         combined_out_prefix
 
   command {
     set -ex -o pipefail
@@ -39,12 +39,12 @@ task download_annotations {
         ${emailAddress} \
         ./ \
         ${sep=' ' accessions} \
-        --combinedFilePrefix "${combined_fasta}" \
+        --combinedFilePrefix "${combined_out_prefix}" \
         --loglevel DEBUG
   }
 
   output {
-    File        combined_fasta = "${combined_fasta}.fasta"
+    File        combined_fasta = "${combined_out_prefix}.fasta"
     Array[File] genomes_fasta  = glob("*.fasta")
     Array[File] features_tbl   = glob("*.tbl")
   }

--- a/pipes/WDL/workflows/tasks/ncbi.wdl
+++ b/pipes/WDL/workflows/tasks/ncbi.wdl
@@ -87,7 +87,6 @@ task download_annotation {
   String        emailAddress
 
   command {
-    set -ex -o pipefail
     ncbi.py fetch_feature_tables \
         ${emailAddress} \
         ./ \
@@ -146,6 +145,7 @@ task prepare_genbank {
   String       comment
 
   command {
+    set -ex -o pipefail
     cp ${sep=' ' annotations_tbl} .
     ncbi.py prep_genbank_files \
         ${authors_sbt} \

--- a/pipes/WDL/workflows/tasks/ncbi.wdl
+++ b/pipes/WDL/workflows/tasks/ncbi.wdl
@@ -87,7 +87,7 @@ task prepare_genbank {
   Array[File]+ assemblies_fasta
   Array[File]+ annotations_tbl
   File         authors_sbt
-  File?        coverage_table # summary.assembly.txt
+  File?        coverage_table # summary.assembly.txt (from Snakemake)
   File?        genbankSourceTable
   File?        biosampleMap
   String?      sequencingTech

--- a/pipes/WDL/workflows/tasks/reports.wdl
+++ b/pipes/WDL/workflows/tasks/reports.wdl
@@ -33,7 +33,7 @@ task plot_coverage {
     read_utils.py align_and_fix \
       ${reads_unmapped_bam} \
       assembly.fasta \
-      --outBamAll ${sample_name}.bam \
+      --outBamAll ${sample_name}.all.bam \
       --outBamFiltered ${sample_name}.mapped.bam \
       --GATK_PATH gatk/ \
       --aligner ${aligner} \
@@ -66,22 +66,24 @@ task plot_coverage {
         --plotDPI 100 \
         --loglevel=DEBUG
     else
-      touch ${sample_name}.coverage_plot.pdf ${sample_name}.mapped_fastqc.html
+      touch ${sample_name}.coverage_plot.pdf
     fi
   }
 
   output {
-    File reads_bam                  = "${sample_name}.bam"
-    File reads_bam_flagstat         = "${sample_name}.bam.flagstat.txt"
-    File mapped_reads_bam           = "${sample_name}.mapped.bam"
-    File mapped_reads_fastqc        = "${sample_name}.mapped_fastqc.html"
-    File coverage_plot              = "${sample_name}.coverage_plot.pdf"
-    Int assembly_length             = read_int("assembly_length")
-    Int assembly_length_unambiguous = read_int("assembly_length_unambiguous")
-    Int reads_aligned               = read_int("reads_aligned")
-    Int read_pairs_aligned          = read_int("read_pairs_aligned")
-    Int bases_aligned               = read_int("bases_aligned")
-    Int mean_coverage               = read_int("mean_coverage")
+    File aligned_bam                 = "${sample_name}.all.bam"
+    File aligned_bam_idx             = "${sample_name}.all.bai"
+    File aligned_bam_flagstat        = "${sample_name}.all.bam.flagstat.txt"
+    File aligned_only_reads_bam      = "${sample_name}.mapped.bam"
+    File aligned_only_reads_bam_idx  = "${sample_name}.mapped.bai"
+    File aligned_only_reads_fastqc   = "${sample_name}.mapped_fastqc.html"
+    File coverage_plot               = "${sample_name}.coverage_plot.pdf"
+    Int  assembly_length             = read_int("assembly_length")
+    Int  assembly_length_unambiguous = read_int("assembly_length_unambiguous")
+    Int  reads_aligned               = read_int("reads_aligned")
+    Int  read_pairs_aligned          = read_int("read_pairs_aligned")
+    Int  bases_aligned               = read_int("bases_aligned")
+    Int  mean_coverage               = read_int("mean_coverage")
   }
 
   runtime {

--- a/pipes/WDL/workflows/tasks/taxon_filter.wdl
+++ b/pipes/WDL/workflows/tasks/taxon_filter.wdl
@@ -117,6 +117,27 @@ task filter_to_taxon {
   }
 }
 
+task build_lastal_db {
+  File    sequences_fasta
+  String  db_name = basename(sequences_fasta, ".fasta")
+
+  command {
+    set -ex -o pipefail
+    taxon_filter.py lastal_build_db ${sequences_fasta} ./ --loglevel=DEBUG
+    tar -c ${db_name}* | lz4 -9 > ${db_name}.tar.lz4
+  }
+
+  output {
+    File lastal_db = "${db_name}.tar.lz4"
+  }
+
+  runtime {
+    docker: "quay.io/broadinstitute/viral-ngs"
+    memory: "7 GB"
+    cpu: 2
+    dx_instance_type: "mem1_ssd1_x4"
+  }
+}
 
 task merge_one_per_sample {
   String       out_bam_basename

--- a/pipes/WDL/workflows/tasks/taxon_filter.wdl
+++ b/pipes/WDL/workflows/tasks/taxon_filter.wdl
@@ -175,6 +175,6 @@ task merge_one_per_sample {
     memory: "7 GB"
     cpu: 4
     docker: "quay.io/broadinstitute/viral-ngs"
-    dx_instance_type: "mem1_hdd2_x8"
+    dx_instance_type: "mem1_ssd2_x4"
   }
 }

--- a/pipes/WDL/workflows/tasks/taxon_filter.wdl
+++ b/pipes/WDL/workflows/tasks/taxon_filter.wdl
@@ -175,6 +175,6 @@ task merge_one_per_sample {
     memory: "7 GB"
     cpu: 4
     docker: "quay.io/broadinstitute/viral-ngs"
-    dx_instance_type: "mem2_hdd2_x4"
+    dx_instance_type: "mem1_hdd2_x8"
   }
 }

--- a/travis/build-dx.sh
+++ b/travis/build-dx.sh
@@ -42,7 +42,7 @@ for workflow in pipes/WDL/workflows/*.wdl; do
 
 	  dx_id=$(java -jar dxWDL.jar compile \
       $workflow $CMD_INPUT $CMD_DEFAULTS -f \
-      -imports pipes/WDL/workflows/ \
+      -imports pipes/WDL/workflows/tasks/ \
       -destination /build/$VERSION/$workflow_name)
 	  echo "Succeeded: $workflow_name = $dx_id"
     echo -e "$workflow_name\t$dx_id" >> $COMPILE_SUCCESS

--- a/travis/build-dx.sh
+++ b/travis/build-dx.sh
@@ -42,6 +42,7 @@ for workflow in pipes/WDL/workflows/*.wdl; do
 
 	  dx_id=$(java -jar dxWDL.jar compile \
       $workflow $CMD_INPUT $CMD_DEFAULTS -f \
+      -imports pipes/WDL/workflows/ \
       -destination /build/$VERSION/$workflow_name)
 	  echo "Succeeded: $workflow_name = $dx_id"
     echo -e "$workflow_name\t$dx_id" >> $COMPILE_SUCCESS

--- a/travis/install-wdl.sh
+++ b/travis/install-wdl.sh
@@ -19,7 +19,7 @@ cached_fetch_jar_from_github () {
 
 cached_fetch_jar_from_github broadinstitute cromwell womtool 30.2
 cached_fetch_jar_from_github broadinstitute cromwell cromwell 30.2
-cached_fetch_jar_from_github dnanexus dxWDL dxWDL 0.59
+cached_fetch_jar_from_github dnanexus dxWDL dxWDL 0.60.2
 
 TGZ=dx-toolkit-v0.240.1-ubuntu-14.04-amd64.tar.gz
 if [ ! -f $CACHE_DIR/$TGZ ]; then

--- a/travis/tests-cromwell.sh
+++ b/travis/tests-cromwell.sh
@@ -2,7 +2,8 @@
 set -e  # intentionally allow for pipe failures below
 
 ln -s $GATK_PATH/GenomeAnalysisTK.jar .
-ln -s pipes/WDL/workflows pipes/WDL/workflows/tasks .
+mkdir -p workflows
+ln -s pipes/WDL/workflows/*.wdl pipes/WDL/workflows/tasks/*.wdl workflows
 
 for workflow in pipes/WDL/workflows/*.wdl; do
 	workflow_name=$(basename $workflow .wdl)
@@ -13,7 +14,6 @@ for workflow in pipes/WDL/workflows/*.wdl; do
 		# the "cat" is to allow a pipe failure (otherwise it halts because of set -e)
 		java -jar cromwell.jar run \
 			workflows/$workflow_name.wdl \
-			--imports tasks \
 			-i $input_json | tee cromwell.out
 		if [ ${PIPESTATUS[0]} -gt 0 ]; then
 			echo "error running $workflow_name"

--- a/travis/tests-cromwell.sh
+++ b/travis/tests-cromwell.sh
@@ -13,6 +13,7 @@ for workflow in pipes/WDL/workflows/*.wdl; do
 		# the "cat" is to allow a pipe failure (otherwise it halts because of set -e)
 		java -jar cromwell.jar run \
 			workflows/$workflow_name.wdl \
+			--imports tasks \
 			-i $input_json | tee cromwell.out
 		if [ ${PIPESTATUS[0]} -gt 0 ]; then
 			echo "error running $workflow_name"

--- a/travis/tests-cromwell.sh
+++ b/travis/tests-cromwell.sh
@@ -4,8 +4,9 @@ set -e  # intentionally allow for pipe failures below
 ln -s $GATK_PATH/GenomeAnalysisTK.jar .
 mkdir -p workflows
 ln -s pipes/WDL/workflows/*.wdl pipes/WDL/workflows/tasks/*.wdl workflows
+cd workflows
 
-for workflow in pipes/WDL/workflows/*.wdl; do
+for workflow in ../pipes/WDL/workflows/*.wdl; do
 	workflow_name=$(basename $workflow .wdl)
 	input_json="test/input/WDL/test_inputs-$workflow_name-local.json"
 	if [ -f $input_json ]; then
@@ -13,7 +14,7 @@ for workflow in pipes/WDL/workflows/*.wdl; do
 		echo "Executing $workflow_name using Cromwell on local instance"
 		# the "cat" is to allow a pipe failure (otherwise it halts because of set -e)
 		java -jar cromwell.jar run \
-			workflows/$workflow_name.wdl \
+			$workflow_name.wdl \
 			-i $input_json | tee cromwell.out
 		if [ ${PIPESTATUS[0]} -gt 0 ]; then
 			echo "error running $workflow_name"
@@ -29,5 +30,6 @@ for workflow in pipes/WDL/workflows/*.wdl; do
     fi
 done
 
+cd -
 date
 echo "note: there is no testing of output correctness yet..."

--- a/travis/validate-wdl.sh
+++ b/travis/validate-wdl.sh
@@ -1,9 +1,23 @@
 #!/bin/bash
 set -e -o pipefail
 
-ln -s pipes/WDL/workflows/tasks .
-for workflow in pipes/WDL/workflows/*.wdl; do
+# validate each imported library of tasks on its own
+for tasks in pipes/WDL/workflows/tasks/*.wdl; do
+  echo "validating tasks $tasks"
+  java -jar womtool.jar validate $tasks
+done
+
+# validate the workflow files
+# unfortunately, dxWDL now requires the -imports parameter and cromwell supports
+# it as well but womtool validate does not yet support it! so we have to copy
+# everything to a temp dir
+mkdir wdl_validate_test
+cd wdl_validate_test
+cp ../pipes/WDL/workflows/tasks/*.wdl ../pipes/WDL/workflows/*.wdl .
+for workflow in ../pipes/WDL/workflows/*.wdl; do
+  workflow=`basename $workflow`
   echo "validating $workflow"
   java -jar womtool.jar validate $workflow
 done
-rm tasks
+cd -
+rm -r wdl_validate_test

--- a/travis/validate-wdl.sh
+++ b/travis/validate-wdl.sh
@@ -17,7 +17,7 @@ cp ../pipes/WDL/workflows/tasks/*.wdl ../pipes/WDL/workflows/*.wdl .
 for workflow in ../pipes/WDL/workflows/*.wdl; do
   workflow=`basename $workflow`
   echo "validating $workflow"
-  java -jar womtool.jar validate $workflow
+  java -jar ../womtool.jar validate $workflow
 done
 cd -
 rm -r wdl_validate_test

--- a/util/genbank.py
+++ b/util/genbank.py
@@ -23,7 +23,6 @@ def parse_accession_str(chr_ref):
     return chr_ref
 
 def get_feature_table_id(featureTableFile):
-    seqid = ""
     with open(featureTableFile, 'rt') as inf:
         for line in inf:
             line = line.rstrip('\r\n')
@@ -37,10 +36,8 @@ def get_feature_table_id(featureTableFile):
                 if not (
                     (seqid.startswith('gb|') or seqid.startswith('ref|')) and seqid.endswith('|') and len(seqid) > 4):
                     raise Exception("reference annotation does not refer to a GenBank or RefSeq accession")
-                seqid = seqid[seqid.find("|") + 1:-1]
-    if len(seqid) > 0:
-        return seqid
-
+                seqid = '|'.join(seqid.split('|')[1:-1])
+                return seqid
 
 def _seq_chunks(seq, n):
     # http://stackoverflow.com/a/312464/190597 (Ned Batchelder)


### PR DESCRIPTION
- mostly WiP work on WDL workflows for genbank submission. Not quite there.
- some updates and fixes for latest tbl2asn usage and other rough edges discovered for recent submission.
- bump dxWDL version from 0.59 to 0.60.2
- use -imports and --imports params to dxWDL and cromwell invocations and remove "tasks/" from all WDL import statements. comment out align_and_annot for now to get compile working again.