### PR TITLE
Fix workflow tag triggers and CodeQL alert

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ on:
       - main
       - '**'
     tags:
-      - 'v*'
+      - '**'
   pull_request:
     branches:
       - main
@@ -93,9 +93,9 @@ jobs:
       - name: Get version from git describe
         id: version
         run: |
-          # Get version like: v1.25.0 or v1.25.0-42-gabcdef
-          # Use --match 'v*' to only match version tags (not archive/* tags)
-          RAW_VERSION=$(git describe --tags --always --match 'v*')
+          # Get version like: v1.25.0, 3.0.0, or v1.25.0-42-gabcdef
+          # Match version tags with or without 'v' prefix, excluding archive/* tags
+          RAW_VERSION=$(git describe --tags --always --match 'v*' --match '[0-9]*')
           # Strip leading 'v' if present
           RAW_VERSION=${RAW_VERSION#v}
 
@@ -1477,6 +1477,7 @@ jobs:
       - test-phylo
       - test-phylo-arm64
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Check test results
         run: |


### PR DESCRIPTION
## Summary
- Change tag trigger from `v*` to `**` to allow any tag format (e.g., `3.0.0` without `v` prefix)
- Add `--match '[0-9]*'` to `git describe` to match version tags without `v` prefix
- Add `permissions: {}` to `all-tests-pass` job to fix CodeQL alert #10

## Context
The v3.0.0 release was published with tag `3.0.0` but the workflow only triggered on `v*` tags. This change makes the workflow more flexible to handle either format while still excluding `archive/*` tags from version detection.

## Test plan
- [ ] After merge, verify workflow triggers on existing `3.0.0` tag (or re-push it)
- [ ] Verify CodeQL alert #10 auto-closes on next scan

🤖 Generated with [Claude Code](https://claude.ai/code)