### PR TITLE
bump Docker viral-baseimage 0.1.14 -> 0.1.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/broadinstitute/viral-baseimage:0.1.14
+FROM quay.io/broadinstitute/viral-baseimage:0.1.15
 
 LABEL maintainer "viral-ngs@broadinstitute.org"
 


### PR DESCRIPTION
version 0.1.15 pins the version of conda installed within the container