### PR TITLE
conda fixes related to changed bioconda guidelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
   include:
 
     - language: java
-      jdk: oraclejdk8
+      jdk: openjdk8
       sudo: required
       addons:
         apt:
@@ -101,7 +101,7 @@ jobs:
     #    - travis/list-docker-tags.sh | tail -1 > $CACHE_DIR/old-docker-tag.txt
     #
     #- language: java
-    #  jdk: oraclejdk8
+    #  jdk: openjdk8
     #  stage: build
     #  env:
     #    - TRAVIS_JOB=build_dxWDL
@@ -115,7 +115,7 @@ jobs:
     #    - travis/validate-wdl.sh
     #    - travis/build-dx.sh
     #- language: java
-    #  jdk: oraclejdk8
+    #  jdk: openjdk8
     #  stage: test
     #  env:
     #    - TRAVIS_JOB=test_cromwell

--- a/DEVELOPMENT_NOTES.md
+++ b/DEVELOPMENT_NOTES.md
@@ -10,7 +10,7 @@ When Python and binary dependencies for viral-ngs are installed by conda, they c
 When adding a new tool or dependency to viral-ngs, check to see if a conda package is already available either on the default channel (`conda search <package_name>`), or on the bioconda channel (`conda search -c bioconda <package_name>`). If so, it will needed to be added to the conda recipe template for viral-ngs. If a recipe is unavailable, it will first need to be added to a particular conda channel. [Bioconda](https://github.com/bioconda/bioconda-recipes) is used by default.
 
 #### Changing dependency versions
-The viral-ngs package installed by `conda install viral-ngs` from the [broad-viral channel](https://anaconda.org/broad-viral/viral-ngs) depends on a conda build recipe distributed in this repository. The recipe files source the various Python and binary depedencies of viral-ngs as conda packages, including version numbers, from the `requirements-*.txt` files within this repository.
+The viral-ngs package installed by `conda install viral-ngs` from the [broad-viral channel](https://anaconda.org/broad-viral/viral-ngs) depends on a conda build recipe distributed in this repository. The recipe files source the various Python and binary depedencies of viral-ngs as conda packages, including version numbers, from the `requirements-*.txt` files within this repository.  When updating a package version in requirements-conda.txt, update it also in requirements-minimal.txt if it appears there as well.
 
 #### Upgrading GATK
 When upgrading the GATK to a new version:

--- a/docker/install-viral-ngs.sh
+++ b/docker/install-viral-ngs.sh
@@ -15,6 +15,8 @@
 
 set -e -o pipefail
 
+CONDA_CHANNEL_STRING="--override-channels -c broad-viral -c conda-forge -c bioconda -c defaults"
+
 mkdir -p $INSTALL_PATH/viral-ngs-etc
 if [ ! -f $INSTALL_PATH/viral-ngs-etc/viral-ngs ]; then
 	ln -s $VIRAL_NGS_PATH $INSTALL_PATH/viral-ngs-etc/viral-ngs
@@ -29,12 +31,12 @@ sync
 # manually install it ourselves instead of using easy-deploy
 if [[ "$1" == "minimal" ]]; then
 	# a more minimal set of tools (smaller docker image?)
-	conda install --override-channels -y \
-		-q -c broad-viral -c bioconda -c conda-forge -c defaults -c r \
+	conda install -y \
+		-q $CONDA_CHANNEL_STRING \
 		--file "$VIRAL_NGS_PATH/requirements-minimal.txt"
 else
-	conda install --override-channels -y \
-		-q -c broad-viral -c bioconda -c conda-forge -c defaults -c r \
+	conda install -y \
+		-q $CONDA_CHANNEL_STRING \
 		--file "$VIRAL_NGS_PATH/requirements-py3.txt" \
 		--file "$VIRAL_NGS_PATH/requirements-conda.txt" \
 		--file "$VIRAL_NGS_PATH/requirements-conda-tests.txt"

--- a/easy-deploy-script/easy-deploy-viral-ngs.sh
+++ b/easy-deploy-script/easy-deploy-viral-ngs.sh
@@ -50,7 +50,7 @@ fi
 
 SELF_UPDATE_URL="https://raw.githubusercontent.com/broadinstitute/viral-ngs/master/easy-deploy-script/easy-deploy-viral-ngs.sh"
 
-CONDA_CHANNEL_STRING="-c broad-viral -c bioconda -c conda-forge -c defaults -c r"
+CONDA_CHANNEL_STRING="--override-channels -c broad-viral -c conda-forge -c bioconda -c defaults"
 
 if [ -z "$VIRAL_NGS_PACKAGE" ]; then
     VIRAL_NGS_PACKAGE="viral-ngs"
@@ -236,21 +236,21 @@ function install_viral_ngs_conda(){
     # provide an avenue to specify a package path, or to use a previously-built local package
     if [ $# -eq 2 ]; then
         if [ "$2" == "--use-local" ]; then
-            conda install -q  $CONDA_CHANNEL_STRING --override-channels -y -p "$VIRAL_CONDA_ENV_PATH" --use-local $VIRAL_NGS_PACKAGE || exit 1
+            conda install -q  $CONDA_CHANNEL_STRING -y -p "$VIRAL_CONDA_ENV_PATH" --use-local $VIRAL_NGS_PACKAGE || exit 1
             echo "using local...."
             exit 0
         else
-            conda install -q  $CONDA_CHANNEL_STRING --override-channels -y -p "$VIRAL_CONDA_ENV_PATH" $2 || exit 1
+            conda install -q  $CONDA_CHANNEL_STRING -y -p "$VIRAL_CONDA_ENV_PATH" $2 || exit 1
         fi
 
     elif [ $# -eq 3 ]; then
         if [ "$2" == "--viral-ngs-version" ]; then
-            conda install -q  $CONDA_CHANNEL_STRING --override-channels -y -p "$VIRAL_CONDA_ENV_PATH" $VIRAL_NGS_PACKAGE=$3 || exit 1
+            conda install -q  $CONDA_CHANNEL_STRING -y -p "$VIRAL_CONDA_ENV_PATH" $VIRAL_NGS_PACKAGE=$3 || exit 1
         else
             echo "--viral-ngs-version specified but no version given"
         fi
     elif [ $# -eq 1 ]; then
-        conda install -q  $CONDA_CHANNEL_STRING --override-channels -y -p "$VIRAL_CONDA_ENV_PATH" $VIRAL_NGS_PACKAGE || exit 1
+        conda install -q  $CONDA_CHANNEL_STRING -y -p "$VIRAL_CONDA_ENV_PATH" $VIRAL_NGS_PACKAGE || exit 1
     fi
 }
 
@@ -269,9 +269,9 @@ function install_viral_ngs_git(){
 
 function install_viral_ngs_conda_dependencies() {
     if [[ $(absolute_path "$VIRAL_CONDA_ENV_PATH") == $(absolute_path "$MINICONDA_PATH") ]]; then
-        conda install -q $CONDA_CHANNEL_STRING --override-channels -y --file "$VIRAL_NGS_PATH/requirements-conda.txt" --file "$VIRAL_NGS_PATH/requirements-py3.txt" --file "$VIRAL_NGS_PATH/requirements-conda-tests.txt" || exit 1
+        conda install -q $CONDA_CHANNEL_STRING -y --file "$VIRAL_NGS_PATH/requirements-conda.txt" --file "$VIRAL_NGS_PATH/requirements-py3.txt" --file "$VIRAL_NGS_PATH/requirements-conda-tests.txt" || exit 1
     else
-        conda install -q $CONDA_CHANNEL_STRING --override-channels -y -p $VIRAL_CONDA_ENV_PATH --file "$VIRAL_NGS_PATH/requirements-conda.txt" --file "$VIRAL_NGS_PATH/requirements-py3.txt" --file "$VIRAL_NGS_PATH/requirements-conda-tests.txt" || exit 1
+        conda install -q $CONDA_CHANNEL_STRING -y -p $VIRAL_CONDA_ENV_PATH --file "$VIRAL_NGS_PATH/requirements-conda.txt" --file "$VIRAL_NGS_PATH/requirements-py3.txt" --file "$VIRAL_NGS_PATH/requirements-conda-tests.txt" || exit 1
     fi
 }
 
@@ -463,7 +463,7 @@ function check_viral_ngs_version(){
             echo "Checking viral-ngs version..."
             CURRENT_VER="$(conda list --no-pip viral-ngs | grep viral-ngs | grep -v packages | awk -F' ' '{print $2}')"
             # perhaps a better way...
-            AVAILABLE_VER="$(conda search --override-channels -f  $CONDA_CHANNEL_STRING --override-channels viral-ngs --json | grep version | tail -n 1 | awk -F' ' '{print $2}' | perl -lape 's/[\",]+//g')"
+            AVAILABLE_VER="$(conda search -f $CONDA_CHANNEL_STRING viral-ngs --json | grep version | tail -n 1 | awk -F' ' '{print $2}' | perl -lape 's/[\",]+//g')"
             if [ "$CURRENT_VER" != "$AVAILABLE_VER" ]; then
                 echo ""
                 echo "============================================================================================================"
@@ -561,9 +561,9 @@ else
             if [ ! -d "$VIRAL_CONDA_ENV_PATH" ]; then
                 # provide an option to use Python 2 in the conda environment
                 if [ "$1" == "setup-py2" ]; then
-                    conda create -q $CONDA_CHANNEL_STRING --override-channels -y -p "$VIRAL_CONDA_ENV_PATH" python=2 || exit 1
+                    conda create -q $CONDA_CHANNEL_STRING -y -p "$VIRAL_CONDA_ENV_PATH" python=2 || exit 1
                 else
-                    conda create -q $CONDA_CHANNEL_STRING --override-channels -y -p "$VIRAL_CONDA_ENV_PATH" python=3.6 || exit 1
+                    conda create -q $CONDA_CHANNEL_STRING -y -p "$VIRAL_CONDA_ENV_PATH" python=3.6 || exit 1
                 fi
 
                 if [[ "$1" == "setup-git" || "$1" == "setup-git-local" ]]; then
@@ -648,7 +648,7 @@ else
                         if [ -L "$VIRAL_NGS_PATH" ]; then
                             rm $VIRAL_NGS_PATH # remove symlink
                         fi
-                        conda update -y $CONDA_CHANNEL_STRING --override-channels viral-ngs
+                        conda update -y $CONDA_CHANNEL_STRING viral-ngs
 
                         # recreate symlink to folder for latest viral-ngs in conda-env/opt/
                         symlink_viral_ngs

--- a/packaging/conda-recipe/viral-ngs-template/meta.yaml
+++ b/packaging/conda-recipe/viral-ngs-template/meta.yaml
@@ -20,7 +20,7 @@ build:
 requirements:
   build:
     - python
-    - java-jdk >=7
+    - openjdk >=8
     - perl
     {% for item in build_requirements %}
     {{ item }}
@@ -31,7 +31,7 @@ requirements:
 
   run:
     - python
-    - java-jdk >=7
+    - openjdk >=8
     - perl
     {% for item in run_requirements %}
     {{ item }}

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -1,14 +1,14 @@
 lbzip2=2.5
 lz4-bin=131
 fastqc=0.11.5
-picard=2.9.0
-pigz=2.3.4
-samtools=1.6
+picard=2.18.11
+pigz=2.4
+samtools=1.9
 unzip=6.0
 # Python packages below
-biopython=1.68
+biopython=1.72
 future==0.16.0
 matplotlib=1.5.3
-pysam=0.13.0
+pysam=0.15.0
 pybedtools=0.7.10
-PyYAML=3.11
+PyYAML=3.12

--- a/travis/build-conda.sh
+++ b/travis/build-conda.sh
@@ -4,6 +4,7 @@
 set -e -o pipefail
 
 # === Build conda package
+CONDA_CHANNEL_STRING="--override-channels -c broad-viral -c conda-forge -c bioconda -c defaults"
 CONDA_PACKAGE_OUTDIR=packaging/conda-packages
 echo "Rendering and building conda package..."
 echo "Python binary: $(which python)"
@@ -24,7 +25,7 @@ if [ -n "$TRAVIS_TAG" ]; then
 
     # render and build the conda package
     python packaging/conda-recipe/render-recipe.py "$TRAVIS_TAG" --build-reqs requirements-conda.txt --run-reqs requirements-conda.txt --py3-run-reqs requirements-py3.txt --py2-run-reqs requirements-py2.txt --test-reqs requirements-conda-tests.txt
-    CONDA_PERL=5.22.0 conda build -c broad-viral -c r -c bioconda -c conda-forge -c defaults --python "$TRAVIS_PYTHON_VERSION" --token "$ANACONDA_TOKEN" packaging/conda-recipe/viral-ngs
+    CONDA_PERL=5.22.0 conda build $CONDA_CHANNEL_STRING --python "$TRAVIS_PYTHON_VERSION" --token "$ANACONDA_TOKEN" packaging/conda-recipe/viral-ngs
 
 else
     # This is a development build
@@ -45,5 +46,5 @@ else
 
     # render and build the conda package
     python packaging/conda-recipe/render-recipe.py "$CONDA_PKG_VERSION" --package-name "viral-ngs-dev" --download-filename "$TRAVIS_COMMIT" --build-reqs requirements-conda.txt --run-reqs requirements-conda.txt --py3-run-reqs requirements-py3.txt --py2-run-reqs requirements-py2.txt --test-reqs requirements-conda-tests.txt
-    CONDA_PERL=5.22.0 conda build -c broad-viral -c r -c bioconda -c conda-forge -c defaults --python "$TRAVIS_PYTHON_VERSION" --token "$ANACONDA_TOKEN" --output-folder "$CONDA_PACKAGE_OUTDIR" packaging/conda-recipe/viral-ngs
+    CONDA_PERL=5.22.0 conda build $CONDA_CHANNEL_STRING --python "$TRAVIS_PYTHON_VERSION" --token "$ANACONDA_TOKEN" --output-folder "$CONDA_PACKAGE_OUTDIR" packaging/conda-recipe/viral-ngs
 fi

--- a/travis/install-conda.sh
+++ b/travis/install-conda.sh
@@ -40,10 +40,9 @@ else # if it does not exist, we need to install miniconda
     fi
     hash -r
     conda config --set always_yes yes --set changeps1 no
-    conda config --add channels r
     conda config --add channels defaults
-    conda config --add channels conda-forge
     conda config --add channels bioconda
+    conda config --add channels conda-forge
     conda config --add channels broad-viral
     conda install --quiet -y conda #conda=4.2 # pin to 4.2.* until this is fixed: https://github.com/conda/conda-build/issues/1666
     conda config --set auto_update_conda false

--- a/travis/install-conda.sh
+++ b/travis/install-conda.sh
@@ -46,7 +46,7 @@ else # if it does not exist, we need to install miniconda
     conda config --add channels broad-viral
     conda install --quiet -y conda #conda=4.2 # pin to 4.2.* until this is fixed: https://github.com/conda/conda-build/issues/1666
     conda config --set auto_update_conda false
-    conda install --quiet -y java-jdk==8.0.112
+    conda install --quiet -y openjdk==8.0.112
 fi
 
 conda info -a # for debugging

--- a/travis/install-pip.sh
+++ b/travis/install-pip.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 set -e
 
+CONDA_CHANNEL_STRING="--override-channels -c broad-viral -c conda-forge -c bioconda -c defaults"
 PYVER=`echo $TRAVIS_PYTHON_VERSION | cut -c 1`
 if [ "$PYVER" = "3" ]; then
     echo "pip installing snakemake packages (py3 only)"
-    #conda install -q -y -c bioconda -c conda-forge -c defaults -p tools/conda-tools/default --file requirements-py3.txt python="$TRAVIS_PYTHON_VERSION"
+    #conda install -q -y $CONDA_CHANNEL_STRING -p tools/conda-tools/default --file requirements-py3.txt python="$TRAVIS_PYTHON_VERSION"
     pip install --quiet -r requirements-py3.txt
 elif [ "$PYVER" = "2" ]; then
     echo "pip install py2 packages"
-    #conda install -q -y -c bioconda -c conda-forge -c defaults -p tools/conda-tools/default --file requirements-py2.txt python="$TRAVIS_PYTHON_VERSION"
+    #conda install -q -y $CONDA_CHANNEL_STRING -p tools/conda-tools/default --file requirements-py2.txt python="$TRAVIS_PYTHON_VERSION"
     pip install --quiet -r requirements-py2.txt
 fi
 

--- a/travis/install-tools.sh
+++ b/travis/install-tools.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e -o pipefail
 
+CONDA_CHANNEL_STRING="--override-channels -c broad-viral -c conda-forge -c bioconda -c defaults"
 CONDA_ENV="$(pwd)/tools/conda-tools/default"
 
 # Set to conda's java
@@ -15,8 +16,8 @@ if [ ! -d $CONDA_ENV ]; then
 	conda create -y -m --quiet -p $CONDA_ENV python="$TRAVIS_PYTHON_VERSION"
 fi
 
-conda install -y --quiet --override-channels \
-	-c broad-viral -c r -c bioconda -c conda-forge -c defaults \
+conda install -y --quiet \
+	$CONDA_CHANNEL_STRING \
 	--file requirements-conda.txt \
 	--file requirements-conda-tests.txt \
 	--file requirements-py$PYVER.txt \


### PR DESCRIPTION
Updates to reflect current bioconda guidelines:

bioconda channel priorities now put conda-forge before bioconda, and do not use r: https://bioconda.github.io/#set-up-channels
bioconda now uses openjdk: https://bioconda.github.io/guidelines.html#java

Also updated requirements-minimal.txt to match versions in requirements-conda.txt .
