### PR TITLE
retry conda environment install on Travis

### DIFF
--- a/reports.py
+++ b/reports.py
@@ -582,10 +582,6 @@ def plot_coverage(
     ''' 
         Generate a coverage plot from an aligned bam file
     '''
-
-    # TODO: remove this:
-    #coverage_tsv_file = "/Users/tomkinsc/Downloads/plottest/test_multisegment.tsv"
-
     samtools = tools.samtools.SamtoolsTool()
 
     # check if in_bam is aligned, if not raise an error

--- a/travis/install-conda.sh
+++ b/travis/install-conda.sh
@@ -50,5 +50,5 @@ else # if it does not exist, we need to install miniconda
 fi
 
 # update certs
-conda update --quiet openssl pyopenssl ca-certificates certifi
+conda update --quiet -y openssl pyopenssl ca-certificates certifi
 conda info -a # for debugging

--- a/travis/install-conda.sh
+++ b/travis/install-conda.sh
@@ -39,7 +39,7 @@ else # if it does not exist, we need to install miniconda
         export PATH="$MINICONDA_DIR/bin:$PATH"
     fi
     hash -r
-    conda config --set always_yes yes --set changeps1 no
+    conda config --set always_yes yes --set changeps1 no --set remote_max_retries 6
     conda config --add channels defaults
     conda config --add channels bioconda
     conda config --add channels conda-forge

--- a/travis/install-conda.sh
+++ b/travis/install-conda.sh
@@ -49,4 +49,6 @@ else # if it does not exist, we need to install miniconda
     conda install --quiet -y openjdk==8.0.112
 fi
 
+# update certs
+conda update --quiet openssl pyopenssl ca-certificates certifi
 conda info -a # for debugging

--- a/travis/install-tools.sh
+++ b/travis/install-tools.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e -o pipefail
+#set -e -o pipefail
 
 CONDA_CHANNEL_STRING="--override-channels -c broad-viral -c conda-forge -c bioconda -c defaults"
 CONDA_ENV="$(pwd)/tools/conda-tools/default"
@@ -13,15 +13,23 @@ export CONDA_ENVS_PATH=tools/conda-cache:tools/conda-tools/default
 PYVER=`echo $TRAVIS_PYTHON_VERSION | cut -c 1`
 
 if [ ! -d $CONDA_ENV ]; then
-	conda create -y -m --quiet -p $CONDA_ENV python="$TRAVIS_PYTHON_VERSION"
+    conda create -y -m --quiet -p $CONDA_ENV python="$TRAVIS_PYTHON_VERSION" || exit $?
 fi
 
-conda install -y --quiet \
-	$CONDA_CHANNEL_STRING \
-	--file requirements-conda.txt \
-	--file requirements-conda-tests.txt \
-	--file requirements-py$PYVER.txt \
-	-p $CONDA_ENV
+RETRIES=0
+RETRY_LIMIT=3
+until conda install -y --quiet \
+    $CONDA_CHANNEL_STRING \
+    --file requirements-conda.txt \
+    --file requirements-conda-tests.txt \
+    --file requirements-py$PYVER.txt \
+    -p $CONDA_ENV; do
+        let RETRIES++
+        if [ "$RETRIES" -gt "$RETRY_LIMIT" ]; then
+            break
+        fi
+        echo "Conda install failed, likely due to transient server errors. Retrying (${RETRIES}/${RETRY_LIMIT})..."
+done
 
 conda clean --all --yes # clean temp/cache files to reduce Travis cache size
 

--- a/travis/install-tools.sh
+++ b/travis/install-tools.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#set -e -o pipefail
+set -e -o pipefail #exit on error or within pipes
 
 CONDA_CHANNEL_STRING="--override-channels -c broad-viral -c conda-forge -c bioconda -c defaults"
 CONDA_ENV="$(pwd)/tools/conda-tools/default"
@@ -16,20 +16,28 @@ if [ ! -d $CONDA_ENV ]; then
     conda create -y -m --quiet -p $CONDA_ENV python="$TRAVIS_PYTHON_VERSION" || exit $?
 fi
 
-RETRIES=0
-RETRY_LIMIT=3
-until conda install -y --quiet \
+# commented out custom retry logic for now
+# until we establish the built-in conda retry logic
+# works as intended when we retry more than the default
+# 3 times
+# remote_max_retries is set in install-conda.sh
+#set +e # disable exit on error
+#RETRIES=0
+#RETRY_LIMIT=3
+#until #conda...
+conda install -y --quiet \
     $CONDA_CHANNEL_STRING \
     --file requirements-conda.txt \
     --file requirements-conda-tests.txt \
     --file requirements-py$PYVER.txt \
-    -p $CONDA_ENV; do
-        let RETRIES++
-        if [ "$RETRIES" -gt "$RETRY_LIMIT" ]; then
-            break
-        fi
-        echo "Conda install failed, likely due to transient server errors. Retrying (${RETRIES}/${RETRY_LIMIT})..."
-done
+    -p $CONDA_ENV #; do
+#        let RETRIES++
+#        if [ "$RETRIES" -gt "$RETRY_LIMIT" ]; then
+#            break
+#        fi
+#        echo "Conda install failed, likely due to transient server errors. Retrying (${RETRIES}/${RETRY_LIMIT})..."
+#done
+#set -e #(re)enable exit on error
 
 conda clean --all --yes # clean temp/cache files to reduce Travis cache size
 


### PR DESCRIPTION
installation of conda packages on Travis often fails due to transient web request errors. This wraps the install command in a retry block to attempt the install up to 3 times.