### PR TITLE
bump viral-baseimage from 0.1.9 to 0.1.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/broadinstitute/viral-baseimage:0.1.9
+FROM quay.io/broadinstitute/viral-baseimage:0.1.11
 
 LABEL maintainer "viral-ngs@broadinstitute.org"
 


### PR DESCRIPTION
Upgrades Ubuntu 17.10 (artful) to 18.04 LTS (bionic)