### PR TITLE
escape vcf path passed to snpeff

### DIFF
--- a/tools/snpeff.py
+++ b/tools/snpeff.py
@@ -10,6 +10,7 @@ import tempfile
 import logging
 import subprocess
 import shutil
+import shlex
 
 # third-party
 import pysam
@@ -206,7 +207,7 @@ class SnpEff(tools.Tool):
 
         args = [
             '-treatAllAsProteinCoding', 'false', '-t', '-noLog', '-ud', '0', '-noStats', '-noShiftHgvs', genomeToUse,
-            '"'+os.path.realpath(inVcf)+'"'
+            shlex.quote(os.path.realpath(inVcf))
         ]
 
         command_ps = self.execute('ann', args, JVMmemory=JVMmemory)

--- a/tools/snpeff.py
+++ b/tools/snpeff.py
@@ -206,7 +206,7 @@ class SnpEff(tools.Tool):
 
         args = [
             '-treatAllAsProteinCoding', 'false', '-t', '-noLog', '-ud', '0', '-noStats', '-noShiftHgvs', genomeToUse,
-            os.path.realpath(inVcf)
+            '"'+os.path.realpath(inVcf)+'"'
         ]
 
         command_ps = self.execute('ann', args, JVMmemory=JVMmemory)


### PR DESCRIPTION
quote vcf path passed to snpeff so directories with spaces and other escapable characters are read correctly