### PR TITLE
Adding logic for default timeouts when running WDL on DNAnexus.

### DIFF
--- a/pipes/WDL/dx-extras.json
+++ b/pipes/WDL/dx-extras.json
@@ -1,0 +1,11 @@
+{
+  "default_task_dx_attributes" : {
+    "runSpec": {
+      "timeoutPolicy": {
+        "*": {
+          "hours": 9
+        }
+      }
+    }
+  }
+}

--- a/travis/build-dx.sh
+++ b/travis/build-dx.sh
@@ -40,6 +40,9 @@ for workflow in pipes/WDL/workflows/*.wdl; do
       CMD_DEFAULTS=""
     fi
 
+    extras_json="pipes/WDL/dx-extras.json"
+    CMD_DEFAULTS+="-extras $extras_json"
+
 	  dx_id=$(java -jar dxWDL.jar compile \
       $workflow $CMD_INPUT $CMD_DEFAULTS -f -verbose \
       -imports pipes/WDL/workflows/tasks/ \


### PR DESCRIPTION
I noticed that some of the CI runs on the DNAnexus platform were failing but the jobs did not terminate for over a month. This PR attempts to add a default timeout of 9 hours to each stage of the given WDL workflow.

Note: I have not tested these changes as I don't have access to the CI system. @mlin, I'm hoping you might be able to help here?