### PR TITLE
add aggregate_spike_count to reports.py

### DIFF
--- a/reports.py
+++ b/reports.py
@@ -10,7 +10,7 @@ import logging
 import glob
 import os
 import time
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 import csv
 import math
 import shutil
@@ -451,6 +451,50 @@ def parser_consolidate_spike_count(parser=argparse.ArgumentParser()):
 
 
 __commands__.append(('consolidate_spike_count', parser_consolidate_spike_count))
+
+
+def aggregate_spike_count(inDir, outFile):
+    '''aggregate multiple spike count reports into one.'''
+    spike_in_sample_counts = defaultdict(dict) # For a given spikein ID, map to sample name and corresponding count
+    samples_seen = []
+    with open(outFile, 'wt') as outf:
+        for fn in glob.glob(inDir+"*.spike_count.txt"):# os.listdir():
+            #fn = os.path.join(inDir, fn)
+            s = os.path.basename(fn)
+            if not s.endswith('.spike_count.txt'):
+                raise Exception()
+            if s.find("ERCC"):
+                s=s[:s.find("ERCC")-1]
+            else:
+                s = s[:-len('.spike_count.txt')]
+            if s not in samples_seen:
+                samples_seen.append(s)
+            with open(fn, 'rt') as inf:
+                for line in inf:
+                    if not line.startswith('Input bam') and not line.startswith('*'):
+                        spike, count = [line.strip().split('\t')[i] for i in [0,2]]
+                        spike_in_sample_counts[spike][s] = count
+                        #outf.write('\t'.join([s, spike, count]) + '\n')
+        outf.write("\t".join(["spike-in"]+samples_seen)+"\n")
+        for spike in spike_in_sample_counts.keys():
+            row = []
+            row.append(spike)
+            for s in samples_seen:
+                if s in spike_in_sample_counts[spike]:
+                    row.append(spike_in_sample_counts[spike][s])
+                else:
+                    row.append("0")
+            outf.write("\t".join(row)+"\n")
+
+
+def parser_aggregate_spike_count(parser=argparse.ArgumentParser()):
+    parser.add_argument('inDir', help='Input spike count directory.')
+    parser.add_argument('outFile', help='Output report file.')
+    util.cmd.attach_main(parser, aggregate_spike_count, split_args=True)
+    return parser
+
+
+__commands__.append(('aggregate_spike_count', parser_aggregate_spike_count))
 
 
 # =========================

--- a/reports.py
+++ b/reports.py
@@ -427,11 +427,11 @@ def get_earliest_date(inDir):
     return time.strftime("%Y-%m-%d", time.localtime(earliest))
 
 
-def consolidate_spike_count(inDir, outFile):
+def consolidate_spike_count(in_dir, out_file):
     '''Consolidate multiple spike count reports into one.'''
-    with open(outFile, 'wt') as outf:
-        for fn in os.listdir(inDir):
-            fn = os.path.join(inDir, fn)
+    with open(out_file, 'wt') as outf:
+        for fn in os.listdir(in_dir):
+            fn = os.path.join(in_dir, fn)
             s = os.path.basename(fn)
             if not s.endswith('.spike_count.txt'):
                 raise Exception()
@@ -444,8 +444,8 @@ def consolidate_spike_count(inDir, outFile):
 
 
 def parser_consolidate_spike_count(parser=argparse.ArgumentParser()):
-    parser.add_argument('inDir', help='Input spike count directory.')
-    parser.add_argument('outFile', help='Output report file.')
+    parser.add_argument('in_dir', metavar="inDir", help='Input spike count directory.')
+    parser.add_argument('out_file', metavar="outFile", help='Output report file.')
     util.cmd.attach_main(parser, consolidate_spike_count, split_args=True)
     return parser
 
@@ -453,13 +453,13 @@ def parser_consolidate_spike_count(parser=argparse.ArgumentParser()):
 __commands__.append(('consolidate_spike_count', parser_consolidate_spike_count))
 
 
-def aggregate_spike_count(inDir, outFile):
+def aggregate_spike_count(in_dir, out_file):
     '''aggregate multiple spike count reports into one.'''
     spike_in_sample_counts = defaultdict(dict) # For a given spikein ID, map to sample name and corresponding count
     samples_seen = []
-    with open(outFile, 'wt') as outf:
-        for fn in glob.glob(inDir+"*.spike_count.txt"):# os.listdir():
-            #fn = os.path.join(inDir, fn)
+    with open(out_file, 'wt') as outf:
+        for fn in glob.glob(os.path.realpath(in_dir)+"/*.spike_count.txt"):# os.listdir():
+            #fn = os.path.join(in_dir, fn)
             s = os.path.basename(fn)
             if not s.endswith('.spike_count.txt'):
                 raise Exception()
@@ -476,7 +476,7 @@ def aggregate_spike_count(inDir, outFile):
                         spike_in_sample_counts[spike][s] = count
                         #outf.write('\t'.join([s, spike, count]) + '\n')
         outf.write("\t".join(["spike-in"]+samples_seen)+"\n")
-        for spike in spike_in_sample_counts.keys():
+        for spike in sorted(spike_in_sample_counts.keys()):
             row = []
             row.append(spike)
             for s in samples_seen:
@@ -488,8 +488,8 @@ def aggregate_spike_count(inDir, outFile):
 
 
 def parser_aggregate_spike_count(parser=argparse.ArgumentParser()):
-    parser.add_argument('inDir', help='Input spike count directory.')
-    parser.add_argument('outFile', help='Output report file.')
+    parser.add_argument('in_dir', metavar="inDir", help='Input spike count directory.')
+    parser.add_argument('out_file', metavar="outFile", help='Output report file.')
     util.cmd.attach_main(parser, aggregate_spike_count, split_args=True)
     return parser
 


### PR DESCRIPTION
This adds a new function, `aggregate_spike_count`, to `reports.py` to produce a matrix of spike-in counts per-sample from a directory containing array of per-sample spike-in count files. This is in contrast to `consolidate_spike_count` which simply concatenates the count files (without extraneous columns).