### PR TITLE
add read_utils.py downsample_bams

### DIFF
--- a/pipes/WDL/workflows/reads.wdl
+++ b/pipes/WDL/workflows/reads.wdl
@@ -1,6 +1,6 @@
 import "read_utils.wdl" as read_utils
 
-workflow downsample_bams {
+workflow downsample {
     File reads_bam
 
     call read_utils.downsample_bams {

--- a/pipes/WDL/workflows/reads.wdl
+++ b/pipes/WDL/workflows/reads.wdl
@@ -1,6 +1,10 @@
 import "read_utils.wdl" as read_utils
 
 workflow downsample_bams {
-  call read_utils.downsample_bams as downsample_bams
+    File reads_bam
 
+    call read_utils.downsample_bams as downsample_bams {
+        input:
+            reads_bam = reads_bam
+    }
 }

--- a/pipes/WDL/workflows/reads.wdl
+++ b/pipes/WDL/workflows/reads.wdl
@@ -1,7 +1,7 @@
 import "read_utils.wdl" as read_utils
 
 workflow downsample {
-    File reads_bam
+    Array[File] reads_bam
 
     call read_utils.downsample_bams {
         input:

--- a/pipes/WDL/workflows/reads.wdl
+++ b/pipes/WDL/workflows/reads.wdl
@@ -1,1 +1,6 @@
 import "read_utils.wdl" as read_utils
+
+workflow downsample_bams {
+  call read_utils.downsample_bams as downsample_bams
+
+}

--- a/pipes/WDL/workflows/reads.wdl
+++ b/pipes/WDL/workflows/reads.wdl
@@ -3,7 +3,7 @@ import "read_utils.wdl" as read_utils
 workflow downsample_bams {
     File reads_bam
 
-    call read_utils.downsample_bams as downsample_bams {
+    call read_utils.downsample_bams {
         input:
             reads_bam = reads_bam
     }

--- a/pipes/WDL/workflows/reads.wdl
+++ b/pipes/WDL/workflows/reads.wdl
@@ -1,0 +1,1 @@
+import "read_utils.wdl" as read_utils

--- a/pipes/WDL/workflows/tasks/read_utils.wdl
+++ b/pipes/WDL/workflows/tasks/read_utils.wdl
@@ -22,6 +22,7 @@ task downsample_bams {
         --outPath downsampled \
         ${'--readCount' + readCount} \
         $DEDUP_OPTION \
+        --JVMmemory "1g"
   }
 
   output {
@@ -31,6 +32,6 @@ task downsample_bams {
     docker: "quay.io/broadinstitute/viral-ngs"
     memory: "3 GB"
     cpu: 2
-    dx_instance_type: "mem1_ssd1_x2"
+    dx_instance_type: "mem1_ssd1_x4"
   }
 }

--- a/pipes/WDL/workflows/tasks/read_utils.wdl
+++ b/pipes/WDL/workflows/tasks/read_utils.wdl
@@ -20,7 +20,7 @@ task downsample_bams {
     read_utils.py downsample_bams \
         ${sep=' ' reads_bam} \
         --outPath downsampled \
-        ${'--readCount' + readCount} \
+        ${'--readCount=' + readCount} \
         $DEDUP_OPTION \
         --JVMmemory "1g"
   }

--- a/pipes/WDL/workflows/tasks/read_utils.wdl
+++ b/pipes/WDL/workflows/tasks/read_utils.wdl
@@ -1,0 +1,36 @@
+
+task downsample_bams {
+  Array[File] reads_bam
+  Int?         readCount
+  Boolean?     deduplicateBefore=false
+  Boolean?     deduplicateAfter=false
+
+  command {
+    if [[ "${deduplicateBefore}" == "true" ]]; then
+      DEDUP_OPTION="--deduplicateBefore"
+    elif [[ "${deduplicateAfter}" == "true" ]]; then
+      DEDUP_OPTION="--deduplicateAfter"
+    fi
+
+    if [[ "${deduplicateBefore}" == "true" && "${deduplicateBefore}" == "true" ]]; then
+      echo "deduplicateBefore and deduplicateAfter are mutually exclusive. Only one can be used."
+      exit 1
+    fi
+    
+    read_utils.py downsample_bams \
+        ${sep=' ' reads_bam} \
+        --outPath downsampled \
+        ${'--readCount' + readCount} \
+        $DEDUP_OPTION \
+  }
+
+  output {
+    Array[File] downsampled_bam = glob("downsampled/*.bam")
+  }
+  runtime {
+    docker: "quay.io/broadinstitute/viral-ngs"
+    memory: "3 GB"
+    cpu: 2
+    dx_instance_type: "mem1_ssd1_x2"
+  }
+}

--- a/pipes/WDL/workflows/tasks/read_utils.wdl
+++ b/pipes/WDL/workflows/tasks/read_utils.wdl
@@ -12,7 +12,7 @@ task downsample_bams {
       DEDUP_OPTION="--deduplicateAfter"
     fi
 
-    if [[ "${deduplicateBefore}" == "true" && "${deduplicateBefore}" == "true" ]]; then
+    if [[ "${deduplicateBefore}" == "true" && "${deduplicateAfter}" == "true" ]]; then
       echo "deduplicateBefore and deduplicateAfter are mutually exclusive. Only one can be used."
       exit 1
     fi

--- a/pipes/WDL/workflows/tasks/read_utils.wdl
+++ b/pipes/WDL/workflows/tasks/read_utils.wdl
@@ -1,6 +1,6 @@
 
 task downsample_bams {
-  Array[File] reads_bam
+  Array[File]  reads_bam
   Int?         readCount
   Boolean?     deduplicateBefore=false
   Boolean?     deduplicateAfter=false

--- a/read_utils.py
+++ b/read_utils.py
@@ -358,7 +358,7 @@ def main_downsample_bams(in_bams, out_path, specified_read_count, deduplicate_be
         downsamplesam = tools.picard.DownsampleSamTool()
         workers = util.misc.sanitize_thread_count(threads)
         with concurrent.futures.ProcessPoolExecutor(max_workers=workers) as executor:
-            future_to_file = {executor.submit(downsamplesam.downsample_to_approx_count, *fp, downsample_target, JVMmemory=str(max(1,int(tools.picard.DownsampleSamTool.jvmMemDefault.rstrip("g"))/workers))+'g'): fp[0] for fp in data_pairs}
+            future_to_file = {executor.submit(downsamplesam.downsample_to_approx_count, *(list(fp)+[downsample_target]), JVMmemory=str(max(1,int(tools.picard.DownsampleSamTool.jvmMemDefault.rstrip("g"))/workers))+'g'): fp[0] for fp in data_pairs}
             for future in concurrent.futures.as_completed(future_to_file):
                 f = future_to_file[future]
                 try:

--- a/test/unit/test_read_utils.py
+++ b/test/unit/test_read_utils.py
@@ -6,6 +6,8 @@ import unittest
 import argparse
 import filecmp
 import os
+import glob
+
 import read_utils
 import shutil
 import tempfile
@@ -257,3 +259,91 @@ class TestAlignAndFix(TestCaseWithTmp):
         args = read_utils.parser_align_and_fix(argparse.ArgumentParser()).parse_args(
             [inBam, self.refFasta, '--outBamAll', outBamAll, '--outBamFiltered', outBamFiltered, '--aligner', aligner])
         args.func_main(args)
+
+class TestDownsampleBams(TestCaseWithTmp):
+    def setUp(self):
+        super(TestDownsampleBams, self).setUp()
+        orig_larger_bam  = os.path.join(util.file.get_test_input_path(), 'G5012.3.testreads.bam')
+        orig_smaller_bam = os.path.join(util.file.get_test_input_path(), 'G5012.3.mini.bam')
+        orig_with_dup    = os.path.join(util.file.get_test_input_path(), 'TestRmdupUnaligned','input.bam')
+        self.larger_bam  = util.file.mkstempfname('.larger.bam')
+        self.smaller_bam = util.file.mkstempfname('.smaller.bam')
+        self.with_dups   = util.file.mkstempfname('.with_dups.bam')
+        shutil.copyfile(orig_larger_bam, self.larger_bam)
+        shutil.copyfile(orig_smaller_bam, self.smaller_bam)
+        shutil.copyfile(orig_with_dup, self.with_dups)
+
+        self.samtools = tools.samtools.SamtoolsTool()
+
+    def test_normalization_to_lowest_cardinality(self):
+        """ Also tests subdir output """
+        temp_dir = tempfile.mkdtemp()
+
+        target_count = self.samtools.count(self.smaller_bam)
+        # target count not passed in since we are checking that the count of the smaller file is used
+        read_utils.main_downsample_bams([self.larger_bam, self.smaller_bam], temp_dir)
+
+        output_bams = list(glob.glob(os.path.join(temp_dir, '*.bam')))
+        
+        self.assertGreater(len(output_bams), 0, msg="No output found")
+        for out_bam in output_bams:
+            self.assertAlmostEqual(self.samtools.count(out_bam), target_count, delta=10, msg="{} not downsampled to the target size: {}".format(os.path.basename(out_bam),target_count))
+
+    def test_downsample_to_target_count(self):
+        """ Also tests subdir output """
+        temp_dir = tempfile.mkdtemp()
+
+        target_count = 4000
+        read_utils.main_downsample_bams([self.larger_bam, self.smaller_bam], temp_dir, specified_read_count=target_count)
+
+        output_bams = list(glob.glob(os.path.join(temp_dir, '*.bam')))
+        
+        self.assertGreater(len(output_bams), 0, msg="No output found")
+        for out_bam in output_bams:
+            self.assertAlmostEqual(self.samtools.count(out_bam), target_count, delta=10, msg="{} not downsampled to the target size: {}".format(os.path.basename(out_bam),target_count))
+
+    def test_downsample_to_target_count_without_subdir(self):
+        target_count = 4000
+        read_utils.main_downsample_bams([self.larger_bam], out_path=None, specified_read_count=target_count)
+
+        output_bams = list(glob.glob(os.path.join(os.path.dirname(self.larger_bam), '*downsampled-*.bam')))
+        
+        print(output_bams)
+        self.assertGreater(len(output_bams), 0, msg="No output files matching *downsampled-*.bam found")
+        for out_bam in output_bams:
+            self.assertAlmostEqual(self.samtools.count(out_bam), target_count, delta=10, msg="{} not downsampled to the target size: {}".format(os.path.basename(out_bam),target_count))
+
+    def test_downsample_with_dedup_after(self):
+        """ Also tests subdir output """
+        temp_dir = tempfile.mkdtemp()
+
+        target_count = 1500
+        read_utils.main_downsample_bams([self.with_dups], temp_dir, deduplicate_after=True, specified_read_count=target_count)
+
+        output_bams = list(glob.glob(os.path.join(temp_dir, '*.bam')))
+        
+        self.assertGreater(len(output_bams), 0, msg="No output found")
+        for out_bam in output_bams:
+            self.assertLess(self.samtools.count(out_bam), target_count, msg="{} not downsampled to the target size: {}".format(os.path.basename(out_bam),target_count))
+
+    def test_downsample_with_dedup_before(self):
+        """ Also tests subdir output """
+        temp_dir = tempfile.mkdtemp()
+
+        target_count = 1500
+        read_utils.main_downsample_bams([self.with_dups], temp_dir, deduplicate_before=True, specified_read_count=target_count)
+
+        output_bams = list(glob.glob(os.path.join(temp_dir, '*.bam')))
+        
+        self.assertGreater(len(output_bams), 0, msg="No output found")
+        for out_bam in output_bams:
+            self.assertAlmostEqual(self.samtools.count(out_bam), target_count, delta=10, msg="{} not downsampled to the target size: {}".format(os.path.basename(out_bam),target_count))
+
+    def test_downsample_to_too_large_target_count(self):
+        """ Should fail """
+        temp_dir = tempfile.mkdtemp()
+
+        target_count = 20000
+
+        with self.assertRaises(ValueError):
+            read_utils.main_downsample_bams([self.larger_bam, self.smaller_bam], temp_dir, specified_read_count=target_count)

--- a/test/unit/test_read_utils.py
+++ b/test/unit/test_read_utils.py
@@ -281,7 +281,7 @@ class TestDownsampleBams(TestCaseWithTmp):
 
         target_count = self.samtools.count(self.smaller_bam)
         # target count not passed in since we are checking that the count of the smaller file is used
-        read_utils.main_downsample_bams([self.larger_bam, self.smaller_bam], temp_dir)
+        read_utils.main_downsample_bams([self.larger_bam, self.smaller_bam], temp_dir, JVMmemory="1g")
 
         output_bams = list(glob.glob(os.path.join(temp_dir, '*.bam')))
         
@@ -294,7 +294,7 @@ class TestDownsampleBams(TestCaseWithTmp):
         temp_dir = tempfile.mkdtemp()
 
         target_count = 4000
-        read_utils.main_downsample_bams([self.larger_bam, self.smaller_bam], temp_dir, specified_read_count=target_count)
+        read_utils.main_downsample_bams([self.larger_bam, self.smaller_bam], temp_dir, specified_read_count=target_count, JVMmemory="1g")
 
         output_bams = list(glob.glob(os.path.join(temp_dir, '*.bam')))
         
@@ -304,7 +304,7 @@ class TestDownsampleBams(TestCaseWithTmp):
 
     def test_downsample_to_target_count_without_subdir(self):
         target_count = 4000
-        read_utils.main_downsample_bams([self.larger_bam], out_path=None, specified_read_count=target_count)
+        read_utils.main_downsample_bams([self.larger_bam], out_path=None, specified_read_count=target_count, JVMmemory="1g")
 
         output_bams = list(glob.glob(os.path.join(os.path.dirname(self.larger_bam), '*downsampled-*.bam')))
         
@@ -318,7 +318,7 @@ class TestDownsampleBams(TestCaseWithTmp):
         temp_dir = tempfile.mkdtemp()
 
         target_count = 1500
-        read_utils.main_downsample_bams([self.with_dups], temp_dir, deduplicate_after=True, specified_read_count=target_count)
+        read_utils.main_downsample_bams([self.with_dups], temp_dir, deduplicate_after=True, specified_read_count=target_count, JVMmemory="1g")
 
         output_bams = list(glob.glob(os.path.join(temp_dir, '*.bam')))
         
@@ -331,7 +331,7 @@ class TestDownsampleBams(TestCaseWithTmp):
         temp_dir = tempfile.mkdtemp()
 
         target_count = 1500
-        read_utils.main_downsample_bams([self.with_dups], temp_dir, deduplicate_before=True, specified_read_count=target_count)
+        read_utils.main_downsample_bams([self.with_dups], temp_dir, deduplicate_before=True, specified_read_count=target_count, JVMmemory="1g")
 
         output_bams = list(glob.glob(os.path.join(temp_dir, '*.bam')))
         
@@ -346,4 +346,4 @@ class TestDownsampleBams(TestCaseWithTmp):
         target_count = 20000
 
         with self.assertRaises(ValueError):
-            read_utils.main_downsample_bams([self.larger_bam, self.smaller_bam], temp_dir, specified_read_count=target_count)
+            read_utils.main_downsample_bams([self.larger_bam, self.smaller_bam], temp_dir, specified_read_count=target_count, JVMmemory="1g")


### PR DESCRIPTION
This adds a utility function, `downsample_bams`, to `read_utils.py` that allows the user to downsample a series of bam files to a normalized read count: either the number of reads in the lowest-cardinality file, or a count specified by the user. Optional flags to deduplicate the input reads prior to, or after, downsampling. This addresses #815.

```
usage: read_utils.py subcommand downsample_bams [-h] [--outPath OUT_PATH]
                                                [--readCount SPECIFIED_READ_COUNT]
                                                [--deduplicateBefore | --deduplicateAfter]
                                                [--JVMmemory JVMMEMORY]
                                                [--picardOptions [PICARDOPTIONS [PICARDOPTIONS ...]]]
                                                [--threads THREADS]
                                                [--loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL,EXCEPTION}]
                                                [--version]
                                                [--tmp_dir TMP_DIR]
                                                [--tmp_dirKeep]
                                                in_bams [in_bams ...]

Downsample multiple bam files to the smallest read count in common, or to the
specified count.

positional arguments:
  in_bams               Input bam files.

optional arguments:
  -h, --help            show this help message and exit
  --outPath OUT_PATH    Output path. If not provided, downsampled bam files
                        will be written to the same paths as each source bam
                        file, with filenames in the format
                        <basename>.downsampled-####.bam
  --readCount SPECIFIED_READ_COUNT
                        The number of reads to downsample to.
  --deduplicateBefore   de-duplicate reads before downsampling.
  --deduplicateAfter    de-duplicate reads after downsampling.
  --JVMmemory JVMMEMORY
                        JVM virtual memory size (default: 4g)
  --picardOptions [PICARDOPTIONS [PICARDOPTIONS ...]]
                        Optional arguments to Picard's DownsampleSam,
                        OPTIONNAME=value ...
  --threads THREADS     Number of threads (default: all available cores)
  --loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL,EXCEPTION}
                        Verboseness of output. [default: INFO]
  --version, -V         show program's version number and exit
  --tmp_dir TMP_DIR     Base directory for temp files. [default:
                        /var/folders/bx/90px0g1n1v122slzjnyvrsk5gn42vm/T/]
  --tmp_dirKeep         Keep the tmp_dir if an exception occurs while running.
                        Default is to delete all temp files at the end, even
                        if there's a failure.
```