### PR TITLE
Add all-tests-pass aggregator job for branch protection

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1433,6 +1433,41 @@ jobs:
               -n auto
 
   # ============================================================================
+  # AGGREGATOR JOB - Single status check for branch protection
+  # This job always runs and reports combined test status, allowing conditional
+  # test jobs to be skipped without blocking PRs that don't need those tests.
+  # ============================================================================
+
+  all-tests-pass:
+    if: always()
+    needs:
+      - test-core
+      - test-core-arm64
+      - test-assemble
+      - test-assemble-arm64
+      - test-classify
+      - test-classify-arm64
+      - test-phylo
+      - test-phylo-arm64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test results
+        run: |
+          # Get all job results
+          results="${{ join(needs.*.result, ' ') }}"
+          echo "Job results: $results"
+
+          # Fail if any job failed or was cancelled
+          for result in $results; do
+            if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
+              echo "One or more test jobs failed or were cancelled"
+              exit 1
+            fi
+          done
+
+          echo "All test jobs passed or were skipped"
+
+  # ============================================================================
   # DEPLOY JOBS - Copy images from GHCR to Quay after tests pass
   # Uses crane to efficiently copy multi-arch manifests without re-pulling layers
   # ============================================================================
@@ -1446,10 +1481,7 @@ jobs:
       create-manifest-classify,
       create-manifest-phylo,
       create-manifest-mega,
-      test-core,
-      test-assemble,
-      test-classify,
-      test-phylo
+      all-tests-pass
     ]
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a single `all-tests-pass` status check job that can be used as the required check in branch protection rules
- The job always runs (using `if: always()`) even when tests are skipped
- Depends on all 8 test jobs (4 x86 + 4 ARM64)
- Fails only if any test actually failed or was cancelled
- Succeeds if all tests passed or were skipped
- Updates `deploy-to-quay` to depend on `all-tests-pass` instead of individual test jobs

## Motivation
Fixes the issue where PRs that don't trigger tests (e.g., PR #1021 which only modifies `.codecov.yml`) get stuck because GitHub treats "skipped" status as not satisfying required checks.

## Test plan
- [ ] This PR itself will exercise the new job - since it only changes the workflow file, tests will be skipped but `all-tests-pass` should succeed
- [ ] After merge, update branch protection to require `all-tests-pass` instead of individual test jobs
- [ ] PR #1021 can then be rebased/updated and should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)