### PR TITLE
update DNAnexus object referenced for the spike-ins DB

### DIFF
--- a/pipes/WDL/dx-defaults-demux_plus.json
+++ b/pipes/WDL/dx-defaults-demux_plus.json
@@ -1,6 +1,6 @@
 {
   "demux_plus.spikein_db":
-    "dx://file-FYvfqyQ0xf5g4Q350gzFP0yz",
+    "dx://file-FZY2v7Q0xf5VBy5FFY3z5fz7",
 
   "demux_plus.bwaDbs": [
     "dx://file-F9k7Bx00Z3ybJjvY3ZVj7Z9P"

--- a/pipes/WDL/dx-defaults-spikein.json
+++ b/pipes/WDL/dx-defaults-spikein.json
@@ -1,4 +1,4 @@
 {
   "spikein.spikein_report.spikein_db":
-    "dx://file-FYvfqyQ0xf5g4Q350gzFP0yz"
+    "dx://file-FZY2v7Q0xf5VBy5FFY3z5fz7"
 }

--- a/travis/install-wdl.sh
+++ b/travis/install-wdl.sh
@@ -21,10 +21,10 @@ cached_fetch_jar_from_github broadinstitute cromwell womtool 33.1
 cached_fetch_jar_from_github broadinstitute cromwell cromwell 33.1
 cached_fetch_jar_from_github dnanexus dxWDL dxWDL 0.72
 
-TGZ=dx-toolkit-v0.255.0-ubuntu-14.04-amd64.tar.gz
+TGZ=dx-toolkit-v0.285.0-ubuntu-16.04-amd64.tar.gz
 if [ ! -f $CACHE_DIR/$TGZ ]; then
 	echo "Fetching $TGZ"
-	wget --quiet https://wiki.dnanexus.com/images/files/$TGZ
+	wget --quiet https://dnanexus-sdk.s3.amazonaws.com/$TGZ
 	mv $TGZ $CACHE_DIR
 else
 	echo "Using cached $TGZ"


### PR DESCRIPTION
the old object had spaces in the sequence of ERCC-00003 from the original source, and these spaces may be interpreted differently by various programs. This changes the reference to one where the spaces have been removed.