### PR TITLE
move metagenomics.py taxlevel_summary to separate task

### DIFF
--- a/pipes/WDL/workflows/demux_metag.wdl
+++ b/pipes/WDL/workflows/demux_metag.wdl
@@ -31,6 +31,10 @@ workflow demux_metag {
     input:
       reads_unmapped_bam = illumina_demux.raw_reads_unaligned_bams,
   }
+  call reports.aggregate_metagenomics_reports as metag_summary_report {
+      input:
+          kraken_summary_reports = kraken.krakenuniq_summary_reports
+  }
   call metagenomics.kaiju as kaiju {
     input:
       reads_unmapped_bam = illumina_demux.raw_reads_unaligned_bams,

--- a/pipes/WDL/workflows/demux_plus.wdl
+++ b/pipes/WDL/workflows/demux_plus.wdl
@@ -39,4 +39,9 @@ workflow demux_plus {
         input:
             reads_unmapped_bam = illumina_demux.raw_reads_unaligned_bams
     }
+
+    call reports.aggregate_metagenomics_reports as metag_summary_report {
+        input:
+            kraken_summary_reports = krakenuniq.krakenuniq_summary_reports
+    }
 }

--- a/pipes/WDL/workflows/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/workflows/tasks/tasks_metagenomics.wdl
@@ -2,11 +2,6 @@ task krakenuniq {
   Array[File] reads_unmapped_bam
   File        krakenuniq_db_tar_lz4  # krakenuniq/{database.kdb,taxonomy}
   File        krona_taxonomy_db_tgz  # taxonomy/taxonomy.tab
-  String     aggregate_taxon_heading_space_separated  = "Viruses" # The taxonomic heading to analyze. More than one can be specified.
-  String     aggregate_taxlevel_focus                 = "species" # species,genus,family,order,class,phylum,kingdom,superkingdom
-  Int?        aggregate_top_N_hits                     = 5 # only include the top N hits from a given sample in the aggregte report
-
-  String aggregate_taxon_heading = sub(aggregate_taxon_heading_space_separated, " ", "_") # replace spaces with underscores for use in filename
 
   parameter_meta {
     krakenuniq_db_tar_lz4:  "stream" # for DNAnexus, until WDL implements the File| type
@@ -51,15 +46,6 @@ task krakenuniq {
 
     wait # for krona_taxonomy_db_tgz to download and extract
 
-    metagenomics.py taxlevel_summary \
-      `cat $OUT_REPORTS` \
-      --csvOut aggregate_taxa_summary_${aggregate_taxon_heading}_by_${aggregate_taxlevel_focus}_top_${aggregate_top_N_hits}_by_sample.csv \
-      --noHist \
-      --taxHeading ${aggregate_taxon_heading_space_separated} \
-      --taxlevelFocus ${aggregate_taxlevel_focus} \
-      --zeroFill --includeRoot --topN ${aggregate_top_N_hits} \
-      --loglevel=DEBUG
-
     # run single-threaded krona on up to nproc samples at once
     parallel -I ,, \
       "metagenomics.py krona \
@@ -73,8 +59,7 @@ task krakenuniq {
 
   output {
     Array[File] krakenuniq_classified_reads    = glob("*.krakenuniq-reads.txt.gz")
-    Array[File] krakenuniq_summary_report      = glob("*.krakenuniq-summary_report.txt")
-    File krakenuniq_aggregate_taxlevel_summary = "aggregate_taxa_summary_${aggregate_taxon_heading}_by_${aggregate_taxlevel_focus}_top_${aggregate_top_N_hits}_by_sample.csv"
+    Array[File] krakenuniq_summary_reports      = glob("*.krakenuniq-summary_report.txt")
     Array[File] krona_report_html              = glob("*.krakenuniq.krona.html")
     String      viralngs_version               = "viral-ngs_version_unknown"
   }

--- a/pipes/WDL/workflows/tasks/tasks_reports.wdl
+++ b/pipes/WDL/workflows/tasks/tasks_reports.wdl
@@ -195,7 +195,7 @@ task spikein_report {
 }
 
 task aggregate_metagenomics_reports {
-  Array[File] kraken_summary_reports 
+  Array[File]+ kraken_summary_reports 
   String     aggregate_taxon_heading_space_separated  = "Viruses" # The taxonomic heading to analyze. More than one can be specified.
   String     aggregate_taxlevel_focus                 = "species" # species,genus,family,order,class,phylum,kingdom,superkingdom
   Int?       aggregate_top_N_hits                     = 5 # only include the top N hits from a given sample in the aggregte report

--- a/pipes/WDL/workflows/tasks/tasks_reports.wdl
+++ b/pipes/WDL/workflows/tasks/tasks_reports.wdl
@@ -194,3 +194,37 @@ task spikein_report {
   }
 }
 
+task aggregate_metagenomics_reports {
+  Array[File] kraken_summary_reports 
+  String     aggregate_taxon_heading_space_separated  = "Viruses" # The taxonomic heading to analyze. More than one can be specified.
+  String     aggregate_taxlevel_focus                 = "species" # species,genus,family,order,class,phylum,kingdom,superkingdom
+  Int?       aggregate_top_N_hits                     = 5 # only include the top N hits from a given sample in the aggregte report
+
+  String aggregate_taxon_heading = sub(aggregate_taxon_heading_space_separated, " ", "_") # replace spaces with underscores for use in filename
+  
+  command {
+    set -ex -o pipefail
+
+    metagenomics.py taxlevel_summary \
+      ${sep=' ' kraken_summary_reports} \
+      --csvOut aggregate_taxa_summary_${aggregate_taxon_heading}_by_${aggregate_taxlevel_focus}_top_${aggregate_top_N_hits}_by_sample.csv \
+      --noHist \
+      --taxHeading ${aggregate_taxon_heading_space_separated} \
+      --taxlevelFocus ${aggregate_taxlevel_focus} \
+      --zeroFill --includeRoot --topN ${aggregate_top_N_hits} \
+      --loglevel=DEBUG
+  }
+
+  output {
+    File krakenuniq_aggregate_taxlevel_summary = "aggregate_taxa_summary_${aggregate_taxon_heading}_by_${aggregate_taxlevel_focus}_top_${aggregate_top_N_hits}_by_sample.csv"
+  }
+
+  runtime {
+    docker: "quay.io/broadinstitute/viral-ngs"
+    memory: "4 GB"
+    cpu: 1
+    dx_instance_type: "mem1_ssd2_x2"
+    preemptible: 0
+  }
+}
+


### PR DESCRIPTION
move metagenomics.py taxlevel_summary to separate WDL task and call this after kraken where it is called; this also allows aggregation of kraken reports created previously or separately