### PR TITLE
bugfixes and deoptimize

### DIFF
--- a/metagenomics.py
+++ b/metagenomics.py
@@ -821,7 +821,7 @@ def krona(inReport, db, outHtml, queryColumn=None, taxidColumn=None, scoreColumn
                     if '<attribute display="Avg. score">score</attribute>' in line:
                         line = line.replace('Avg. score', 'Est. unique kmers')
                     print(line, file=new_report)
-            os.rename(fn, outHtml)
+            shutil.copyfile(fn, outHtml)
         return
     elif inputType == 'kaiju':
         kaiju = tools.kaiju.Kaiju()

--- a/pipes/WDL/workflows/tasks/tasks_demux.wdl
+++ b/pipes/WDL/workflows/tasks/tasks_demux.wdl
@@ -49,9 +49,9 @@ task illumina_demux {
   Boolean? forceGC=true
 
 
-  parameter_meta {
-    flowcell_tgz : "stream" # for DNAnexus, until WDL implements the File| type
-  }
+#  parameter_meta {
+#    flowcell_tgz : "stream" # for DNAnexus, until WDL implements the File| type
+#  }
 
   command {
     set -ex -o pipefail

--- a/pipes/WDL/workflows/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/workflows/tasks/tasks_metagenomics.wdl
@@ -68,7 +68,7 @@ task krakenuniq {
     docker: "quay.io/broadinstitute/viral-ngs"
     memory: "200 GB"
     cpu: 32
-    dx_instance_type: "mem3_ssd1_v2_x32"
+    dx_instance_type: "mem3_ssd1_x32"
     preemptible: 0
   }
 }

--- a/pipes/WDL/workflows/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/workflows/tasks/tasks_metagenomics.wdl
@@ -3,11 +3,11 @@ task krakenuniq {
   File        krakenuniq_db_tar_lz4  # krakenuniq/{database.kdb,taxonomy}
   File        krona_taxonomy_db_tgz  # taxonomy/taxonomy.tab
 
-  parameter_meta {
-    krakenuniq_db_tar_lz4:  "stream" # for DNAnexus, until WDL implements the File| type
-    krona_taxonomy_db_tgz : "stream" # for DNAnexus, until WDL implements the File| type
-    reads_unmapped_bam: "stream" # for DNAnexus, until WDL implements the File| type
-  }
+#  parameter_meta {
+#    krakenuniq_db_tar_lz4:  "stream" # for DNAnexus, until WDL implements the File| type
+#    krona_taxonomy_db_tgz : "stream" # for DNAnexus, until WDL implements the File| type
+#    reads_unmapped_bam: "stream" # for DNAnexus, until WDL implements the File| type
+#  }
 
   command {
     set -ex -o pipefail
@@ -68,7 +68,7 @@ task krakenuniq {
     docker: "quay.io/broadinstitute/viral-ngs"
     memory: "200 GB"
     cpu: 32
-    dx_instance_type: "mem3_ssd1_x32"
+    dx_instance_type: "mem3_ssd1_v2_x32"
     preemptible: 0
   }
 }

--- a/pipes/WDL/workflows/tasks/tasks_metagenomics.wdl
+++ b/pipes/WDL/workflows/tasks/tasks_metagenomics.wdl
@@ -79,9 +79,9 @@ task krona {
 
   String input_basename = basename(classified_reads_txt_gz, ".txt.gz")
 
-  parameter_meta {
-    krona_taxonomy_db_tgz : "stream" # for DNAnexus, until WDL implements the File| type
-  }
+#  parameter_meta {
+#    krona_taxonomy_db_tgz : "stream" # for DNAnexus, until WDL implements the File| type
+#  }
 
   command {
     set -ex -o pipefail
@@ -122,9 +122,9 @@ task filter_bam_to_taxa {
 
   String input_basename = basename(classified_bam, ".bam")
 
-  parameter_meta {
-    ncbi_taxonomy_db_tgz              : "stream" # for DNAnexus, until WDL implements the File| type
-  }
+#  parameter_meta {
+#    ncbi_taxonomy_db_tgz              : "stream" # for DNAnexus, until WDL implements the File| type
+#  }
 
   command {
     set -ex -o pipefail
@@ -179,11 +179,11 @@ task kaiju {
 
   String input_basename = basename(reads_unmapped_bam, ".bam")
 
-  parameter_meta {
-    kaiju_db_lz4            : "stream" # for DNAnexus, until WDL implements the File| type
-    ncbi_taxonomy_db_tgz    : "stream"
-    krona_taxonomy_db_tgz   : "stream"
-  }
+#  parameter_meta {
+#    kaiju_db_lz4            : "stream" # for DNAnexus, until WDL implements the File| type
+#    ncbi_taxonomy_db_tgz    : "stream"
+#    krona_taxonomy_db_tgz   : "stream"
+#  }
 
   command {
     set -ex -o pipefail

--- a/tools/krona.py
+++ b/tools/krona.py
@@ -5,7 +5,7 @@ from os.path import join
 from builtins import super
 
 TOOL_NAME = 'krona'
-CONDA_TOOL_VERSION = '2.7'
+CONDA_TOOL_VERSION = '2.7.1'
 
 
 class Krona(tools.Tool):


### PR DESCRIPTION
1. Comment out all `parameter_meta` `stream` hinting in WDL for large input files until we resolve what's going suboptimally with us regarding `dxfuse` behavior. We can revert later once we sort that out. Meanwhile, the new `dxda` localization method appears to have improved localization speeds to about 2Gbps.
2. Bugfix: version mismatch between `requirements.txt` and `tools/krona.py` on Krona version number.
3. Bugfix: post-krona processing had an `os.rename` instead of `shutil.copyfile` and was broken whenever the output file resided on a different file system from the TMPDIR (which is true in most execution contexts).