### PR TITLE
Fix deploy-to-quay job being skipped

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1511,7 +1511,20 @@ jobs:
       create-manifest-mega,
       all-tests-pass
     ]
-    if: github.event_name != 'pull_request'
+    # Use always() to evaluate condition even when upstream jobs were skipped.
+    # Without this, GitHub skips this job if any job in the dependency chain was skipped,
+    # even if all direct dependencies succeeded.
+    if: |
+      always() &&
+      !cancelled() &&
+      needs.all-tests-pass.result == 'success' &&
+      needs.create-manifest-baseimage.result == 'success' &&
+      needs.create-manifest-core.result == 'success' &&
+      needs.create-manifest-assemble.result == 'success' &&
+      needs.create-manifest-classify.result == 'success' &&
+      needs.create-manifest-phylo.result == 'success' &&
+      needs.create-manifest-mega.result == 'success' &&
+      github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
Fixes the deploy-to-quay job being incorrectly skipped on all runs since PR #1023.

## Problem
Since PR #1023 added the all-tests-pass job, deploy-to-quay has been skipped on every run. This is a GitHub Actions quirk:

1. Some ARM64 test jobs are skipped (they only run on main/tags with matching path changes)
2. The all-tests-pass job uses if: always() which runs regardless of skipped deps
3. But deploy-to-quay depends on all-tests-pass WITHOUT if: always()
4. GitHub default behavior: if any upstream job in the dependency chain was skipped, downstream jobs skip too

**Evidence:**
- Run 21675896602 (before PR #1023): deploy-to-quay succeeded
- Run 21679131979 (PR #1023 merge): deploy-to-quay skipped
- All subsequent runs: deploy-to-quay skipped

## Solution
Use always() to force condition evaluation, then explicitly check that all required jobs succeeded.

## Test plan
- [ ] Verify deploy-to-quay runs on next main branch push
- [ ] Verify images appear on Quay.io after workflow completes