### PR TITLE
add fallback method for bioconda wrapper of gatk v3

### DIFF
--- a/tools/gatk.py
+++ b/tools/gatk.py
@@ -44,6 +44,7 @@ class GATKTool(tools.Tool):
                     )
                 )
         install_methods.append(tools.CondaPackage(TOOL_NAME, version=TOOL_VERSION, executable="gatk3"))
+        install_methods.append(tools.CondaPackage(TOOL_NAME, version=TOOL_VERSION, executable="gatk"))
         tools.Tool.__init__(self, install_methods=install_methods)
 
     def execute(self, command, gatkOptions=None, JVMmemory=None):    # pylint: disable=W0221


### PR DESCRIPTION
add install method for `gatk` executable as well as `gatk3` as provided by bioconda.  The current [recipe](https://github.com/bioconda/bioconda-recipes/blob/master/recipes/gatk/build.sh) uses gatk3, however a new install received a package build with the older `gatk` executable name (some bioconda packages are currently in build flux). This adds a fallback method so either executable supplied by bioconda will work.