### PR TITLE
preserve Unmatched.bam in illumina_demux WDL task

### DIFF
--- a/pipes/WDL/workflows/tasks/tasks_demux.wdl
+++ b/pipes/WDL/workflows/tasks/tasks_demux.wdl
@@ -153,7 +153,9 @@ task illumina_demux {
       --compression_level=5 \
       --loglevel=DEBUG
 
-    rm -f Unmatched.bam
+    mkdir -p unmatched
+    mv Unmatched.bam unmatched/
+
     for bam in *.bam; do
       fastqc_out=$(basename $bam .bam)_fastqc.html
       reports.py fastqc $bam $fastqc_out
@@ -164,6 +166,7 @@ task illumina_demux {
     File        metrics                  = "metrics.txt"
     File        commonBarcodes           = "barcodes.txt"
     Array[File] raw_reads_unaligned_bams = glob("*.bam")
+    File        unmatched_reads_bam      = "unmatched/Unmatched.bam"
     Array[File] raw_reads_fastqc         = glob("*_fastqc.html")
   }
 


### PR DESCRIPTION
This PR includes changes to preserve the `Unmatched.bam` file following executions of the `illumina_demux` task in the WDL pipelines, to be consistent with prior behavior of the DNAnexus pipelines. The `Unmatched.bam` file is treated as a separate task output, `unmatched_reads_bam`, so downstream tasks (kraken, _de novo_ assembly, etc.) are not run on the `Unmatched.bam` by default (since it can often be quite large).