### PR TITLE
in picard demux set max_mismatches=0

### DIFF
--- a/pipes/WDL/workflows/tasks/tasks_demux.wdl
+++ b/pipes/WDL/workflows/tasks/tasks_demux.wdl
@@ -37,7 +37,7 @@ task illumina_demux {
 
   String? flowcell
   Int?    minimumBaseQuality = 10
-  Int?    maxMismatches = 1
+  Int?    maxMismatches = 0
   Int?    minMismatchDelta
   Int?    maxNoCalls
   String? readStructure

--- a/tools/picard.py
+++ b/tools/picard.py
@@ -458,7 +458,7 @@ class CollectIlluminaLaneMetricsTool(PicardTools):
 class ExtractIlluminaBarcodesTool(PicardTools):
     subtoolName = 'ExtractIlluminaBarcodes'
     jvmMemDefault = '8g'
-    defaults = {'read_structure': '101T8B8B101T', 'max_mismatches': 1, 'minimum_base_quality': 10, 'num_processors': 0}
+    defaults = {'read_structure': '101T8B8B101T', 'max_mismatches': 0, 'minimum_base_quality': 10, 'num_processors': 0}
     option_list = (
         'read_structure', 'max_mismatches', 'minimum_base_quality', 'min_mismatch_delta', 'max_no_calls',
         'minimum_quality', 'compress_outputs', 'num_processors'


### PR DESCRIPTION
For more stringent demux, in picard demux set max_mismatches=0, from max_mismatches=1.

For larger runs, perhaps we should tolerate 1 mismatch by setting an alternative default [here](https://github.com/broadinstitute/viral-ngs/blob/master/pipes/WDL/workflows/tasks/tasks_demux.wdl#L109)?