### PR TITLE
Fix Codecov coverage reporting with paths-filter

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,6 +10,34 @@ coverage:
       default:
         informational: true  # Never fails, just shows patch coverage
 
+# Flag configuration for multi-component coverage
+flags:
+  core:
+    paths:
+      - src/viral_ngs/core/
+      - src/viral_ngs/util/
+      - src/viral_ngs/*.py
+    carryforward: true
+  assemble:
+    paths:
+      - src/viral_ngs/assemble/
+      - src/viral_ngs/assembly.py
+    carryforward: true
+  classify:
+    paths:
+      - src/viral_ngs/classify/
+      - src/viral_ngs/metagenomics.py
+      - src/viral_ngs/taxon_filter.py
+      - src/viral_ngs/kmer_utils.py
+    carryforward: true
+  phylo:
+    paths:
+      - src/viral_ngs/phylo/
+      - src/viral_ngs/interhost.py
+      - src/viral_ngs/intrahost.py
+      - src/viral_ngs/ncbi.py
+    carryforward: true
+
 comment:
   layout: "reach,diff,flags,files"
   behavior: default

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1071,7 +1071,12 @@ jobs:
   # Test core (x86)
   test-core:
     needs: [paths-filter, get-version, create-manifest-core]
-    if: needs.paths-filter.outputs.core == 'true' || needs.paths-filter.outputs.docker == 'true'
+    if: |
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/main' ||
+      github.ref_type == 'tag' ||
+      needs.paths-filter.outputs.core == 'true' ||
+      needs.paths-filter.outputs.docker == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1110,6 +1115,7 @@ jobs:
               -n auto
 
       - name: Upload coverage to Codecov
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || github.ref_type == 'tag'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -1162,7 +1168,13 @@ jobs:
   # Test assemble (x86)
   test-assemble:
     needs: [paths-filter, get-version, create-manifest-assemble]
-    if: needs.paths-filter.outputs.assemble == 'true' || needs.paths-filter.outputs.core == 'true' || needs.paths-filter.outputs.docker == 'true'
+    if: |
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/main' ||
+      github.ref_type == 'tag' ||
+      needs.paths-filter.outputs.assemble == 'true' ||
+      needs.paths-filter.outputs.core == 'true' ||
+      needs.paths-filter.outputs.docker == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1201,6 +1213,7 @@ jobs:
               -n auto
 
       - name: Upload coverage to Codecov
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || github.ref_type == 'tag'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -1253,7 +1266,13 @@ jobs:
   # Test classify (x86)
   test-classify:
     needs: [paths-filter, get-version, create-manifest-classify]
-    if: needs.paths-filter.outputs.classify == 'true' || needs.paths-filter.outputs.core == 'true' || needs.paths-filter.outputs.docker == 'true'
+    if: |
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/main' ||
+      github.ref_type == 'tag' ||
+      needs.paths-filter.outputs.classify == 'true' ||
+      needs.paths-filter.outputs.core == 'true' ||
+      needs.paths-filter.outputs.docker == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1292,6 +1311,7 @@ jobs:
               -n auto
 
       - name: Upload coverage to Codecov
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || github.ref_type == 'tag'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -1344,7 +1364,13 @@ jobs:
   # Test phylo (x86)
   test-phylo:
     needs: [paths-filter, get-version, create-manifest-phylo]
-    if: needs.paths-filter.outputs.phylo == 'true' || needs.paths-filter.outputs.core == 'true' || needs.paths-filter.outputs.docker == 'true'
+    if: |
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/main' ||
+      github.ref_type == 'tag' ||
+      needs.paths-filter.outputs.phylo == 'true' ||
+      needs.paths-filter.outputs.core == 'true' ||
+      needs.paths-filter.outputs.docker == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1383,6 +1409,7 @@ jobs:
               -n auto
 
       - name: Upload coverage to Codecov
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || github.ref_type == 'tag'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

- Run full test suite on PRs, main branch, and tags to ensure complete coverage uploads
- Feature branch pushes continue to use selective testing via paths-filter but skip coverage upload
- Add flag definitions with `carryforward: true` to `.codecov.yml`

## Problem

1. **Duplicate coverage uploads**: Same commit gets coverage from both branch push AND PR event
2. **Incomplete coverage on feature branches**: Selective testing via dorny/paths-filter means missing flags in Codecov
3. **Codecov confusion**: No differentiation between authoritative (PR/main) and partial (feature branch) coverage reports

## Solution

| Event | Tests Run | Coverage Uploaded |
|-------|-----------|-------------------|
| PR to main | ALL (full suite) | Yes |
| Push to main | ALL (full suite) | Yes |
| Push to feature branch | Selective (paths-filter) | No |
| Tag (v*) | ALL (full suite) | Yes |

## Test plan

- [ ] Push to feature branch - verify selective tests run, no coverage upload
- [ ] Open PR - verify ALL tests run, coverage uploads with all 4 flags
- [ ] Check Codecov dashboard - verify complete coverage report

🤖 Generated with [Claude Code](https://claude.com/claude-code)