### PR TITLE
bugfix merge_bams reheader_table check

### DIFF
--- a/pipes/WDL/workflows/tasks/demux.wdl
+++ b/pipes/WDL/workflows/tasks/demux.wdl
@@ -123,7 +123,7 @@ task merge_and_reheader_bams {
       ln -s ${select_first(in_bams)} merged.bam
     fi    
 
-    if [ -f ${reheader_table} ]; then
+    if [[ -f "${reheader_table}" ]]; then
       read_utils.py reheader_bam merged.bam ${reheader_table} ${out_basename}.bam --loglevel DEBUG
     else
       echo "Skipping reheader, no mapping table specified"


### PR DESCRIPTION
if reheader_table was omitted, reheader would be attempted anyway. This corrects the conditional so it is skipped if the file is not provided