### PR TITLE
remove build_lastal_db as a local rule

### DIFF
--- a/pipes/rules/ncbi.rules
+++ b/pipes/rules/ncbi.rules
@@ -8,7 +8,7 @@ __author__ = 'Kristian Andersen <andersen@broadinstitute.org>, Daniel Park <dpar
 from snakemake.utils import makedirs
 import os, os.path, time
 
-localrules: download_reference_genome, download_lastal_sources, build_lastal_db
+localrules: download_reference_genome, download_lastal_sources
 
 rule all_annot:
     input:


### PR DESCRIPTION
remove `build_lastal_db` as a local rule since the rule itself was removed in commit 9d13f5b4b4f54c7af3ed8744d16f21a6076898ce