### PR TITLE
genbank submission fixes

### DIFF
--- a/ncbi.py
+++ b/ncbi.py
@@ -40,6 +40,7 @@ def tbl_transfer_common(cmap, ref_tbl, out_tbl, alt_chrlens, oob_clip=False):
     with open(ref_tbl, 'rt') as inf:
         with open(out_tbl, 'wt') as outf:
             for line in inf:
+                notes = [] # reset with each new line
                 line = line.rstrip('\r\n')
                 if not line:
                     pass
@@ -85,6 +86,8 @@ def tbl_transfer_common(cmap, ref_tbl, out_tbl, alt_chrlens, oob_clip=False):
                     else:
                         # feature overhangs end of sequence
                         if oob_clip:
+                            if row[2] == 'CDS':
+                                notes.append('sequencing did not capture complete CDS')
                             if strand == '+':
                                 # clip pos strand feature
                                 if row[0] == None:
@@ -97,7 +100,7 @@ def tbl_transfer_common(cmap, ref_tbl, out_tbl, alt_chrlens, oob_clip=False):
                                         row[0] = '<1'
                                 if row[1] == None:
                                     # clip the end
-                                    row[1] = '>{}'.format(alt_chrlens[altid])
+                                    row[1] = '<{}'.format(alt_chrlens[altid])
                             else:
                                 # clip neg strand feature
                                 if row[0] == None:
@@ -111,7 +114,7 @@ def tbl_transfer_common(cmap, ref_tbl, out_tbl, alt_chrlens, oob_clip=False):
                                             # less than a codon remains, drop it
                                             feature_keep = False
                                             continue
-                                    row[0] = '>{}'.format(r)
+                                    row[0] = '<{}'.format(r)
                                 if row[1] == None:
                                     # clip the end (left side)
                                     row[1] = '<1'
@@ -130,6 +133,8 @@ def tbl_transfer_common(cmap, ref_tbl, out_tbl, alt_chrlens, oob_clip=False):
                         # skip any lines that refer to an explicit protein_id
                         continue
                 outf.write(line + '\n')
+                for note in notes:
+                    outf.write('\t\t\tnote ' + note + '\n')
 
 
 def tbl_transfer(ref_fasta, ref_tbl, alt_fasta, out_tbl, oob_clip=False):

--- a/pipes/WDL/workflows/tasks/interhost.wdl
+++ b/pipes/WDL/workflows/tasks/interhost.wdl
@@ -2,7 +2,7 @@
 task multi_align_mafft_ref {
   File           reference_fasta
   Array[File]+   assemblies_fasta # fasta files, one per sample, multiple chrs per file okay
-  String         out_prefix = basename(reference_fasta, '.fasta')
+  String         fasta_basename = basename(reference_fasta, '.fasta')
   Int?           mafft_maxIters
   Float?         mafft_ep
   Float?         mafft_gapOpeningPenalty
@@ -14,16 +14,16 @@ task multi_align_mafft_ref {
       ${'--ep' + mafft_ep} \
       ${'--gapOpeningPenalty' + mafft_gapOpeningPenalty} \
       ${'--maxiters' + mafft_maxIters} \
-      --outFilePrefix ${out_prefix} \
+      --outFilePrefix align_mafft-${fasta_basename} \
       --preservecase \
       --localpair \
-      --sampleNameListFile ${out_prefix}-sample_names.txt \
+      --sampleNameListFile align_mafft-${fasta_basename}-sample_names.txt \
       --loglevel DEBUG
   }
 
   output {
-    File         sampleNamesFile   = "${out_prefix}-sample_names.txt"
-    Array[File]+ alignments_by_chr = glob("${out_prefix}*.fasta")
+    #File         sampleNamesFile   = "align_mafft-${fasta_basename}-sample_names.txt"
+    Array[File]+ alignments_by_chr = glob("align_mafft-${fasta_basename}*.fasta")
   }
 
   runtime {


### PR DESCRIPTION
This PR introduces the following changes:
1. `ncbi.py tbl_transfer_prealigned` -- bug fix: a clipped feature on the end of a segment/chromosome should be denoted in a `tbl` file with a `<` (like clipping at the beginning of a segment), not a `>`.
2. `ncbi.py tbl_transfer_prealigned` -- enhancement: clipped CDS features are now marked with `/note=sequencing did not capture complete CDS` to clarify to NCBI data consumers why a CDS might be missing a start or stop codon.
3. WDL task multi_align_mafft_ref no longer outputs sampleNamesFile (doesn't seem useful.. feel free to add it back if it's needed for anything).
4. WDL task multi_align_mafft_ref output fasta files now are prefixed with `align_mafft-` so that it is clearer what the contents of the files are from their filenames (since previously, the prefix was only the reference genome fasta file name, which is confusing).