### PR TITLE
allow sequencing_center to be passed as an optional input to demux_launcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ cache:
   directories:
     - $HOME/misc_cache
     - $HOME/miniconda
-  timeout: 480
+  timeout: 1000
 
 #stages:
 #  - build

--- a/illumina.py
+++ b/illumina.py
@@ -212,6 +212,9 @@ def main_illumina_demux(args):
     if not picardOpts.get('sequencing_center') and runinfo:
         picardOpts['sequencing_center'] = runinfo.get_machine()
 
+    if picardOpts.get('sequencing_center'):
+        picardOpts["sequencing_center"] = util.file.string_to_file_name(picardOpts["sequencing_center"])
+
     # manually garbage collect to make sure we have as much RAM free as possible
     gc.collect()
     if multiplexed_samples:
@@ -875,7 +878,7 @@ def miseq_fastq_to_bam(outBam, sampleSheet, inFastq1, inFastq2=None, runInfo=Non
     if sequencing_center is None and runInfo:
         sequencing_center = runInfo.get_machine()
     if sequencing_center:
-        picardOpts['SEQUENCING_CENTER'] = sequencing_center
+        picardOpts['SEQUENCING_CENTER'] = util.file.string_to_file_name(sequencing_center)
     picardOpts['PLATFORM_UNIT'] = '.'.join((flowcell, '1', barcode))
     if len(flowcell) > 5:
         flowcell = flowcell[:5]

--- a/pipes/WDL/dx-launcher/demux_launcher.yml
+++ b/pipes/WDL/dx-launcher/demux_launcher.yml
@@ -22,7 +22,7 @@ inputSpec:
 - name: sequencing_center
   class: string
   optional: true
-  help: Optional- the name of the sequencing center specified in the demultiplexing output (bam files)
+  help: Optional- the name of the sequencing center to be included in the demultiplexed output (bam files). Please avoid spaces and special characters.
 - name: api_token
   class: file
   optional: true

--- a/pipes/WDL/dx-launcher/demux_launcher.yml
+++ b/pipes/WDL/dx-launcher/demux_launcher.yml
@@ -19,6 +19,10 @@ inputSpec:
   class: string
   default: /
   help: Output folder in the root project. For this applet, the --destination should be set to / and this input should be used to control the output folder.
+- name: sequencing_center
+  class: string
+  optional: true
+  help: Optional- the name of the sequencing center specified in the demultiplexing output (bam files)
 - name: api_token
   class: file
   optional: true
@@ -140,9 +144,14 @@ runSpec:
         # launch the demux workflow on each lane
         analyses=()
         output_project=$DX_WORKSPACE_ID
+        if [ -n "$sequencing_center" ]; then
+          sequencing_center_input="-i illumina_demux.sequencingCenter=$sequencing_center"
+        else
+          sequencing_center_input=""
+        fi
         for i in $(seq "$lane_count"); do
           folder2=$(printf "%s/%s/reads/L%d" "$folder" "$run_id" $i)
-          runcmd="dx run $demux_workflow_id -i stage-0.flowcell_tgz=$run_tarball -i illumina_demux.lane=$i -i illumina_demux.minimumBaseQuality=$min_base_quality -i illumina_demux.threads=$demux_threads --folder $folder2 --instance-type illumina_demux=$demux_instance_type --name demux:$run_id:L$i -y --brief"
+          runcmd="dx run $demux_workflow_id -i stage-0.flowcell_tgz=$run_tarball -i illumina_demux.lane=$i -i illumina_demux.minimumBaseQuality=$min_base_quality -i illumina_demux.threads=$demux_threads $sequencing_center_input --folder $folder2 --instance-type illumina_demux=$demux_instance_type --name demux:$run_id:L$i -y --brief"
           echo "$runcmd"
           set +x
           if [ -n "$api_token" ]; then


### PR DESCRIPTION
With this PR, sequencing_center can be passed as an optional input to the demux_launcher DNAnexus applet; this allows each job spawning a demux (uploader laptops, etc.) to set the sequencing center at upload time