### PR TITLE
allow ints in remote protocols ("s3://"...)

### DIFF
--- a/pipes/rules/common.rules
+++ b/pipes/rules/common.rules
@@ -97,7 +97,7 @@ def webfile_readlines(uriToGet):
 def strip_protocol(uri, relative=False):
 
     def parse_address(text):
-        return re.search("^(?P<protocol>[a-zA-Z]+\://){1}(?P<path_remainder>.*)$", text)
+        return re.search(r"^(?P<protocol>[a-zA-Z0-9]+\://){1}(?P<path_remainder>.*)$", text)
 
     if parse_address(uri):
         if not relative:


### PR DESCRIPTION
allow ints in remote protocols ("s3://"...) for files specified as input remote snakemake rules. This changes the regex used to strip protocols before passing the paths to CLI tools.