### PR TITLE
do not upload dev conda packages

### DIFF
--- a/travis/build-conda.sh
+++ b/travis/build-conda.sh
@@ -44,6 +44,6 @@ else
 
     # render and build the conda package
     python packaging/conda-recipe/render-recipe.py "$CONDA_PKG_VERSION" --package-name "viral-ngs-dev" --download-filename "$TRAVIS_COMMIT" --build-reqs requirements-conda.txt --run-reqs requirements-conda.txt --py3-run-reqs requirements-py3.txt --py2-run-reqs requirements-py2.txt --test-reqs requirements-conda-tests.txt
-    CONDA_PERL=5.22.0 conda build -c broad-viral -c r -c bioconda -c conda-forge -c defaults --python "$TRAVIS_PYTHON_VERSION" --token "$ANACONDA_TOKEN" --output-folder "$CONDA_PACKAGE_OUTDIR" packaging/conda-recipe/viral-ngs
+    CONDA_PERL=5.22.0 conda build --no-anaconda-upload -c broad-viral -c r -c bioconda -c conda-forge -c defaults --python "$TRAVIS_PYTHON_VERSION" --token "$ANACONDA_TOKEN" --output-folder "$CONDA_PACKAGE_OUTDIR" packaging/conda-recipe/viral-ngs
 
 fi


### PR DESCRIPTION
adds `--no-anaconda-upload` so we do not upload dev builds of viral-ngs to anaconda.org, since the dev packages rapidly fill our storage quota