### PR TITLE
add optional QC check to filter_lastal_bam

### DIFF
--- a/errors.py
+++ b/errors.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+class QCError(RuntimeError):
+    '''Indicates a failure at a QC step.'''
+    
+    def __init__(self, reason):
+        super(QCError, self).__init__(reason)


### PR DESCRIPTION
This adds an optional QC check to taxon_filter.py::filter_lastal_bam() to raise a `QCError()` if the sample name (bam file basename) begins with any number of negative control prefixes and lastal has identified reads to keep after filtering, where the number of reads is above a thresold of a minimum acceptable read count. This can be enabled via `--errorOnReadsInNegControl`. The readcount threshold can be set via `--negativeControlReadsThreshold` and the negative control prefixes can be set via `--negControlPrefixes` with defaults of "neg, water, NTC". The check has been added to the corresponding WDL file as well (off by default). A new `errors.py` file has been added to store error classes that may be useful across files.

If we end up liking this feature, the QC functionality can be abstracted into a separate class to inspect bam files and be included in various places in the codebase, along with an argparse base object that configures arguments for the QC checker.