### PR TITLE
bump viral-baseimage 0.1.8 to 0.1.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/broadinstitute/viral-baseimage:0.1.8
+FROM quay.io/broadinstitute/viral-baseimage:0.1.9
 
 LABEL maintainer "viral-ngs@broadinstitute.org"
 


### PR DESCRIPTION
Bump Ubuntu to artful-20180227.

See:
- https://github.com/broadinstitute/viral-baseimage/releases/tag/0.1.9
- https://wiki.ubuntu.com/SecurityTeam/KnowledgeBase/SpectreAndMeltdown