### PR TITLE
bump pytest 3.0.5 -> 3.6.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ tools/conda-cache/
 tools/conda-tools/
 
 *.snakemake/
+
+.pytest_cache/

--- a/requirements-conda-tests.txt
+++ b/requirements-conda-tests.txt
@@ -2,8 +2,7 @@ coveralls=1.1
 flake8>=3.2.1
 mock=2.0.0
 pycodestyle=2.2.0
-pytest=3.0.5
-pytest-catchlog=1.2.2
+pytest=3.6.3
 pytest-cov==2.5.1
 pytest-mock=1.5.0
 pytest-xdist=1.15.0


### PR DESCRIPTION
also removes `pytest-catchlog`, which has been moved to the core pytest