### PR TITLE
add custom demux settings for NextSeq, more stringent barcode Q score threshold for all systems but NovaSeq

### DIFF
--- a/pipes/WDL/dx-launcher/demux_launcher.yml
+++ b/pipes/WDL/dx-launcher/demux_launcher.yml
@@ -98,6 +98,8 @@ runSpec:
       demux_instance_type="mem1_ssd1_x4"
       demux_threads=$(echo "$demux_instance_type" | cut -dx -f2)
       min_base_quality=25
+      max_reads_in_ram_per_tile=1000000
+      max_records_in_ram=2000000
       if [ "$total_tile_count" -le 50 ]; then 
           tar_consolidation_instance_size="mem1_ssd1_x4"
           demux_instance_type="mem1_ssd1_x4"
@@ -119,8 +121,8 @@ runSpec:
           # increase the number of reads in ram per-tile for NextSeq, since the tiles are larger
           # without this setting, reads will spill to disk and may read the limit
           # on the number of files that can be opened
-          max_reads_in_ram_per_tile=1500000 # reduce the number of reads per tile since the NovaSeq has so many
-          max_records_in_ram=2500000
+          max_reads_in_ram_per_tile=200000 # reduce the number of reads per tile since the NovaSeq has so many
+          max_records_in_ram=1500000
           echo "Detected $total_tile_count tiles, interpreting as NextSeq (high-output) run."
       elif [ "$total_tile_count" -le 896 ]; then
           tar_consolidation_instance_size="mem1_ssd1_x32"
@@ -131,6 +133,7 @@ runSpec:
           tar_consolidation_instance_size="mem1_ssd2_x36"
           demux_instance_type="mem1_ssd2_x36"
           min_base_quality=20
+          max_reads_in_ram_per_tile=750000
           demux_threads=20 # with NovaSeq-size output, OOM errors can sporadically occur with higher thread counts
           echo "Detected $total_tile_count tiles, interpreting as NovaSeq run, executing on a $demux_instance_type machine."
           echo "  **Note: Q20 threshold used since NovaSeq with RTA3 writes only four Q-score values: 2, 12, 23, and 37.**"

--- a/pipes/WDL/dx-launcher/demux_launcher.yml
+++ b/pipes/WDL/dx-launcher/demux_launcher.yml
@@ -97,22 +97,34 @@ runSpec:
 
       demux_instance_type="mem1_ssd1_x4"
       demux_threads=$(echo "$demux_instance_type" | cut -dx -f2)
+      min_base_quality=25
       if [ "$total_tile_count" -le 50 ]; then 
           tar_consolidation_instance_size="mem1_ssd1_x4"
           demux_instance_type="mem1_ssd1_x4"
-          min_base_quality=25
           demux_threads=$(echo "$demux_instance_type" | cut -dx -f2)
           echo "Detected $total_tile_count tiles, interpreting as MiSeq run, executing on a $demux_instance_type machine."
       elif [ "$total_tile_count" -le 150 ]; then
           tar_consolidation_instance_size="mem1_ssd2_x4"
           demux_instance_type="mem1_ssd2_x4"
-          min_base_quality=25
           demux_threads=$(echo "$demux_instance_type" | cut -dx -f2)
           echo "Detected $total_tile_count tiles, interpreting as HiSeq2k run, executing on a $demux_instance_type machine."
+      elif [ "$total_tile_count" -le 288 ]; then
+          # increase the number of reads in ram per-tile for NextSeq, since the tiles are larger
+          # without this setting, reads will spill to disk and may read the limit
+          # on the number of files that can be opened
+          max_reads_in_ram_per_tile=1500000
+          max_records_in_ram=2000000
+          echo "Detected $total_tile_count tiles, interpreting as NextSeq (mid-output) run."
+      elif [ "$total_tile_count" -le 864 ]; then
+          # increase the number of reads in ram per-tile for NextSeq, since the tiles are larger
+          # without this setting, reads will spill to disk and may read the limit
+          # on the number of files that can be opened
+          max_reads_in_ram_per_tile=1500000 # reduce the number of reads per tile since the NovaSeq has so many
+          max_records_in_ram=2500000
+          echo "Detected $total_tile_count tiles, interpreting as NextSeq (high-output) run."
       elif [ "$total_tile_count" -le 896 ]; then
           tar_consolidation_instance_size="mem1_ssd1_x32"
           demux_instance_type="mem1_ssd1_x32"
-          min_base_quality=25
           demux_threads=$(echo "$demux_instance_type" | cut -dx -f2)
           echo "Detected $total_tile_count tiles, interpreting as HiSeq4k run, executing on a $demux_instance_type machine."
       elif [ "$total_tile_count" -le 1408 ]; then
@@ -126,7 +138,6 @@ runSpec:
       elif [ "$total_tile_count" -gt 1408 ]; then
           tar_consolidation_instance_size="mem1_ssd2_x36"
           demux_instance_type="mem1_ssd2_x36"
-          min_base_quality=25
           demux_threads=$(echo "$demux_instance_type" | cut -dx -f2)
           echo "Tile count: $total_tile_count tiles, (unknown instrument type), executing on a $demux_instance_type machine."
       fi
@@ -163,7 +174,7 @@ runSpec:
         fi
         for i in $(seq "$lane_count"); do
           folder2=$(printf "%s/%s/reads/L%d" "$folder" "$run_id" $i)
