### PR TITLE
bugfixes to bwa deplete

### DIFF
--- a/tools/bwa.py
+++ b/tools/bwa.py
@@ -82,6 +82,8 @@ class Bwa(tools.Tool):
             align_bams = []
 
             threads_for_chunk = int(round(min(max(threads / len(rgs),1),threads),0))+1
+            # worker count limited to 1 for now to reduce in-memory index size resulting from
+            # running multiple copies of bwa in parallel
             workers = 1 #len(rgs) if len(rgs)<threads else threads
             with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
                 futures = []# executor.submit(util.file.count_occurrences_in_tsv, filePath, include_noise=includeNoise) for rg in rgs]

--- a/tools/bwa.py
+++ b/tools/bwa.py
@@ -82,7 +82,7 @@ class Bwa(tools.Tool):
             align_bams = []
 
             threads_for_chunk = int(round(min(max(threads / len(rgs),1),threads),0))+1
-            workers = len(rgs) if len(rgs)<threads else threads
+            workers = 1 #len(rgs) if len(rgs)<threads else threads
             with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
                 futures = []# executor.submit(util.file.count_occurrences_in_tsv, filePath, include_noise=includeNoise) for rg in rgs]
 

--- a/tools/samtools.py
+++ b/tools/samtools.py
@@ -80,6 +80,8 @@ class SamtoolsTool(tools.Tool):
         regions = regions or []
         args    = args or []
 
+        # -@ seems to result in segfaults in some cases
+        # so this is commented out for now...
         #if '-@' not in args:
         #    args.extend(('-@', str(util.misc.sanitize_thread_count(threads))))
 

--- a/tools/samtools.py
+++ b/tools/samtools.py
@@ -80,8 +80,8 @@ class SamtoolsTool(tools.Tool):
         regions = regions or []
         args    = args or []
 
-        if '-@' not in args:
-            args.extend(('-@', str(util.misc.sanitize_thread_count(threads))))
+        #if '-@' not in args:
+        #    args.extend(('-@', str(util.misc.sanitize_thread_count(threads))))
 
         self.execute('view', args + ['-o', outFile, inFile] + regions, background=background)
         #opts = args + ['-o', outFile, inFile] + regions


### PR DESCRIPTION
limit RG sharding to one worker to reduce in-memory index size from multiple instances of bwa; comment out (for now) `-@` from `samtools view` due to segfault