### PR TITLE
Move quay expiration annotation to manifest creation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -238,7 +238,7 @@ jobs:
           # Add expiration annotation for feature branches (copied to Quay by crane)
           EXPIRE_ANNOTATION=""
           if [[ "${{ github.ref_type }}" == "branch" && "${{ github.ref_name }}" != "main" ]]; then
-            EXPIRE_ANNOTATION='--annotation "index:quay.expires-after=10w"'
+            EXPIRE_ANNOTATION='--annotation index:quay.expires-after=10w'
           fi
 
           # Create manifest with OCI annotations
@@ -407,7 +407,7 @@ jobs:
           # Add expiration annotation for feature branches (copied to Quay by crane)
           EXPIRE_ANNOTATION=""
           if [[ "${{ github.ref_type }}" == "branch" && "${{ github.ref_name }}" != "main" ]]; then
-            EXPIRE_ANNOTATION='--annotation "index:quay.expires-after=10w"'
+            EXPIRE_ANNOTATION='--annotation index:quay.expires-after=10w'
           fi
 
           docker buildx imagetools create \
@@ -573,7 +573,7 @@ jobs:
           # Add expiration annotation for feature branches (copied to Quay by crane)
           EXPIRE_ANNOTATION=""
           if [[ "${{ github.ref_type }}" == "branch" && "${{ github.ref_name }}" != "main" ]]; then
-            EXPIRE_ANNOTATION='--annotation "index:quay.expires-after=10w"'
+            EXPIRE_ANNOTATION='--annotation index:quay.expires-after=10w'
           fi
 
           docker buildx imagetools create \
@@ -739,7 +739,7 @@ jobs:
           # Add expiration annotation for feature branches (copied to Quay by crane)
           EXPIRE_ANNOTATION=""
           if [[ "${{ github.ref_type }}" == "branch" && "${{ github.ref_name }}" != "main" ]]; then
-            EXPIRE_ANNOTATION='--annotation "index:quay.expires-after=10w"'
+            EXPIRE_ANNOTATION='--annotation index:quay.expires-after=10w'
           fi
 
           docker buildx imagetools create \
@@ -905,7 +905,7 @@ jobs:
           # Add expiration annotation for feature branches (copied to Quay by crane)
           EXPIRE_ANNOTATION=""
           if [[ "${{ github.ref_type }}" == "branch" && "${{ github.ref_name }}" != "main" ]]; then
-            EXPIRE_ANNOTATION='--annotation "index:quay.expires-after=10w"'
+            EXPIRE_ANNOTATION='--annotation index:quay.expires-after=10w'
           fi
 
           docker buildx imagetools create \
@@ -1065,7 +1065,7 @@ jobs:
           # Add expiration annotation for feature branches (copied to Quay by crane)
           EXPIRE_ANNOTATION=""
           if [[ "${{ github.ref_type }}" == "branch" && "${{ github.ref_name }}" != "main" ]]; then
-            EXPIRE_ANNOTATION='--annotation "index:quay.expires-after=10w"'
+            EXPIRE_ANNOTATION='--annotation index:quay.expires-after=10w'
           fi
 
           docker buildx imagetools create \


### PR DESCRIPTION
## Summary
Fixes the failing 'Add expiration annotation for feature branches' step in deploy-to-quay.

## Problem
The step was failing with:
```
ERROR: "" annotations are not supported yet
```

This happens because `docker buildx imagetools create` doesn't support `--annotation` when re-tagging an existing image to itself - it only works when creating a new manifest from multiple sources.

## Solution
- Add the `quay.expires-after=10w` annotation during manifest creation on GHCR (for non-main branches)
- The annotation is then copied to Quay automatically by crane
- Remove the failing step from deploy-to-quay

## Additional improvement
Added `org.opencontainers.image.authors` annotation to all multi-arch manifests for better OCI metadata completeness.

## Test plan
- [ ] Verify feature branch builds succeed with expiration annotation
- [ ] Verify annotations appear on GHCR manifests