### PR TITLE
update to use viral-baseimage 0.1.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/broadinstitute/viral-baseimage:0.1.13
+FROM quay.io/broadinstitute/viral-baseimage:0.1.14
 
 LABEL maintainer "viral-ngs@broadinstitute.org"
 


### PR DESCRIPTION
update to use viral-baseimage 0.1.14 , which added ttf-dejavu package to fix Java hanging when running fastqc due to missing fonts ( https://github.com/broadinstitute/viral-baseimage/pull/12 )