### PR TITLE
handle when gatk jar is in subdir

### DIFF
--- a/pipes/WDL/workflows/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/workflows/tasks/tasks_assembly.wdl
@@ -194,6 +194,8 @@ task refine {
         mkdir gatk
         if [[ ${gatk_jar} == *.tar.bz2 ]]; then
           tar -xjvof ${gatk_jar} -C gatk
+          # find the jar and move it one level up if it is buried in a subdir
+          find gatk -mindepth 1 -type f -iname '*.jar' -exec mv -f '{}' gatk/ \;
         else
           ln -s ${gatk_jar} gatk/GenomeAnalysisTK.jar
         fi
@@ -266,6 +268,8 @@ task refine_2x_and_plot {
         mkdir gatk
         if [[ ${gatk_jar} == *.tar.bz2 ]]; then
           tar -xjvof ${gatk_jar} -C gatk
+          # find the jar and move it one level up if it is buried in a subdir
+          find gatk -mindepth 1 -type f -iname '*.jar' -exec mv -f '{}' gatk/ \;
         else
           ln -s ${gatk_jar} gatk/GenomeAnalysisTK.jar
         fi

--- a/pipes/WDL/workflows/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/workflows/tasks/tasks_assembly.wdl
@@ -195,7 +195,7 @@ task refine {
         if [[ ${gatk_jar} == *.tar.bz2 ]]; then
           tar -xjvof ${gatk_jar} -C gatk
           # find the jar and move it one level up if it is buried in a subdir
-          find gatk -mindepth 1 -type f -iname '*.jar' -exec mv -f '{}' gatk/ \;
+          find gatk -mindepth 1 -type f -iname '*.jar' | xargs -I__ mv -f "__" gatk/
         else
           ln -s ${gatk_jar} gatk/GenomeAnalysisTK.jar
         fi
@@ -269,7 +269,7 @@ task refine_2x_and_plot {
         if [[ ${gatk_jar} == *.tar.bz2 ]]; then
           tar -xjvof ${gatk_jar} -C gatk
           # find the jar and move it one level up if it is buried in a subdir
-          find gatk -mindepth 1 -type f -iname '*.jar' -exec mv -f '{}' gatk/ \;
+          find gatk -mindepth 1 -type f -iname '*.jar' | xargs -I__ mv -f "__" gatk/
         else
           ln -s ${gatk_jar} gatk/GenomeAnalysisTK.jar
         fi

--- a/pipes/WDL/workflows/tasks/tasks_reports.wdl
+++ b/pipes/WDL/workflows/tasks/tasks_reports.wdl
@@ -27,7 +27,7 @@ task plot_coverage {
     if [[ ${gatk_jar} == *.tar.bz2 ]]; then
       tar -xjvof ${gatk_jar} -C gatk
       # find the jar and move it one level up if it is buried in a subdir
-      find gatk -mindepth 1 -type f -iname '*.jar' -exec mv -f '{}' gatk/ \;
+      find gatk -mindepth 1 -type f -iname '*.jar' | xargs -I__ mv -f "__" gatk/
     else
       ln -s ${gatk_jar} gatk/GenomeAnalysisTK.jar
     fi

--- a/pipes/WDL/workflows/tasks/tasks_reports.wdl
+++ b/pipes/WDL/workflows/tasks/tasks_reports.wdl
@@ -26,6 +26,8 @@ task plot_coverage {
     mkdir gatk
     if [[ ${gatk_jar} == *.tar.bz2 ]]; then
       tar -xjvof ${gatk_jar} -C gatk
+      # find the jar and move it one level up if it is buried in a subdir
+      find gatk -mindepth 1 -type f -iname '*.jar' -exec mv -f '{}' gatk/ \;
     else
       ln -s ${gatk_jar} gatk/GenomeAnalysisTK.jar
     fi


### PR DESCRIPTION
gatk 3.8-1 is packed as a bz2 such that when extracted the jar file is found within a subdirectory, in contrast to earlier versions where it is at the top level. This commit searches any subdirs for the jar and moves it to the top level of the extracted path if found