-          runcmd="dx run $demux_workflow_id -i stage-1.flowcell_tgz=$run_tarball -i illumina_demux.lane=$i -i illumina_demux.minimumBaseQuality=$min_base_quality -i illumina_demux.threads=$demux_threads $sequencing_center_input --folder $folder2 --instance-type illumina_demux=$demux_instance_type --name demux:$run_id:L$i -y --brief"
+          runcmd="dx run $demux_workflow_id -i stage-1.flowcell_tgz=$run_tarball -i illumina_demux.lane=$i -i illumina_demux.maxReadsInRamPerTile=$max_reads_in_ram_per_tile -i illumina_demux.maxRecordsInRam=$max_records_in_ram -i illumina_demux.minimumBaseQuality=$min_base_quality -i illumina_demux.threads=$demux_threads $sequencing_center_input --folder $folder2 --instance-type illumina_demux=$demux_instance_type --name demux:$run_id:L$i -y --brief"
           echo "$runcmd"
           set +x
           if [ -n "$api_token" ]; then

--- a/pipes/WDL/workflows/tasks/tasks_demux.wdl
+++ b/pipes/WDL/workflows/tasks/tasks_demux.wdl
@@ -36,7 +36,7 @@ task illumina_demux {
   String? sequencingCenter
 
   String? flowcell
-  Int?    minimumBaseQuality = 10
+  Int?    minimumBaseQuality = 25
   Int?    maxMismatches = 0
   Int?    minMismatchDelta
   Int?    maxNoCalls
@@ -105,11 +105,27 @@ task illumina_demux {
         echo "Detected $total_tile_count tiles, interpreting as MiSeq run."
     elif [ "$total_tile_count" -le 150 ]; then
         echo "Detected $total_tile_count tiles, interpreting as HiSeq2k run."
+    elif [ "$total_tile_count" -le 288 ]; then
+        # increase the number of reads in ram per-tile for NextSeq, since the tiles are larger
+        # without this setting, reads will spill to disk and may read the limit
+        # on the number of files that can be opened
+        max_reads_in_ram_per_tile=1500000
+        max_records_in_ram=2000000
+        echo "Detected $total_tile_count tiles, interpreting as NextSeq (mid-output) run."
+    elif [ "$total_tile_count" -le 864 ]; then
+        # increase the number of reads in ram per-tile for NextSeq, since the tiles are larger
+        # without this setting, reads will spill to disk and may read the limit
+        # on the number of files that can be opened
+        max_reads_in_ram_per_tile=1500000 # reduce the number of reads per tile since the NovaSeq has so many
+        max_records_in_ram=2500000
+        echo "Detected $total_tile_count tiles, interpreting as NextSeq (high-output) run."
     elif [ "$total_tile_count" -le 896 ]; then
         echo "Detected $total_tile_count tiles, interpreting as HiSeq4k run."
     elif [ "$total_tile_count" -le 1408 ]; then
         mem_in_mb=$(/opt/viral-ngs/source/docker/calc_mem.py mb 80)
         demux_threads=20 # with NovaSeq-size output, OOM errors can sporadically occur with higher thread counts
+        max_reads_in_ram_per_tile=200000 # reduce the number of reads per tile since the NovaSeq has so many
+        max_records_in_ram=1500000
         echo "Detected $total_tile_count tiles, interpreting as NovaSeq run."
         echo "  **Note: Q20 threshold used since NovaSeq with RTA3 writes only four Q-score values: 2, 12, 23, and 37.**"
         echo "    See: https://www.illumina.com/content/dam/illumina-marketing/documents/products/appnotes/novaseq-hiseq-q30-app-note-770-2017-010.pdf"

--- a/tools/picard.py
+++ b/tools/picard.py
@@ -458,7 +458,8 @@ class CollectIlluminaLaneMetricsTool(PicardTools):
 class ExtractIlluminaBarcodesTool(PicardTools):
     subtoolName = 'ExtractIlluminaBarcodes'
     jvmMemDefault = '8g'
-    defaults = {'read_structure': '101T8B8B101T', 'max_mismatches': 0, 'minimum_base_quality': 10, 'num_processors': 0}
+    # minimum_base_quality=20 used to accommodate NovaSeq, which with RTA3 writes only four Q-score values: 2, 12, 23, and 37
+    defaults = {'read_structure': '101T8B8B101T', 'max_mismatches': 0, 'minimum_base_quality': 20, 'num_processors': 0}
     option_list = (
         'read_structure', 'max_mismatches', 'minimum_base_quality', 'min_mismatch_delta', 'max_no_calls',
         'minimum_quality', 'compress_outputs', 'num_processors'
@@ -499,8 +500,8 @@ class IlluminaBasecallsToSamTool(PicardTools):
     defaults = {
         'read_structure': '101T8B8B101T',
         'adapters_to_check': ('PAIRED_END', 'NEXTERA_V1', 'NEXTERA_V2'),
-        'max_reads_in_ram_per_tile': 200000,
-        'max_records_in_ram': 1000000,
+        'max_reads_in_ram_per_tile': 1000000,
+        'max_records_in_ram': 2000000,
         'num_processors': 0,
         'include_non_pf_reads': False,
         'compression_level': 7,


### PR DESCRIPTION
In WDL:
* raise `minimum_base_quality` for barcode matching to `25` except for NovaSeq
* increase `max_reads_in_ram_per_tile` and `max_records_in_ram` for NextSeq to account for larger tile size (avoid running out of open file handles)

In py tool defaults for picard:
* increase `minimum_base_quality` from 10 to 20 for more stringent barcode Q score threshold (while still allowing two levels of NovaSeq quality)
