### PR TITLE
allow run-pipe.sh to be called when a conda env is active

### DIFF
--- a/pipes/Broad_UGER/run-pipe.sh
+++ b/pipes/Broad_UGER/run-pipe.sh
@@ -15,6 +15,11 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# if a conda environment is active, deactivate it
+if [[ ! -z "${CONDA_PREFIX}" ]]; then
+    echo "deactivating env: $CONDA_PREFIX"
+    source deactivate
+fi
 
 # load necessary Broad dotkits
 source /broad/software/scripts/useuse


### PR DESCRIPTION
allow run-pipe.sh to be called when a conda env is active (such as the one created by the easy-deploy script). Within the context of `run-pipe.sh` we now deactivate a conda env if present. This solves python import conficts