### PR TITLE
fixes to tbl_transfer_prealigned oob_clip

### DIFF
--- a/ncbi.py
+++ b/ncbi.py
@@ -82,11 +82,19 @@ def tbl_transfer_common(cmap, ref_tbl, out_tbl, alt_chrlens, oob_clip=False):
                         # feature overhangs end of sequence
                         if oob_clip:
                             if row[0] == None:
-                                row[0] = '<1'
+                                # clip the beginning
+                                if row[2] == 'CDS':
+                                    # for CDS features, clip in multiples of 3
+                                    r = (row[1] if row[1] is not None else alt_chrlens[altid])
+                                    row[0] = '<{}'.format((r % 3) + 1)
+                                else:
+                                    row[0] = '<1'
                             if row[1] == None:
+                                # clip the end
                                 row[1] = '>{}'.format(alt_chrlens[altid])
                             feature_keep = True
                         else:
+                            # drop the partially out of bounds feature
                             feature_keep = False
                             continue
                     line = '\t'.join(map(str, row))

--- a/ncbi.py
+++ b/ncbi.py
@@ -64,15 +64,19 @@ def tbl_transfer_common(cmap, ref_tbl, out_tbl, alt_chrlens, oob_clip=False):
                         raise Exception("this line has only one column?")
                     row[0] = int(row[0])
                     row[1] = int(row[1])
+                    strand = None
                     if row[1] >= row[0]:
+                        strand = '+'
                         row[0] = cmap.mapChr(refSeqID, altid, row[0], -1)[1]
                         row[1] = cmap.mapChr(refSeqID, altid, row[1], 1)[1]
                     else:
                         # negative strand feature
+                        strand = '-'
                         row[0] = cmap.mapChr(refSeqID, altid, row[0], 1)[1]
                         row[1] = cmap.mapChr(refSeqID, altid, row[1], -1)[1]
 
                     if row[0] and row[1]:
+                        # feature completely within bounds
                         feature_keep = True
                     elif row[0] == None and row[1] == None:
                         # feature completely out of bounds
@@ -81,17 +85,36 @@ def tbl_transfer_common(cmap, ref_tbl, out_tbl, alt_chrlens, oob_clip=False):
                     else:
                         # feature overhangs end of sequence
                         if oob_clip:
-                            if row[0] == None:
-                                # clip the beginning
-                                if row[2] == 'CDS':
-                                    # for CDS features, clip in multiples of 3
-                                    r = (row[1] if row[1] is not None else alt_chrlens[altid])
-                                    row[0] = '<{}'.format((r % 3) + 1)
-                                else:
-                                    row[0] = '<1'
-                            if row[1] == None:
-                                # clip the end
-                                row[1] = '>{}'.format(alt_chrlens[altid])
+                            if strand == '+':
+                                # clip pos strand feature
+                                if row[0] == None:
+                                    # clip the beginning
+                                    if row[2] == 'CDS':
+                                        # for CDS features, clip in multiples of 3
+                                        r = (row[1] if row[1] is not None else alt_chrlens[altid])
+                                        row[0] = '<{}'.format((r % 3) + 1)
+                                    else:
+                                        row[0] = '<1'
+                                if row[1] == None:
+                                    # clip the end
+                                    row[1] = '>{}'.format(alt_chrlens[altid])
+                            else:
+                                # clip neg strand feature
+                                if row[0] == None:
+                                    # clip the beginning (right side)
+                                    r = alt_chrlens[altid]
+                                    if row[2] == 'CDS':
+                                        # for CDS features, clip in multiples of 3
+                                        l = (row[1] if row[1] is not None else 1) # new left
+                                        r = r - ((r-l+1) % 3) # create new right in multiples of 3 from left
+                                        if (r-l) < 3:
+                                            # less than a codon remains, drop it
+                                            feature_keep = False
+                                            continue
+                                    row[0] = '>{}'.format(r)
+                                if row[1] == None:
+                                    # clip the end (left side)
+                                    row[1] = '<1'
                             feature_keep = True
                         else:
                             # drop the partially out of bounds feature

--- a/tools/tbl2asn.py
+++ b/tools/tbl2asn.py
@@ -14,7 +14,7 @@ import subprocess
 import gzip
 
 TOOL_NAME = "tbl2asn"
-TOOL_VERSION = "25.3" # quirk: versions error-out one year after their compilation date
+TOOL_VERSION = "25.6" # quirk: versions error-out one year after their compilation date
 TOOL_URL = 'ftp://ftp.ncbi.nih.gov/toolbox/ncbi_tools/converters/by_program/tbl2asn/{os}.tbl2asn.gz'
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Fixes and updates to `tbl_transfer_prealigned --oob_clip` behavior. Specifically:

1. CDS features are handled a bit specially: the 5' end is trimmed in multiples of 3 to retain original reading frame. 3' ends are still trimmed as-is.
2. oob_clip behavior was buggy for negative strand features: if the right end of the genome caused the 5' of a negative strand feature to be clipped, it was previously getting recorded as `<1` which caused it to become positive stranded and encode the wrong half of the genome. This is now trimming to the right end of the genome instead (except with CDS features which get rounded off to the nearest multiple of 3).