### PR TITLE
pin attrs=19.1.0 for now

### DIFF
--- a/requirements-conda-tests.txt
+++ b/requirements-conda-tests.txt
@@ -4,6 +4,7 @@ lxml=4.3.3
 mock=2.0.0
 pycodestyle=2.2.0
 pytest=4.2.0
+attrs=19.1.0
 pytest-cov==2.6.1
 pytest-mock=1.10.0
 pytest-xdist=1.26.1


### PR DESCRIPTION
See: https://stackoverflow.com/questions/58189683/typeerror-attrib-got-an-unexpected-keyword-argument-convert
This can be removed once pytest has been updated to >5.2.0, which has been started in #989 