### PR TITLE
memory spec corrections in UGER job submission script; JVM memory for demux

### DIFF
--- a/pipes/Broad_LSF/cluster-submitter.py
+++ b/pipes/Broad_LSF/cluster-submitter.py
@@ -26,7 +26,7 @@ if "-N" not in props["params"].get("LSF", ""):
     cmdline += "-oo {logdir}/LSF-{jobname}.txt ".format(logdir=LOGDIR, jobname=jobname)
 
 # pass memory resource request to LSF
-mem = int(props.get('resources', {}).get('mem_mb'))/1000
+mem = int(props.get('resources', {}).get('mem_mb',1000))/1000
 if mem:
     cmdline += '-R "rusage[mem={}]" -M {} '.format(mem, 2 * int(mem))
 

--- a/pipes/Broad_UGER/cluster-submitter.py
+++ b/pipes/Broad_UGER/cluster-submitter.py
@@ -37,12 +37,14 @@ cmdline = "qsub -N {jobname} -cwd -r y ".format(jobname=jobname)
 cmdline += "-o {logdir} -j y ".format(logdir=LOGDIR)
 
 # pass memory resource request to cluster
-mem = int(props.get('resources', {}).get('mem_mb'))/1000
+mem = props.get('resources', {}).get('mem_mb')
 threads = props.get('resources', {}).get('threads')
-threads = threads or 1
+
 if mem:
+    mem = int(mem)
+    threads = int(threads) or 1 # only used here for the calculation of memory per-core
     # on UGER, memory requests are per-core (according to BITS as of Sept. 6, 2016)
-    mem_per_core = round((int(mem)*1024)/int(threads), 2)
+    mem_per_core = round(float(mem)/float(threads), 2)
     # increase memory requested to reflect new JVM-UGER changes requiring greater memory headroom
     mem_per_core = round(mem_per_core*1.1,2)
     if blacklisted_nodes:

--- a/pipes/rules/demux.rules
+++ b/pipes/rules/demux.rules
@@ -96,7 +96,7 @@ rule illumina_demux:
         shutil.rmtree(outdir, ignore_errors=True)
         makedirs(set(map(os.path.dirname, output)))
         lane = get_one_lane_from_run(wildcards.flowcell, wildcards.lane, config['seqruns_demux'])
-        opts = '--threads={} --JVMmemory={}g'.format(resources.threads, resources.mem_mb)
+        opts = '--threads={} --JVMmemory={}m'.format(resources.threads, resources.mem_mb)
         for opt in ('minimum_base_quality', 'max_mismatches', 'min_mismatch_delta', 'max_no_calls', 'read_structure', 'minimum_quality', 'run_start_date'):
             if lane.get(opt):
                 opts += ' --%s=%s' % (opt, lane[opt])


### PR DESCRIPTION
A few corrections to account for specifying memory in MB rather than G.
Thanks to @09aaronl and @notestaff for catching these.