### PR TITLE
testing: fixed an issue with the handling  of tempdirs

### DIFF
--- a/DEVELOPMENT_NOTES.md
+++ b/DEVELOPMENT_NOTES.md
@@ -45,6 +45,5 @@ Some TO DO improvements for the future:
    - Second-stage jobs that pull the docker image should utilize quay.io's torrent squashed image pull to reduce the time spent pulling our Docker image (currently about 5 minutes to pull from DockerHub).
    - Alternatively, we can explore creating a minimal docker image that installs only the conda pip packages (and perhaps extremely common conda tools like samtools and Picard) and leaves the rest of the conda tools out, letting them dynamically install themselves as needed using our dynamic tool install code.
 
-
 ### Building documentation
 Documentation is built automatically for certain branches of viral-ngs by [Read the Docs](http://viral-ngs.readthedocs.io/en/latest/). The documentation template files reside within `viral-ngs/docs`, and are formatted in standard docutils [reStructuredText format](http://docutils.sourceforge.net/rst.html). [Pandoc](http://pandoc.org/) may be used for converting from other formats (such as Markdown) to reStructuredText. The `sphinx-argparse` module is used to automatically generate documentation for the argparse parsers used in viral-ngs.

--- a/conftest.py
+++ b/conftest.py
@@ -41,35 +41,36 @@ def pytest_configure(config):
 #
 
 @contextlib.contextmanager
-def _tmpdir_aux(request, tmpdir_factory, scope, name):
+def _tmpdir_aux(base_dir, scope, name):
     """Create and return a temporary directory; remove it and its contents on context exit."""
-    with util.file.tmp_dir(dir=str(tmpdir_factory.getbasetemp()),
+    with util.file.tmp_dir(dir=base_dir,
                            prefix='test-{}-{}-'.format(scope, name)) as tmpdir:
         yield tmpdir
 
 @pytest.fixture(scope='session')
 def tmpdir_session(request, tmpdir_factory):
     """Create a session-scope temporary directory."""
-    with _tmpdir_aux(request, tmpdir_factory, 'session', id(request.session)) as tmpdir:
+    with _tmpdir_aux(str(tmpdir_factory.getbasetemp()),
+                     'session', id(request.session)) as tmpdir:
         yield tmpdir
 
 @pytest.fixture(scope='module')
-def tmpdir_module(request, tmpdir_factory):
+def tmpdir_module(request, tmpdir_session):
     """Create a module-scope temporary directory."""
-    with _tmpdir_aux(request, tmpdir_factory, 'module', request.module.__name__) as tmpdir:
+    with _tmpdir_aux(tmpdir_session, 'module', request.module.__name__) as tmpdir:
         yield tmpdir
 
 @pytest.fixture(scope='class')
-def tmpdir_class(request, tmpdir_factory):
+def tmpdir_class(request, tmpdir_module):
     """Create a class-scope temporary directory."""
-    with _tmpdir_aux(request, tmpdir_factory, 'class',
-                     request.module.__name__ + ('.' + request.cls.__name__ if request.cls else '')) as tmpdir:
+    with _tmpdir_aux(tmpdir_module, 'class',
+                     request.cls.__name__ if request.cls else '__noclass__') as tmpdir:
         yield tmpdir
 
 @pytest.fixture(autouse=True)
-def tmpdir_function(request, tmpdir_factory, monkeypatch):
+def tmpdir_function(request, tmpdir_class, monkeypatch):
     """Create a temporary directory and set it to be used by the tempfile module and as the TMPDIR environment variable."""
-    with _tmpdir_aux(request, tmpdir_factory, 'node', request.node.name) as tmpdir:
+    with _tmpdir_aux(tmpdir_class, 'node', request.node.name) as tmpdir:
         monkeypatch.setattr(tempfile, 'tempdir', tmpdir)
         monkeypatch.setenv('TMPDIR', tmpdir)
         yield tmpdir

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -80,22 +80,9 @@ def assert_md5_equal_to_line_in_file(testCase, filename, checksum_file, msg=None
 
     testCase.assertEqual(hash_md5.hexdigest(), expected_checksum, msg=msg)
 
+@pytest.mark.usefixtures('tmpdir_class')
 class TestCaseWithTmp(unittest.TestCase):
     'Base class for tests that use tempDir'
-
-    @classmethod
-    def setUpClass(cls):
-        cls._class_tempdir = util.file.set_tmp_dir(cls.__name__)
-
-    def setUp(self):
-        util.file.set_tmp_dir(type(self).__name__)
-
-    @classmethod
-    def tearDownClass(cls):
-        util.file.destroy_tmp_dir(cls._class_tempdir)
-
-    def tearDown(self):
-        util.file.destroy_tmp_dir()
 
     def assertEqualContents(self, f1, f2):
         assert_equal_contents(self, f1, f2)

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -12,6 +12,7 @@ import logging
 
 # third-party
 import Bio.SeqIO
+import pytest
 
 # intra-project
 import util.file

--- a/test/integration/test_ncbi.py
+++ b/test/integration/test_ncbi.py
@@ -20,7 +20,7 @@ import util.file
 log = logging.getLogger(__name__)
 
 
-skip_test = True
+skip_test = False
 
 @unittest.skipIf(skip_test, "test is marked to be skipped")
 class TestNcbiFetch(TestCaseWithTmp):

--- a/test/integration/test_ncbi.py
+++ b/test/integration/test_ncbi.py
@@ -20,7 +20,7 @@ import util.file
 log = logging.getLogger(__name__)
 
 
-skip_test = False
+skip_test = True
 
 @unittest.skipIf(skip_test, "test is marked to be skipped")
 class TestNcbiFetch(TestCaseWithTmp):


### PR DESCRIPTION
Fixed an issue with the handling of temporary directories during testing, caused by an interaction of a legacy unittest-based class with the newer pytest-based fixtures.