### PR TITLE
minor changes to unit tests

### DIFF
--- a/test/integration/test_intrahost.py
+++ b/test/integration/test_intrahost.py
@@ -23,7 +23,7 @@ class TestPerSample(test.TestCaseWithTmp):
         strand-bias filtering and adds library-bias statistics.
     '''
 
-    @unittest.skipIf(tools.is_osx(), "vphaser2 osx binary from bioconda has issues")
+    #@unittest.skipIf(tools.is_osx(), "vphaser2 osx binary from bioconda has issues")
     def test_vphaser_one_sample_indels(self):
         # Files here were created as follows:
         # ref.indels.fasta is Seed-stock-137_S2_L001_001.fasta
@@ -58,7 +58,7 @@ class TestPerSample(test.TestCaseWithTmp):
         intrahost.vphaser_one_sample(inBam, refFasta, outTab, vphaserNumThreads=test._CPUS, minReadsEach=0, removeDoublyMappedReads=True)
         assert os.path.getsize(outTab) == 0
 
-    @unittest.skipIf(tools.is_osx(), "vphaser2 osx binary from bioconda has issues")
+    #@unittest.skipIf(tools.is_osx(), "vphaser2 osx binary from bioconda has issues")
     def test_vphaser_one_sample_2libs(self):
         # in.2libs.bam was created by "manually" editing in.bam and moving about
         # 1/3 of the reads to ReadGroup2.
@@ -70,7 +70,7 @@ class TestPerSample(test.TestCaseWithTmp):
         expected = os.path.join(myInputDir, 'vphaser_one_sample_2libs_expected.txt')
         self.assertEqualContents(outTab, expected)
 
-    @unittest.skipIf(tools.is_osx(), "vphaser2 osx binary from bioconda has issues")
+    #@unittest.skipIf(tools.is_osx(), "vphaser2 osx binary from bioconda has issues")
     def test_vphaser_one_sample_3libs_and_chi2(self):
         # In addition to testing that we can handle 3 libraries, this is testing
         #    the chi2_contingency approximation to fisher_exact. The 4th, 5th,

--- a/test/integration/test_ncbi.py
+++ b/test/integration/test_ncbi.py
@@ -22,6 +22,7 @@ log = logging.getLogger(__name__)
 
 skip_test = True
 
+@unittest.skipIf(skip_test, "test is marked to be skipped")
 class TestNcbiFetch(TestCaseWithTmp):
 
     def setUp(self):

--- a/test/unit/test_ncbi.py
+++ b/test/unit/test_ncbi.py
@@ -23,7 +23,7 @@ class TestCommandHelp(unittest.TestCase):
 
 class TestFeatureTransfer(TestCaseWithTmp):
     def setUp(self):
-        TestCaseWithTmp.setUp(self)
+        super(TestFeatureTransfer, self).setUp()
         self.input_dir = util.file.get_test_input_path(self)
 
     def test_synthetic_feature_table(self):

--- a/test/unit/test_tools_vphaser2.py
+++ b/test/unit/test_tools_vphaser2.py
@@ -11,7 +11,7 @@ from intrahost import vphaser_main
 from test import TestCaseWithTmp, _CPUS
 
 
-@unittest.skipIf(tools.is_osx(), "vphaser2 osx binary from bioconda has issues")
+#@unittest.skipIf(tools.is_osx(), "vphaser2 osx binary from bioconda has issues")
 class TestVPhaser2(TestCaseWithTmp):
 
     def test_vphaser2(self):


### PR DESCRIPTION
reenable vphaser tests under osx, skip TestNcbiFetch since it was not being used; py2-style TestFeatureTransfer init