### PR TITLE
install conda packages to separate environment within Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,17 +20,20 @@ LABEL maintainer "viral-ngs@broadinstitute.org"
 ENV \
 	INSTALL_PATH="/opt/viral-ngs" \
 	VIRAL_NGS_PATH="/opt/viral-ngs/source" \
-	MINICONDA_PATH="/opt/miniconda"
+	MINICONDA_PATH="/opt/miniconda" \
+	CONDA_DEFAULT_ENV=viral-ngs-env
 ENV \
-	PATH="$VIRAL_NGS_PATH:$MINICONDA_PATH/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
-	CONDA_DEFAULT_ENV=$MINICONDA_PATH \
-	CONDA_PREFIX=$MINICONDA_PATH \
+	PATH="$VIRAL_NGS_PATH:$MINICONDA_PATH/envs/$CONDA_DEFAULT_ENV/bin:$MINICONDA_PATH/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+	CONDA_PREFIX=$MINICONDA_PATH/envs/$CONDA_DEFAULT_ENV \
 	JAVA_HOME=$MINICONDA_PATH
 
 # Prepare viral-ngs user and installation directory
 # Set it up so that this slow & heavy build layer is cached
 # unless the requirements* files or the install scripts actually change
 WORKDIR $INSTALL_PATH
+RUN conda create -n $CONDA_DEFAULT_ENV python=3.6
+RUN echo "source activate $CONDA_DEFAULT_ENV" > ~/.bashrc
+RUN hash -r
 COPY docker/install-viral-ngs.sh $VIRAL_NGS_PATH/docker/
 COPY requirements-minimal.txt $VIRAL_NGS_PATH/
 RUN $VIRAL_NGS_PATH/docker/install-viral-ngs.sh minimal

--- a/docker/install-viral-ngs.sh
+++ b/docker/install-viral-ngs.sh
@@ -15,15 +15,13 @@
 
 set -e -o pipefail
 
+echo "PATH:              ${PATH}"
+echo "INSTALL_PATH:      ${INSTALL_PATH}"
+echo "CONDA_PREFIX:      ${CONDA_PREFIX}"
+echo "VIRAL_NGS_PATH:    ${VIRAL_NGS_PATH}"
+echo "MINICONDA_PATH:    ${MINICONDA_PATH}"
+echo "CONDA_DEFAULT_ENV: ${CONDA_DEFAULT_ENV}"
 CONDA_CHANNEL_STRING="--override-channels -c broad-viral -c conda-forge -c bioconda -c defaults"
-
-mkdir -p $INSTALL_PATH/viral-ngs-etc
-if [ ! -f $INSTALL_PATH/viral-ngs-etc/viral-ngs ]; then
-	ln -s $VIRAL_NGS_PATH $INSTALL_PATH/viral-ngs-etc/viral-ngs
-fi
-if [ ! -f $INSTALL_PATH/viral-ngs-etc/conda-env ]; then
-	ln -s $CONDA_DEFAULT_ENV $INSTALL_PATH/viral-ngs-etc/conda-env
-fi
 
 # setup/install viral-ngs directory tree and conda dependencies
 sync
@@ -33,13 +31,15 @@ if [[ "$1" == "minimal" ]]; then
 	# a more minimal set of tools (smaller docker image?)
 	conda install -y \
 		-q $CONDA_CHANNEL_STRING \
-		--file "$VIRAL_NGS_PATH/requirements-minimal.txt"
+		--file "$VIRAL_NGS_PATH/requirements-minimal.txt" \
+		-p "${CONDA_PREFIX}"
 else
 	conda install -y \
 		-q $CONDA_CHANNEL_STRING \
 		--file "$VIRAL_NGS_PATH/requirements-py3.txt" \
 		--file "$VIRAL_NGS_PATH/requirements-conda.txt" \
-		--file "$VIRAL_NGS_PATH/requirements-conda-tests.txt"
+		--file "$VIRAL_NGS_PATH/requirements-conda-tests.txt" \
+		-p "${CONDA_PREFIX}"
 fi
 
 # clean up


### PR DESCRIPTION
With this PR, conda packages are installed to a separate conda environment within the Docker container rather than within the base environment. This is useful since overriding base env package versions can break conda. This is also another step toward being able to install task-specific dependencies for more minimal Docker containers.