### PR TITLE
add .git to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 __pycache__
 tools/conda-cache
 tools/conda-tools
+.git


### PR DESCRIPTION
add .git to .dockerignore to reduce the size of the build context sent to the Docker daemon (all of the files in the pwd)