### PR TITLE
More robust determination of GATK version

### DIFF
--- a/pipes/WDL/workflows/tasks/tasks_assembly.wdl
+++ b/pipes/WDL/workflows/tasks/tasks_assembly.wdl
@@ -269,7 +269,7 @@ task refine_2x_and_plot {
         if [[ ${gatk_jar} == *.tar.bz2 ]]; then
           tar -xjvof ${gatk_jar} -C gatk
           # find the jar and move it one level up if it is buried in a subdir
-          find gatk -mindepth 1 -type f -iname '*.jar' | xargs -I__ mv -f "__" gatk/
+          find gatk -mindepth 2 -type f -iname '*.jar' | xargs -I__ mv -f "__" gatk/
         else
           ln -s ${gatk_jar} gatk/GenomeAnalysisTK.jar
         fi

--- a/tools/gatk.py
+++ b/tools/gatk.py
@@ -78,7 +78,7 @@ class GATKTool(tools.Tool):
         return self.tool_version
 
     def version_tuple(self):
-        version_match = re.match('(\d+)\.(\d+)', self.version())
+        version_match = re.match(r'(\d+)\.(\d+)', self.version())
         util.misc.chk(version_match, 'Cannot parse GATK version: {}'.format(self.version()))
         return tuple(map(int, version_match.groups()))
 

--- a/tools/gatk.py
+++ b/tools/gatk.py
@@ -93,7 +93,8 @@ class GATKTool(tools.Tool):
                 self.install_and_get_path(), '--version'
             ]
 
-        self.tool_version = util.misc.run_and_print(cmd, buffered=False, silent=True).stdout.decode("utf-8").strip()
+        self.tool_version = util.misc.run_and_print(cmd, buffered=False, silent=True,
+                                                    stderr=subprocess.DEVNULL).stdout.decode("utf-8").strip()
 
     def ug(self, inBam, refFasta, outVcf, options=None, JVMmemory=None, threads=None):
         options = options or ["--min_base_quality_score", 15, "-ploidy", 4]

--- a/tools/gatk.py
+++ b/tools/gatk.py
@@ -15,6 +15,7 @@ import util.misc
 import logging
 import os
 import os.path
+import re
 import subprocess
 import tempfile
 
@@ -76,6 +77,9 @@ class GATKTool(tools.Tool):
             self._get_tool_version()
         return self.tool_version
 
+    def version_tuple(self):
+        return tuple(map(int, re.match('(\d+)\.(\d+)', self.version()).groups()))
+
     def _get_tool_version(self):
         if self.install_and_get_path().endswith(".jar"):
             cmd = [
@@ -105,7 +109,7 @@ class GATKTool(tools.Tool):
             '--num_threads', threads,
             '-A', 'AlleleBalance',
         ]
-        if TOOL_VERSION_TUPLE < (3, 7):
+        if self.version_tuple() < (3, 7):
             opts += ['-stand_call_conf', 0, '-stand_emit_conf', 0]  # deprecated in 3.7+
 
         self.execute('UnifiedGenotyper', opts + options, JVMmemory=JVMmemory)

--- a/tools/gatk.py
+++ b/tools/gatk.py
@@ -78,7 +78,9 @@ class GATKTool(tools.Tool):
         return self.tool_version
 
     def version_tuple(self):
-        return tuple(map(int, re.match('(\d+)\.(\d+)', self.version()).groups()))
+        version_match = re.match('(\d+)\.(\d+)', self.version())
+        util.misc.chk(version_match, 'Cannot parse GATK version: {}'.format(self.version()))
+        return tuple(map(int, version_match.groups()))
 
     def _get_tool_version(self):
         if self.install_and_get_path().endswith(".jar"):

--- a/travis/install-gatk.sh
+++ b/travis/install-gatk.sh
@@ -3,7 +3,7 @@ set -e -o pipefail
 
 GATK_VERSION=3.8
 GATK_BUILD=1-0-gf15c1c3ef
-GATK_URL="https://software.broadinstitute.org/gatk/download/auth?package=GATK-archive&version=${GATK_VERSION}-${GATK_BUILD}"
+GATK_URL="https://storage.googleapis.com/gatk-software/package-archive/gatk/GenomeAnalysisTK-${GATK_VERSION}-${GATK_BUILD}.tar.bz2"
 GATK_TAR=GenomeAnalysisTK-${GATK_VERSION}.tar
 GATK_JAR=${CACHE_DIR}/GenomeAnalysisTK.jar
 GATK_JAR_MD5=186aee868bb7cffc18007966ace8d053


### PR DESCRIPTION
When determining GATK version (e.g. for choosing version-specific switches), base it on the actual GATK jar, rather than on tools.gatk.TOOL_VERSION_TUPLE .  Fix how GATK jar is extracted in refine_2x_and_plot task.

This PR includes the GATK URL updates from #1003 to make testing work.