### PR TITLE
Create a stub CondaPackage for use with tests.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -11,6 +11,9 @@ import util.file
 
 import pytest
 
+import test.stubs
+import tools
+
 def timer():
     if sys.version_info < (3, 3):
         return time.time()
@@ -42,7 +45,7 @@ def pytest_configure(config):
 
 #
 # Fixtures for creating a temp dir at session/module/class/function scope.
-# Unlike pytest's tmpdir fixture, they use tempfile.mkdtemp to create a 
+# Unlike pytest's tmpdir fixture, they use tempfile.mkdtemp to create a
 # tempdir in the most secure/race-condition-free manner possible.
 # Also, since util.file.tmp_dir() is used, the tempdir contens can be
 # preserved for debugging by setting the environment variable VIRAL_NGS_TMP_DIRKEEP.
@@ -82,6 +85,15 @@ def tmpdir_function(request, tmpdir_class, monkeypatch):
         monkeypatch.setattr(tempfile, 'tempdir', tmpdir)
         monkeypatch.setenv('TMPDIR', tmpdir)
         yield tmpdir
+
+
+@pytest.fixture(scope='module', autouse=True)
+def stub_conda(request):
+    cls = tools.CondaPackage
+    tools.CondaPackage = test.stubs.StubCondaPackage
+    yield
+    tools.CondaPackage = cls
+
 
 #############################################################################################
 

--- a/test/stubs.py
+++ b/test/stubs.py
@@ -1,0 +1,79 @@
+import logging
+import os
+import pytest
+import tools
+
+
+class StubCondaPackage(tools.Tool):
+
+    # Skip gathering in all_tool_classes
+    _skiptest = True
+
+    def __init__(
+        self,
+        package,
+        channel="bioconda",
+        executable=None,
+        version="",
+        verifycmd=None,
+        verifycode=0,
+        require_executability=True,
+        env=None,
+        env_root_path=None,
+        conda_cache_path=None,
+        patches=None,
+        post_install_command=None,
+        post_install_ret=0,
+        post_verify_command=None,
+        post_verify_ret=0
+    ):
+        self.executable = executable or package
+        if type(version) == tools.CondaPackageVersion:
+            self.version = version
+        else:
+            self.version = tools.CondaPackageVersion(version)
+
+        self.env_path = None
+        if 'CONDA_PREFIX' in os.environ and len(os.environ['CONDA_PREFIX']):
+            last_path_component = os.path.basename(os.path.normpath(os.environ['CONDA_PREFIX']))
+            self.env_path = os.path.dirname(os.environ['CONDA_PREFIX']) if last_path_component == "bin" else os.environ['CONDA_PREFIX']
+
+        else:
+            raise Exception
+
+    def is_attempted(self):
+        return True
+
+    def is_installed(self):
+        return True
+
+    @property
+    def bin_path(self):
+        return os.path.join(self.env_path, 'bin')
+
+    def executable_path(self):
+        return os.path.join(self.bin_path, self.executable)
+
+    def apply_patches(self):
+        pass
+
+    def verify_install(self):
+        return
+
+    def package_available(self):
+        return True
+
+    def uninstall_package(self):
+        return True
+
+    def install_package(self):
+        return True
+
+    def get_installed_version(self):
+        return self.version
+
+    def post_install(self):
+        pass
+
+    def execute(self, cmd, loglevel=logging.DEBUG):
+        return {}

--- a/test/unit/test_tools.py
+++ b/test/unit/test_tools.py
@@ -2,15 +2,20 @@
 
 __author__ = "yesimon@broadinstitute.org"
 
+import pytest
 import tools
 from tools import *
-import pytest
+
+# Simply do nothing to override stub_conda in conftest.py
+@pytest.fixture(autouse=True)
+def stub_conda():
+    pass
 
 @pytest.fixture(params=tools.all_tool_classes())
 def tool_class(request):
-    print(request.param)
     return request.param
 
+@pytest.mark.slow
 def test_tool_install(tool_class):
     t = tool_class()
     t.install()


### PR DESCRIPTION
For all tests except test_tools, stub out the CondaPackage class using a globally autoused conftest
fixture. This CondaPackage doesn't do anything and simply assumes that the packages are installed.
This is useful because simple commands like "conda list" take considerable amounts of time. The
conda commands are still tested in test_tools, which overrides the stub_conda fixture with a local one.