### PR TITLE
Fix issues with Trinity

### DIFF
--- a/tools/trinity.py
+++ b/tools/trinity.py
@@ -79,6 +79,6 @@ class TrinityTool(tools.Tool):
         if 'OSTYPE' not in trinity_env:
             trinity_env['OSTYPE'] = platform.system().lower()
         with unlimited_stack():
-            subprocess.check_call(cmd)
+            subprocess.check_call(cmd, env=trinity_env)
         shutil.copyfile(os.path.join(outdir, 'Trinity.fasta'), outFasta)
         shutil.rmtree(outdir, ignore_errors=True)

--- a/tools/trinity.py
+++ b/tools/trinity.py
@@ -75,10 +75,22 @@ class TrinityTool(tools.Tool):
             '--output', outdir
         ]
         log.debug(' '.join(cmd))
+
+        #
+        # Fix some quirks of the Trinity.pl script
+        #
         trinity_env = dict(os.environ)
+        # Ensure OSTYPE is set
         if 'OSTYPE' not in trinity_env:
             trinity_env['OSTYPE'] = platform.system().lower()
+        # Ensure _JAVA_OPTIONS is not set: OpenJDK java always prints a message to stdout that it picked up
+        # _JAVA_OPTIONS, which confuses Trinity.pl's attempt to get the java version.
+        # Note that the Java heap options will still be passed to trinity via the --bflyHeapSpace parameter.
+        if '_JAVA_OPTIONS' in trinity_env:
+            del trinity_env['_JAVA_OPTIONS']
+
         with unlimited_stack():
             subprocess.check_call(cmd, env=trinity_env)
+
         shutil.copyfile(os.path.join(outdir, 'Trinity.fasta'), outFasta)
         shutil.rmtree(outdir, ignore_errors=True)

--- a/tools/trinity.py
+++ b/tools/trinity.py
@@ -10,6 +10,7 @@ import contextlib
 import logging
 import os
 import os.path
+import platform
 import resource
 import subprocess
 import tempfile
@@ -74,6 +75,9 @@ class TrinityTool(tools.Tool):
             '--output', outdir
         ]
         log.debug(' '.join(cmd))
+        trinity_env = dict(os.environ)
+        if 'OSTYPE' not in trinity_env:
+            trinity_env['OSTYPE'] = platform.system().lower()
         with unlimited_stack():
             subprocess.check_call(cmd)
         shutil.copyfile(os.path.join(outdir, 'Trinity.fasta'), outFasta)


### PR DESCRIPTION
Fix some quirks of Trinity, that were breaking the build.  Trinity needs env var 'OSTYPE' to be set, and the output of 'java -version' to start with the java version.