### PR TITLE
add krakenuniq summary kmer filter

### DIFF
--- a/metagenomics.py
+++ b/metagenomics.py
@@ -1119,7 +1119,7 @@ def krakenuniq_report_filter(summary_file_in, summary_file_out, field_to_filter,
     """
         Filter a krakenuniq report by field to include rows above some threshold, 
         where contributions to the value from subordinate levels
-        are first removed from the value.
+        are removed from the value and the value of superior levels.
     """
 
     # class to represent taxonomic tree
@@ -1319,8 +1319,6 @@ def krakenuniq_report_filter(summary_file_in, summary_file_out, field_to_filter,
             to correct numeric values prior to an operation
             to output only those nodes above some value.
         """
-        total_number_of_reads = float(node.data["num_reads"])/float(node.data["pct_of_reads"])
-
         if node.has_children:
             for child in node.children:
                 subtract_low_values_with_upward_propagation(child, field_to_filter, keep_threshold, fields_to_adjust)

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -1078,8 +1078,8 @@ def filter_bam_to_taxa(in_bam, read_IDs_to_tax_IDs, out_bam,
 __commands__.append(('filter_bam_to_taxa', parser_filter_bam_to_taxa))
 
 def parser_krakenuniq_report_filter(parser=argparse.ArgumentParser()):
-    parser.add_argument('summary_file_in', help='Input KrakenUNiq-format summary text file with tab-delimited fields and indented taxonomic levels.')
-    parser.add_argument('summary_file_out', help='Output KrakenUNiq-format summary text file with tab-delimited fields and indented taxonomic levels.')
+    parser.add_argument('summary_file_in', help='Input KrakenUniq-format summary text file with tab-delimited fields and indented taxonomic levels.')
+    parser.add_argument('summary_file_out', help='Output KrakenUniq-format summary text file with tab-delimited fields and indented taxonomic levels.')
     parser.add_argument('--fieldToFilterOn', 
                             choices=[
                                 "num_reads",


### PR DESCRIPTION
To address https://github.com/broadinstitute/viral-classify/issues/1, this adds a new command, `krakenuniq_report_filter`, to `metagenomics.py`:

```
usage: metagenomics.py subcommand krakenuniq_report_filter [-h]
                                                           [--fieldToFilterOn {num_reads,uniq_kmers}]
                                                           [--fieldToAdjust {num_reads,uniq_kmers} [{num_reads,uniq_kmers} ...]]
                                                           [--keepAboveN KEEP_THRESHOLD]
                                                           [--loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL,EXCEPTION}]
                                                           [--version]
                                                           [--tmp_dir TMP_DIR]
                                                           [--tmp_dirKeep]
                                                           summary_file_in
                                                           summary_file_out

Filter a krakenuniq report by field to include rows above some threshold,
where contributions to the value from subordinate levels are first removed
from the value.

positional arguments:
  summary_file_in       Input KrakenUNiq-format summary text file with tab-
                        delimited fields and indented taxonomic levels.
  summary_file_out      Output KrakenUNiq-format summary text file with tab-
                        delimited fields and indented taxonomic levels.

optional arguments:
  -h, --help            show this help message and exit
  --fieldToFilterOn {num_reads,uniq_kmers}
                        The field to filter on (default: uniq_kmers).
  --fieldToAdjust {num_reads,uniq_kmers} [{num_reads,uniq_kmers} ...]
                        The field to adjust along with the --fieldToFilterOn
                        (default: ['num_reads']).
  --keepAboveN KEEP_THRESHOLD
                        Only taxa with values above this will be kept. Higher
                        taxonomic ranks will have their values reduced by the
                        values of removed sub-ranks (default: 100)
  --loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL,EXCEPTION}
                        Verboseness of output. [default: INFO]
  --version, -V         show program's version number and exit
  --tmp_dir TMP_DIR     Base directory for temp files. [default:
                        /var/folders/bx/90px0g1n1v122slzjnyvrsk5gn42vm/T/]
  --tmp_dirKeep         Keep the tmp_dir if an exception occurs while running.
                        Default is to delete all temp files at the end, even
                        if there's a failure. (default: False)
```

The behavior of this command is such that using a depth-first traversal, the lowest rows in the report have the value in the field specified by `--fieldToFilterOn` (default: `uniq_kmers`) zeroed out if their value is below the threshold given by `--keepAboveN` (default: `100`). Under the assumption that higher taxonomic levels have cumulative values including contributions from the zeroed-out rows, the values of the selected field in higher levels are reduced by the amount contained within lower-levels that were below the specified threshold (the subtraction is propagated up the tree to the root node). Since the traversal is depth-first, the higher levels are eventually re-evaluated to see if they no longer meet the threshold after being subjected to subtraction of their lower levels.

The hierarchy of rows is read based on the indentation of the `taxName` column since many rows do not have a formal taxonomic rank assigned (i.e. their rank is "`no rank`").

Secondarily, the fields specified by `--fieldToAdjust` (default: `num_reads`) are similarly adjusted using the conditional threshold established by `--keepAboveN` and `--fieldToFilterOn`: their values are subtracted similarly, with propagation up the tree. 

After adjustment to these counts across the entire tree, the part-of-whole percentages for the rows are reflected to reflect the new read counts. The resulting tree is then written out to a new KrakenUniq-format report, filtered to include only those rows meeting the initial threshold criterion.