### PR TITLE
samtools 1.6->1.7; pysam 0.13.0->0.14.1

### DIFF
--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -21,7 +21,7 @@ parallel=20160622
 picard=2.17.6
 pigz=2.3.4
 prinseq=0.20.4
-samtools=1.6
+samtools=1.7
 snpeff=4.1l
 spades=3.11.1
 tbl2asn=25.6
@@ -34,6 +34,6 @@ bedtools=2.26.0
 biopython=1.70
 future==0.16.0
 matplotlib=1.5.3
-pysam=0.13.0
+pysam=0.14.1
 pybedtools=0.7.10
 PyYAML=3.12

--- a/tools/samtools.py
+++ b/tools/samtools.py
@@ -33,7 +33,7 @@ import util.file
 import util.misc
 
 TOOL_NAME = 'samtools'
-TOOL_VERSION = '1.6'
+TOOL_VERSION = '1.7'
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
samtools and htslib are now at v1.8, however pysam has not yet updated to use 1.8. This updates pysam to the latest current version, which depends on samtools/htslib v1.7 (also updated here).