### PR TITLE
dxWDL 0.72: revert WDLs to unbound task inputs

### DIFF
--- a/pipes/Broad_UGER/run-pipe.sh
+++ b/pipes/Broad_UGER/run-pipe.sh
@@ -15,6 +15,11 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# if a conda environment is active, deactivate it
+if [[ ! -z "${CONDA_PREFIX}" ]]; then
+    echo "deactivating env: $CONDA_PREFIX"
+    source deactivate
+fi
 
 # load necessary Broad dotkits
 source /broad/software/scripts/useuse

--- a/pipes/WDL/dx-defaults-assemble_denovo.json
+++ b/pipes/WDL/dx-defaults-assemble_denovo.json
@@ -1,4 +1,4 @@
 {
-  "assemble_denovo.trim_clip_db":
+  "assemble_denovo.assemble.trim_clip_db":
     "dx://file-BXF0vYQ0QyBF509G9J12g927"
 }

--- a/pipes/WDL/dx-defaults-assemble_denovo_with_deplete.json
+++ b/pipes/WDL/dx-defaults-assemble_denovo_with_deplete.json
@@ -1,14 +1,14 @@
 {
-  "assemble_denovo_with_deplete.bwaDbs": [
+  "assemble_denovo_with_deplete.deplete_taxa.bwaDbs": [
     "dx://file-F9k7Bx00Z3ybJjvY3ZVj7Z9P"
   ],
-  "assemble_denovo_with_deplete.blastDbs": [
+  "assemble_denovo_with_deplete.deplete_taxa.blastDbs": [
     "dx://file-F8B3B6Q09y3bZg3j1FqK7bJ9",
     "dx://file-F8BjgXj09y3gkfZGPPQZbZkK",
     "dx://file-F8B3Pp809y3jBpXq7xjxbq94",
     "dx://file-F8B3B6809y3kK1JP5X8Pg361"
   ],
 
-  "assemble_denovo_with_deplete.trim_clip_db":
+  "assemble_denovo_with_deplete.assemble.trim_clip_db":
     "dx://file-BXF0vYQ0QyBF509G9J12g927"
 }

--- a/pipes/WDL/dx-defaults-assemble_denovo_with_deplete_and_isnv_calling.json
+++ b/pipes/WDL/dx-defaults-assemble_denovo_with_deplete_and_isnv_calling.json
@@ -1,14 +1,14 @@
 {
-  "assemble_denovo_with_deplete_and_isnv_calling.bwaDbs": [
+  "assemble_denovo_with_deplete_and_isnv_calling.deplete_taxa.bwaDbs": [
     "dx://file-F9k7Bx00Z3ybJjvY3ZVj7Z9P"
   ],
-  "assemble_denovo_with_deplete_and_isnv_calling.blastDbs": [
+  "assemble_denovo_with_deplete_and_isnv_calling.deplete_taxa.blastDbs": [
     "dx://file-F8B3B6Q09y3bZg3j1FqK7bJ9",
     "dx://file-F8BjgXj09y3gkfZGPPQZbZkK",
     "dx://file-F8B3Pp809y3jBpXq7xjxbq94",
     "dx://file-F8B3B6809y3kK1JP5X8Pg361"
   ],
 
-  "assemble_denovo_with_deplete_and_isnv_calling.trim_clip_db":
+  "assemble_denovo_with_deplete_and_isnv_calling.assemble.trim_clip_db":
     "dx://file-BXF0vYQ0QyBF509G9J12g927"
 }

--- a/pipes/WDL/dx-defaults-assemble_denovo_with_isnv_calling.json
+++ b/pipes/WDL/dx-defaults-assemble_denovo_with_isnv_calling.json
@@ -1,4 +1,4 @@
 {
-  "assemble_denovo_with_isnv_calling.trim_clip_db":
+  "assemble_denovo_with_isnv_calling.assemble.trim_clip_db":
     "dx://file-BXF0vYQ0QyBF509G9J12g927"
 }

--- a/pipes/WDL/dx-defaults-classify_kraken.json
+++ b/pipes/WDL/dx-defaults-classify_kraken.json
@@ -1,6 +1,6 @@
 {
-  "classify_kraken.kraken_db_tar_lz4":
+  "classify_kraken.kraken.kraken_db_tar_lz4":
     "dx://file-F8QF3bj0xf5gZv76BG4QgpF4",
-  "classify_kraken.krona_taxonomy_db_tgz":
+  "classify_kraken.kraken.krona_taxonomy_db_tgz":
     "dx://file-F4z0fgj07FZ8jg8yP7yz0Qzb"
 }

--- a/pipes/WDL/dx-defaults-contigs.json
+++ b/pipes/WDL/dx-defaults-contigs.json
@@ -1,14 +1,14 @@
 {
-  "contigs.bwaDbs": [
+  "contigs.deplete.bwaDbs": [
     "dx://file-F9k7Bx00Z3ybJjvY3ZVj7Z9P"
   ],
-  "contigs.blastDbs": [
+  "contigs.deplete.blastDbs": [
     "dx://file-F8B3B6Q09y3bZg3j1FqK7bJ9",
     "dx://file-F8BjgXj09y3gkfZGPPQZbZkK",
     "dx://file-F8B3Pp809y3jBpXq7xjxbq94",
     "dx://file-F8B3B6809y3kK1JP5X8Pg361"
   ],
 
-  "contigs.trim_clip_db":
+  "contigs.spades.trim_clip_db":
     "dx://file-BXF0vYQ0QyBF509G9J12g927"
 }

--- a/pipes/WDL/dx-defaults-demux_plus.json
+++ b/pipes/WDL/dx-defaults-demux_plus.json
@@ -15,8 +15,8 @@
   "demux_plus.trim_clip_db":
     "dx://file-BXF0vYQ0QyBF509G9J12g927",
 
-  "demux_plus.kraken_db_tar_lz4":
+  "demux_plus.kraken.kraken_db_tar_lz4":
     "dx://file-F8QF3bj0xf5gZv76BG4QgpF4",
-  "demux_plus.krona_taxonomy_db_tgz":
+  "demux_plus.kraken.krona_taxonomy_db_tgz":
     "dx://file-F4z0fgj07FZ8jg8yP7yz0Qzb"
 }

--- a/pipes/WDL/dx-defaults-deplete_only.json
+++ b/pipes/WDL/dx-defaults-deplete_only.json
@@ -1,8 +1,8 @@
 {
-  "deplete_only.bwaDbs": [
+  "deplete_only.deplete_taxa.bwaDbs": [
     "dx://file-F9k7Bx00Z3ybJjvY3ZVj7Z9P"
   ],
-  "deplete_only.blastDbs": [
+  "deplete_only.deplete_taxa.blastDbs": [
     "dx://file-F8B3B6Q09y3bZg3j1FqK7bJ9",
     "dx://file-F8BjgXj09y3gkfZGPPQZbZkK",
     "dx://file-F8B3Pp809y3jBpXq7xjxbq94",

--- a/pipes/WDL/dx-defaults-spikein.json
+++ b/pipes/WDL/dx-defaults-spikein.json
@@ -1,4 +1,4 @@
 {
-  "spikein.spikein_db":
+  "spikein.spikein_report.spikein_db":
     "dx://file-F6PXkF00Yqp3zVXq14fF98Kz"
 }

--- a/pipes/WDL/workflows/align_and_plot.wdl
+++ b/pipes/WDL/workflows/align_and_plot.wdl
@@ -1,19 +1,8 @@
 import "reports.wdl" as reports
 
 workflow align_and_plot {
-    String sample_name
-
-    File assembly_fasta
-    File reads_unmapped_bam
-
-    File gatk_jar
-
     call reports.plot_coverage {
         input:
-            aligner_options = "-r Random -l 30 -g 40 -x 20 -t 502",
-            sample_name = sample_name,
-            assembly_fasta = assembly_fasta,
-            reads_unmapped_bam = reads_unmapped_bam,
-            gatk_jar = gatk_jar
+            aligner_options = "-r Random -l 30 -g 40 -x 20 -t 502"
     }
 }

--- a/pipes/WDL/workflows/assemble_denovo.wdl
+++ b/pipes/WDL/workflows/assemble_denovo.wdl
@@ -4,33 +4,26 @@ import "assembly.wdl" as assembly
 workflow assemble_denovo {
   
   File reads_unmapped_bam
-  File lastal_db_fasta
+
   call taxon_filter.filter_to_taxon {
     input:
-      reads_unmapped_bam = reads_unmapped_bam,
-      lastal_db_fasta = lastal_db_fasta
+      reads_unmapped_bam = reads_unmapped_bam
   }
 
-  File trim_clip_db
   call assembly.assemble {
     input:
-      reads_unmapped_bam = filter_to_taxon.taxfilt_bam,
-      trim_clip_db = trim_clip_db
+      reads_unmapped_bam = filter_to_taxon.taxfilt_bam
   }
 
-  Array[File]+ reference_genome_fasta
   call assembly.scaffold {
     input:
       contigs_fasta = assemble.contigs_fasta,
-      reads_bam = filter_to_taxon.taxfilt_bam,
-      reference_genome_fasta = reference_genome_fasta
+      reads_bam = filter_to_taxon.taxfilt_bam
   }
 
-  File gatk_jar
   call assembly.refine_2x_and_plot {
     input:
       assembly_fasta = scaffold.scaffold_fasta,
-      reads_unmapped_bam = reads_unmapped_bam,
-      gatk_jar = gatk_jar
+      reads_unmapped_bam = reads_unmapped_bam
   }
 }

--- a/pipes/WDL/workflows/assemble_denovo_with_deplete.wdl
+++ b/pipes/WDL/workflows/assemble_denovo_with_deplete.wdl
@@ -4,44 +4,31 @@ import "assembly.wdl" as assembly
 workflow assemble_denovo_with_deplete {
   
   File raw_reads_unmapped_bam
-  Array[File]? bmtaggerDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
-  Array[File]? blastDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
-  Array[File]? bwaDbs
+
   call taxon_filter.deplete_taxa {
     input:
-      raw_reads_unmapped_bam = raw_reads_unmapped_bam,
-      bmtaggerDbs = bmtaggerDbs,
-      blastDbs = blastDbs,
-      bwaDbs = bwaDbs
+      raw_reads_unmapped_bam = raw_reads_unmapped_bam
   }
 
-  File lastal_db_fasta
   call taxon_filter.filter_to_taxon {
     input:
-      reads_unmapped_bam = deplete_taxa.cleaned_bam,
-      lastal_db_fasta = lastal_db_fasta
+      reads_unmapped_bam = deplete_taxa.cleaned_bam
   }
 
-  File trim_clip_db
   call assembly.assemble {
     input:
-      reads_unmapped_bam = filter_to_taxon.taxfilt_bam,
-      trim_clip_db = trim_clip_db
+      reads_unmapped_bam = filter_to_taxon.taxfilt_bam
   }
 
-  Array[File]+ reference_genome_fasta
   call assembly.scaffold {
     input:
       contigs_fasta = assemble.contigs_fasta,
-      reads_bam = filter_to_taxon.taxfilt_bam,
-      reference_genome_fasta = reference_genome_fasta
+      reads_bam = filter_to_taxon.taxfilt_bam
   }
 
-  File gatk_jar
   call assembly.refine_2x_and_plot {
     input:
       assembly_fasta = scaffold.scaffold_fasta,
-      reads_unmapped_bam = deplete_taxa.cleaned_bam,
-      gatk_jar = gatk_jar
+      reads_unmapped_bam = deplete_taxa.cleaned_bam
   }
 }

--- a/pipes/WDL/workflows/assemble_denovo_with_deplete.wdl
+++ b/pipes/WDL/workflows/assemble_denovo_with_deplete.wdl
@@ -3,12 +3,7 @@ import "assembly.wdl" as assembly
 
 workflow assemble_denovo_with_deplete {
   
-  File raw_reads_unmapped_bam
-
-  call taxon_filter.deplete_taxa {
-    input:
-      raw_reads_unmapped_bam = raw_reads_unmapped_bam
-  }
+  call taxon_filter.deplete_taxa
 
   call taxon_filter.filter_to_taxon {
     input:

--- a/pipes/WDL/workflows/assemble_denovo_with_deplete_and_isnv_calling.wdl
+++ b/pipes/WDL/workflows/assemble_denovo_with_deplete_and_isnv_calling.wdl
@@ -3,46 +3,34 @@ import "assembly.wdl" as assembly
 import "tasks_intrahost.wdl" as intrahost
 
 workflow assemble_denovo_with_deplete_and_isnv_calling {
+  
   File raw_reads_unmapped_bam
-  Array[File]? bmtaggerDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
-  Array[File]? blastDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
-  Array[File]? bwaDbs
+
   call taxon_filter.deplete_taxa {
     input:
-      raw_reads_unmapped_bam = raw_reads_unmapped_bam,
-      bmtaggerDbs = bmtaggerDbs,
-      blastDbs = blastDbs,
-      bwaDbs = bwaDbs
+      raw_reads_unmapped_bam = raw_reads_unmapped_bam
   }
 
-  File lastal_db_fasta
   call taxon_filter.filter_to_taxon {
     input:
-      reads_unmapped_bam = deplete_taxa.cleaned_bam,
-      lastal_db_fasta = lastal_db_fasta
+      reads_unmapped_bam = deplete_taxa.cleaned_bam
   }
 
-  File trim_clip_db
   call assembly.assemble {
     input:
-      reads_unmapped_bam = filter_to_taxon.taxfilt_bam,
-      trim_clip_db = trim_clip_db
+      reads_unmapped_bam = filter_to_taxon.taxfilt_bam
   }
 
-  Array[File]+ reference_genome_fasta
   call assembly.scaffold {
     input:
       contigs_fasta = assemble.contigs_fasta,
-      reads_bam = filter_to_taxon.taxfilt_bam,
-      reference_genome_fasta = reference_genome_fasta
+      reads_bam = filter_to_taxon.taxfilt_bam
   }
 
-  File gatk_jar
   call assembly.refine_2x_and_plot {
     input:
       assembly_fasta = scaffold.scaffold_fasta,
-      reads_unmapped_bam = deplete_taxa.cleaned_bam,
-      gatk_jar = gatk_jar
+      reads_unmapped_bam = deplete_taxa.cleaned_bam
   }
 
   call intrahost.isnvs_per_sample {

--- a/pipes/WDL/workflows/assemble_denovo_with_deplete_and_isnv_calling.wdl
+++ b/pipes/WDL/workflows/assemble_denovo_with_deplete_and_isnv_calling.wdl
@@ -4,12 +4,7 @@ import "tasks_intrahost.wdl" as intrahost
 
 workflow assemble_denovo_with_deplete_and_isnv_calling {
   
-  File raw_reads_unmapped_bam
-
-  call taxon_filter.deplete_taxa {
-    input:
-      raw_reads_unmapped_bam = raw_reads_unmapped_bam
-  }
+  call taxon_filter.deplete_taxa
 
   call taxon_filter.filter_to_taxon {
     input:

--- a/pipes/WDL/workflows/assemble_denovo_with_isnv_calling.wdl
+++ b/pipes/WDL/workflows/assemble_denovo_with_isnv_calling.wdl
@@ -5,34 +5,26 @@ import "tasks_intrahost.wdl" as intrahost
 workflow assemble_denovo_with_isnv_calling {
     File reads_unmapped_bam
 
-    File lastal_db_fasta
     call taxon_filter.filter_to_taxon {
         input:
-            reads_unmapped_bam = reads_unmapped_bam,
-            lastal_db_fasta = lastal_db_fasta
+            reads_unmapped_bam = reads_unmapped_bam
     }
 
-    File trim_clip_db
     call assembly.assemble {
         input:
-            reads_unmapped_bam = filter_to_taxon.taxfilt_bam,
-            trim_clip_db = trim_clip_db
+            reads_unmapped_bam = filter_to_taxon.taxfilt_bam
     }
 
-    Array[File]+ reference_genome_fasta
     call assembly.scaffold {
         input:
             contigs_fasta = assemble.contigs_fasta,
-            reads_bam = filter_to_taxon.taxfilt_bam,
-            reference_genome_fasta = reference_genome_fasta
+            reads_bam = filter_to_taxon.taxfilt_bam
     }
 
-    File gatk_jar
     call assembly.refine_2x_and_plot {
         input:
             assembly_fasta = scaffold.scaffold_fasta,
-            reads_unmapped_bam = reads_unmapped_bam,
-            gatk_jar = gatk_jar
+            reads_unmapped_bam = reads_unmapped_bam
     }
 
     call intrahost.isnvs_per_sample {

--- a/pipes/WDL/workflows/assemble_refbased.wdl
+++ b/pipes/WDL/workflows/assemble_refbased.wdl
@@ -1,14 +1,5 @@
 import "assembly.wdl" as assembly
 
 workflow assemble_refbased {
-
-  File reads_unmapped_bam
-  File ref_fasta
-  File gatk_jar
-  call assembly.refine_2x_and_plot{
-    input:
-        assembly_fasta = ref_fasta,
-        reads_unmapped_bam = reads_unmapped_bam,
-        gatk_jar = gatk_jar
-  }
+  call assembly.refine_2x_and_plot
 }

--- a/pipes/WDL/workflows/classify_kraken.wdl
+++ b/pipes/WDL/workflows/classify_kraken.wdl
@@ -1,13 +1,5 @@
 import "metagenomics.wdl" as metagenomics
 
 workflow classify_kraken {
-    Array[File] reads_unmapped_bam
-    File        kraken_db_tar_lz4
-    File        krona_taxonomy_db_tgz
-    call metagenomics.kraken {
-        input:
-            reads_unmapped_bam = reads_unmapped_bam,
-            kraken_db_tar_lz4 = kraken_db_tar_lz4,
-            krona_taxonomy_db_tgz = krona_taxonomy_db_tgz
-    }
+    call metagenomics.kraken
 }

--- a/pipes/WDL/workflows/contigs.wdl
+++ b/pipes/WDL/workflows/contigs.wdl
@@ -3,24 +3,13 @@ import "taxon_filter.wdl" as taxon_filter
 import "assembly.wdl" as assembly
 
 workflow contigs {
-    File raw_reads_unmapped_bam
-    Array[File]? bmtaggerDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
-    Array[File]? blastDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
-    Array[File]? bwaDbs
-    call taxon_filter.deplete_taxa as deplete {
-        input:
-            raw_reads_unmapped_bam = raw_reads_unmapped_bam,
-            bmtaggerDbs = bmtaggerDbs,
-            blastDbs = blastDbs,
-            bwaDbs = bwaDbs
-    }
 
-    File trim_clip_db
+    call taxon_filter.deplete_taxa as deplete
+
     call assembly.assemble as spades {
         input:
             assembler = "spades",
-            reads_unmapped_bam = deplete.cleaned_bam,
-            trim_clip_db = trim_clip_db
+            reads_unmapped_bam = deplete.cleaned_bam
     }
 
   # TO DO: taxonomic classification of contigs

--- a/pipes/WDL/workflows/coverage_table.wdl
+++ b/pipes/WDL/workflows/coverage_table.wdl
@@ -1,11 +1,5 @@
 import "reports.wdl" as reports
 
 workflow coverage_table {
-    Array[File]+ mapped_bams
-    Array[File] mapped_bam_idx # optional.. speeds it up if you provide it, otherwise we auto-index
-    call reports.coverage_report {
-        input:
-            mapped_bams = mapped_bams,
-            mapped_bam_idx = mapped_bam_idx
-    }
+    call reports.coverage_report
 }

--- a/pipes/WDL/workflows/demux_only.wdl
+++ b/pipes/WDL/workflows/demux_only.wdl
@@ -1,9 +1,5 @@
 import "demux.wdl" as tasks_demux
 
 workflow demux_only {
-    File flowcell_tgz
-    call tasks_demux.illumina_demux {
-        input:
-            flowcell_tgz = flowcell_tgz
-  }
+    call tasks_demux.illumina_demux
 }

--- a/pipes/WDL/workflows/demux_plus.wdl
+++ b/pipes/WDL/workflows/demux_plus.wdl
@@ -6,11 +6,7 @@ import "reports.wdl" as reports
 
 workflow demux_plus {
 
-    File flowcell_tgz
-    call demux.illumina_demux as illumina_demux {
-        input:
-            flowcell_tgz = flowcell_tgz
-    }
+    call demux.illumina_demux as illumina_demux
 
     File spikein_db
     File trim_clip_db
@@ -38,12 +34,8 @@ workflow demux_plus {
         }
     }
 
-    File kraken_db_tar_lz4
-    File krona_taxonomy_db_tgz
     call metagenomics.kraken as kraken {
         input:
-            reads_unmapped_bam = illumina_demux.raw_reads_unaligned_bams,
-            kraken_db_tar_lz4 = kraken_db_tar_lz4,
-            krona_taxonomy_db_tgz = krona_taxonomy_db_tgz
+            reads_unmapped_bam = illumina_demux.raw_reads_unaligned_bams
     }
 }

--- a/pipes/WDL/workflows/deplete_only.wdl
+++ b/pipes/WDL/workflows/deplete_only.wdl
@@ -1,15 +1,5 @@
 import "taxon_filter.wdl" as taxon_filter
 
 workflow deplete_only {
-    File raw_reads_unmapped_bam
-    Array[File]? bmtaggerDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
-    Array[File]? blastDbs  # .tar.gz, .tgz, .tar.bz2, .tar.lz4, .fasta, or .fasta.gz
-    Array[File]? bwaDbs
-    call taxon_filter.deplete_taxa {
-        input:
-            raw_reads_unmapped_bam = raw_reads_unmapped_bam,
-            bmtaggerDbs = bmtaggerDbs,
-            blastDbs = blastDbs,
-            bwaDbs = bwaDbs
-    }
+    call taxon_filter.deplete_taxa 
 }

--- a/pipes/WDL/workflows/fetch_annotations.wdl
+++ b/pipes/WDL/workflows/fetch_annotations.wdl
@@ -1,13 +1,5 @@
 import "ncbi.wdl" as ncbi
 
 workflow fetch_annotations {
-    Array[String]+ accessions
-    String         emailAddress
-    String         combined_out_prefix
-    call ncbi.download_annotations as download {
-        input:
-            accessions = accessions,
-            emailAddress = emailAddress,
-            combined_out_prefix = combined_out_prefix
-    }
+    call ncbi.download_annotations
 }

--- a/pipes/WDL/workflows/genbank.wdl
+++ b/pipes/WDL/workflows/genbank.wdl
@@ -5,39 +5,22 @@ workflow genbank {
 
     File          reference_fasta
     Array[File]+  assemblies_fasta     # one per genome
+
     call interhost.multi_align_mafft_ref as mafft {
         input:
             reference_fasta = reference_fasta,
             assemblies_fasta = assemblies_fasta
     }
 
-    Array[File]+  ref_annotations_tbl  # one per chromosome
     call ncbi.annot_transfer as annot {
         input:
             multi_aln_fasta = mafft.alignments_by_chr,
-            reference_fasta = reference_fasta,
-            reference_feature_table = ref_annotations_tbl
+            reference_fasta = reference_fasta
     }
  
-    File         authors_sbt
-    File         biosampleMap
-    File         genbankSourceTable
-    File?        coverage_table # summary.assembly.txt (from Snakemake) -- change this to accept a list of mapped bam files and we can create this table ourselves
-    String       sequencingTech
-    String       comment # TO DO: make this optional
-    String       organism
-    String       molType = "cRNA"
     call ncbi.prepare_genbank as prep_genbank {
         input:
             assemblies_fasta = assemblies_fasta,
-            annotations_tbl = annot.transferred_feature_tables,
-            authors_sbt = authors_sbt,
-            biosampleMap = biosampleMap,
-            genbankSourceTable = genbankSourceTable,
-            coverage_table = coverage_table, # summary.assembly.txt (from Snakemake) -- change this to accept a list of mapped bam files and we can create this table ourselves
-            sequencingTech = sequencingTech,
-            comment = comment, # TO DO: make this optional
-            organism = organism,
-            molType = molType
+            annotations_tbl = annot.transferred_feature_tables
     }
 }

--- a/pipes/WDL/workflows/isnvs_one_sample.wdl
+++ b/pipes/WDL/workflows/isnvs_one_sample.wdl
@@ -1,11 +1,5 @@
 import "tasks_intrahost.wdl" as tasks_intrahost
 
 workflow isnvs_one_sample {
-    File mapped_bam
-    File assembly_fasta
-    call tasks_intrahost.isnvs_per_sample {
-        input:
-            mapped_bam = mapped_bam,
-            assembly_fasta = assembly_fasta
-    }
+    call tasks_intrahost.isnvs_per_sample
 }

--- a/pipes/WDL/workflows/mafft.wdl
+++ b/pipes/WDL/workflows/mafft.wdl
@@ -1,9 +1,5 @@
 import "interhost.wdl" as interhost
 
 workflow mafft {
-    Array[File]+  assemblies_fasta     # one per genome
-    call interhost.multi_align_mafft {
-        input:
-            assemblies_fasta = assemblies_fasta
-    }
+    call interhost.multi_align_mafft
 }

--- a/pipes/WDL/workflows/merge_bams.wdl
+++ b/pipes/WDL/workflows/merge_bams.wdl
@@ -1,11 +1,5 @@
 import "demux.wdl" as demux
 
 workflow merge_bams {
-    Array[File]+  in_bams
-    String        out_basename
-    call demux.merge_and_reheader_bams {
-        input:
-            in_bams = in_bams,
-            out_basename = out_basename
-    }
+    call demux.merge_and_reheader_bams
 }

--- a/pipes/WDL/workflows/read_utils.wdl
+++ b/pipes/WDL/workflows/read_utils.wdl
@@ -1,10 +1,5 @@
 import "tasks_read_utils.wdl" as reads
 
 workflow downsample {
-    Array[File] reads_bam
-
-    call reads.downsample_bams {
-        input:
-            reads_bam = reads_bam
-    }
+    call reads.downsample_bams
 }

--- a/pipes/WDL/workflows/scaffold_and_refine.wdl
+++ b/pipes/WDL/workflows/scaffold_and_refine.wdl
@@ -2,20 +2,15 @@ import "assembly.wdl" as assembly
 
 workflow scaffold_and_refine {
     File reads_unmapped_bam
-    File contigs_fasta
-    Array[File]+ reference_genome_fasta
+
     call assembly.scaffold {
         input:
-            reads_bam = reads_unmapped_bam,
-            contigs_fasta = contigs_fasta,
-            reference_genome_fasta = reference_genome_fasta
+            reads_bam = reads_unmapped_bam
     }
 
-    File gatk_jar
     call assembly.refine_2x_and_plot {
         input:
             assembly_fasta = scaffold.scaffold_fasta,
-            reads_unmapped_bam = reads_unmapped_bam,
-            gatk_jar = gatk_jar
+            reads_unmapped_bam = reads_unmapped_bam
     }
 }

--- a/pipes/WDL/workflows/spikein.wdl
+++ b/pipes/WDL/workflows/spikein.wdl
@@ -1,11 +1,5 @@
 import "reports.wdl" as reports
 
 workflow spikein {
-    File reads_bam
-    File  spikein_db
-    call reports.spikein_report as spikein_report {
-        input:
-            reads_bam = reads_bam,
-            spikein_db = spikein_db
-    }
+    call reports.spikein_report
 }

--- a/test/input/WDL/test_inputs-assemble_denovo_with_deplete-dnanexus.dx.json
+++ b/test/input/WDL/test_inputs-assemble_denovo_with_deplete-dnanexus.dx.json
@@ -1,13 +1,13 @@
 {
 	"stage-0.raw_reads_unmapped_bam": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-F8F2kVQ09y3Q9Qj14fF806q2" } },
 
-	"stage-0.bmtaggerDbs": [
+	"stage-1.bmtaggerDbs": [
 		{ "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-BYF6g8Q0zjF77x79bGYgJ1Zb" } }
 	],
 
-	"stage-0.lastal_db_fasta": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-F1zXZ9Q0pvkp7FkZ646YJX2y" } },
-	"stage-0.reference_genome_fasta": [ { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-F1zXZ9Q0pvkp7FkZ646YJX2y" } } ],
+	"stage-2.lastal_db_fasta": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-F1zXZ9Q0pvkp7FkZ646YJX2y" } },
+	"stage-4.reference_genome_fasta": [ { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-F1zXZ9Q0pvkp7FkZ646YJX2y" } } ],
 
-	"stage-0.gatk_jar": { "$dnanexus_link": { "project": "project-F89kXY805X08BpXq7xjxbX9F", "id": "file-F89Vx8Q09y3VFxf1KKXbbVv4" } },
+	"stage-5.gatk_jar": { "$dnanexus_link": { "project": "project-F89kXY805X08BpXq7xjxbX9F", "id": "file-F89Vx8Q09y3VFxf1KKXbbVv4" } },
 	"stage-5.novocraft_license": { "$dnanexus_link": { "project": "project-F89kXY805X08BpXq7xjxbX9F", "id": "file-F1zkVGQ0jy1P68J88kyJ8zVF" } }
 }

--- a/test/input/WDL/test_inputs-assemble_denovo_with_deplete-dnanexus.dx.json
+++ b/test/input/WDL/test_inputs-assemble_denovo_with_deplete-dnanexus.dx.json
@@ -1,5 +1,5 @@
 {
-	"stage-0.raw_reads_unmapped_bam": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-F8F2kVQ09y3Q9Qj14fF806q2" } },
+	"stage-1.raw_reads_unmapped_bam": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-F8F2kVQ09y3Q9Qj14fF806q2" } },
 
 	"stage-1.bmtaggerDbs": [
 		{ "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-BYF6g8Q0zjF77x79bGYgJ1Zb" } }

--- a/test/input/WDL/test_inputs-assemble_denovo_with_deplete-local.json
+++ b/test/input/WDL/test_inputs-assemble_denovo_with_deplete-local.json
@@ -1,11 +1,11 @@
 {
-  "assemble_denovo_with_deplete.raw_reads_unmapped_bam": "test/input/G5012.3.testreads.bam",
-  "assemble_denovo_with_deplete.blastDbs": [
+  "assemble_denovo_with_deplete.deplete_taxa.raw_reads_unmapped_bam": "test/input/G5012.3.testreads.bam",
+  "assemble_denovo_with_deplete.deplete_taxa.blastDbs": [
 	"test/input/5kb_human_from_chr6.fasta"
   ],
-  "assemble_denovo_with_deplete.lastal_db_fasta": "test/input/ebov-makona.fasta",
-  "assemble_denovo_with_deplete.trim_clip_db": "test/input/TestAssembleTrinity/clipDb.fasta",
-  "assemble_denovo_with_deplete.reference_genome_fasta": ["test/input/ebov-makona.fasta"],
+  "assemble_denovo_with_deplete.filter_to_taxon.lastal_db_fasta": "test/input/ebov-makona.fasta",
+  "assemble_denovo_with_deplete.assemble.trim_clip_db": "test/input/TestAssembleTrinity/clipDb.fasta",
+  "assemble_denovo_with_deplete.scaffold.reference_genome_fasta": ["test/input/ebov-makona.fasta"],
 
-  "assemble_denovo_with_deplete.gatk_jar": "GenomeAnalysisTK.jar"
+  "assemble_denovo_with_deplete.refine_2x_and_plot.gatk_jar": "GenomeAnalysisTK.jar"
 }

--- a/test/input/WDL/test_inputs-demux_plus-dnanexus.dx.json
+++ b/test/input/WDL/test_inputs-demux_plus-dnanexus.dx.json
@@ -1,5 +1,5 @@
 {
-  "stage-0.flowcell_tgz": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-F86qY0j09y3Q5FbKKK3k4gzq" } },
+  "stage-1.flowcell_tgz": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-F86qY0j09y3Q5FbKKK3k4gzq" } },
   "stage-1.samplesheet":  { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-F8F32gQ09y3VJ4kjBzvgZkKv" } },
   "stage-1.maxMismatches": 0,
   "stage-1.minimumQuality": 25,
@@ -11,6 +11,6 @@
 	{ "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-BzBpkK80x0z8GBQPfZ4kgPKp" } }
   ],
 
-  "stage-0.kraken_db_tar_lz4": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-F86qZg809y3Qvp7j7vgFKj4Z" } },
-  "stage-0.krona_taxonomy_db_tgz": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-F4z0fgj07FZ8jg8yP7yz0Qzb" } }
+  "stage-3.kraken_db_tar_lz4": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-F86qZg809y3Qvp7j7vgFKj4Z" } },
+  "stage-3.krona_taxonomy_db_tgz": { "$dnanexus_link": { "project": "project-F8PQ6380xf5bK0Qk0YPjB17P", "id": "file-F4z0fgj07FZ8jg8yP7yz0Qzb" } }
 }

--- a/travis/build-dx.sh
+++ b/travis/build-dx.sh
@@ -41,7 +41,7 @@ for workflow in pipes/WDL/workflows/*.wdl; do
     fi
 
 	  dx_id=$(java -jar dxWDL.jar compile \
-      $workflow $CMD_INPUT $CMD_DEFAULTS -f \
+      $workflow $CMD_INPUT $CMD_DEFAULTS -f -verbose \
       -imports pipes/WDL/workflows/tasks/ \
       -project $DX_PROJECT \
       -destination /build/$VERSION/$workflow_name)

--- a/travis/install-wdl.sh
+++ b/travis/install-wdl.sh
@@ -19,7 +19,7 @@ cached_fetch_jar_from_github () {
 
 cached_fetch_jar_from_github broadinstitute cromwell womtool 33.1
 cached_fetch_jar_from_github broadinstitute cromwell cromwell 33.1
-cached_fetch_jar_from_github dnanexus dxWDL dxWDL 0.71
+cached_fetch_jar_from_github dnanexus dxWDL dxWDL 0.72
 
 TGZ=dx-toolkit-v0.255.0-ubuntu-14.04-amd64.tar.gz
 if [ ! -f $CACHE_DIR/$TGZ ]; then

--- a/travis/install-wdl.sh
+++ b/travis/install-wdl.sh
@@ -17,9 +17,9 @@ cached_fetch_jar_from_github () {
 	ln -s $CACHE_DIR/$_jar_fname $_tool_name.jar
 }
 
-cached_fetch_jar_from_github broadinstitute cromwell womtool 32
-cached_fetch_jar_from_github broadinstitute cromwell cromwell 32
-cached_fetch_jar_from_github dnanexus dxWDL dxWDL 0.69
+cached_fetch_jar_from_github broadinstitute cromwell womtool 33.1
+cached_fetch_jar_from_github broadinstitute cromwell cromwell 33.1
+cached_fetch_jar_from_github dnanexus dxWDL dxWDL 0.71
 
 TGZ=dx-toolkit-v0.255.0-ubuntu-14.04-amd64.tar.gz
 if [ ! -f $CACHE_DIR/$TGZ ]; then


### PR DESCRIPTION
The recent bump to dxWDL 0.69 brought with it a limitation that required task input variables were not allowed to be left unbound at the workflow level. This resulted in significant new additions of redundant WDL variables at the workflow level and, more importantly, a resulting DNAnexus workflow that aggregated all input variables at the top common stage, regardless of which stage it was actually used in (and this broke output caching, etc).

dxWDL 0.72 now compiles simple WDL top-level tasks directly to DNAnexus stages which allows us to leave these required inputs at the task level. Resulting UI is much [prettier](https://platform.dnanexus.com/projects/F8PQ6380xf5bK0Qk0YPjB17P/data/build/quay.io/broadinstitute/viral-ngs-dev/1.20.1-8-g53e1364-dp-dxwdl) (well, same as before really).

The only case this isn't identical to before is with required inputs within complex stages (scatters, conditionals, subworkflows), such as all of the scattered tasks within [demux_plus](https://platform.dnanexus.com/projects/F8PQ6380xf5bK0Qk0YPjB17P/data/build/quay.io/broadinstitute/viral-ngs-dev/1.20.1-8-g53e1364-dp-dxwdl/demux_plus) which still require all of their inputs to be percolated up to the common stage. Also, all of their optional params are hidden unless we manually replicate them out to the workflow level.