### PR TITLE
Use Docker LABEL for Quay image expiration

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -165,6 +165,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-baseimage-amd64
+          labels: ${{ github.ref_type == 'branch' && github.ref_name != 'main' && 'quay.expires-after=10w' || '' }}
           cache-from: |
             type=registry,ref=${{ env.GHCR_REPO }}:cache-baseimage-amd64-${{ needs.get-version.outputs.image-tag-prefix }}
             type=registry,ref=${{ env.GHCR_REPO }}:cache-baseimage-amd64-main
@@ -203,6 +204,7 @@ jobs:
           platforms: linux/arm64
           push: true
           tags: ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-baseimage-arm64
+          labels: ${{ github.ref_type == 'branch' && github.ref_name != 'main' && 'quay.expires-after=10w' || '' }}
           cache-from: |
             type=registry,ref=${{ env.GHCR_REPO }}:cache-baseimage-arm64-${{ needs.get-version.outputs.image-tag-prefix }}
             type=registry,ref=${{ env.GHCR_REPO }}:cache-baseimage-arm64-main
@@ -235,19 +237,12 @@ jobs:
 
       - name: Create multi-arch manifest
         run: |
-          # Add expiration annotation for feature branches (copied to Quay by crane)
-          EXPIRE_ANNOTATION=""
-          if [[ "${{ github.ref_type }}" == "branch" && "${{ github.ref_name }}" != "main" ]]; then
-            EXPIRE_ANNOTATION='--annotation index:quay.expires-after=10w'
-          fi
-
           # Create manifest with OCI annotations
           docker buildx imagetools create \
             --annotation "index:org.opencontainers.image.source=https://github.com/broadinstitute/viral-ngs" \
             --annotation "index:org.opencontainers.image.description=Viral genomics analysis tools - base image" \
             --annotation "index:org.opencontainers.image.licenses=MIT" \
             --annotation "index:org.opencontainers.image.authors=viral-ngs@broadinstitute.org" \
-            $EXPIRE_ANNOTATION \
             --tag ${{ env.GHCR_REPO }}:${{ steps.get-tag.outputs.tag }} \
             ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-baseimage-amd64 \
             ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-baseimage-arm64
@@ -324,6 +319,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-core-amd64
+          labels: ${{ github.ref_type == 'branch' && github.ref_name != 'main' && 'quay.expires-after=10w' || '' }}
           build-args: |
             BASEIMAGE=${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-baseimage-amd64
             VERSION=${{ needs.get-version.outputs.version }}
@@ -367,6 +363,7 @@ jobs:
           platforms: linux/arm64
           push: true
           tags: ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-core-arm64
+          labels: ${{ github.ref_type == 'branch' && github.ref_name != 'main' && 'quay.expires-after=10w' || '' }}
           build-args: |
             BASEIMAGE=${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-baseimage-arm64
             VERSION=${{ needs.get-version.outputs.version }}
@@ -404,18 +401,11 @@ jobs:
 
       - name: Create multi-arch manifest
         run: |
-          # Add expiration annotation for feature branches (copied to Quay by crane)
-          EXPIRE_ANNOTATION=""
-          if [[ "${{ github.ref_type }}" == "branch" && "${{ github.ref_name }}" != "main" ]]; then
-            EXPIRE_ANNOTATION='--annotation index:quay.expires-after=10w'
-          fi
-
           docker buildx imagetools create \
             --annotation "index:org.opencontainers.image.source=https://github.com/broadinstitute/viral-ngs" \
             --annotation "index:org.opencontainers.image.description=Viral genomics analysis tools - core utilities" \
             --annotation "index:org.opencontainers.image.licenses=MIT" \
             --annotation "index:org.opencontainers.image.authors=viral-ngs@broadinstitute.org" \
-            $EXPIRE_ANNOTATION \
             --tag ${{ env.GHCR_REPO }}:${{ steps.get-tag.outputs.tag }} \
             ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-core-amd64 \
             ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-core-arm64
@@ -490,6 +480,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-assemble-amd64
+          labels: ${{ github.ref_type == 'branch' && github.ref_name != 'main' && 'quay.expires-after=10w' || '' }}
           build-args: |
             BASEIMAGE=${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-core-amd64
             VERSION=${{ needs.get-version.outputs.version }}
@@ -533,6 +524,7 @@ jobs:
           platforms: linux/arm64
           push: true
           tags: ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-assemble-arm64
+          labels: ${{ github.ref_type == 'branch' && github.ref_name != 'main' && 'quay.expires-after=10w' || '' }}
           build-args: |
             BASEIMAGE=${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-core-arm64
             VERSION=${{ needs.get-version.outputs.version }}
@@ -570,18 +562,11 @@ jobs:
 
       - name: Create multi-arch manifest
         run: |
-          # Add expiration annotation for feature branches (copied to Quay by crane)
-          EXPIRE_ANNOTATION=""
-          if [[ "${{ github.ref_type }}" == "branch" && "${{ github.ref_name }}" != "main" ]]; then
-            EXPIRE_ANNOTATION='--annotation index:quay.expires-after=10w'
-          fi
-
           docker buildx imagetools create \
             --annotation "index:org.opencontainers.image.source=https://github.com/broadinstitute/viral-ngs" \
             --annotation "index:org.opencontainers.image.description=Viral genomics analysis tools - assembly" \
             --annotation "index:org.opencontainers.image.licenses=MIT" \
             --annotation "index:org.opencontainers.image.authors=viral-ngs@broadinstitute.org" \
-            $EXPIRE_ANNOTATION \
             --tag ${{ env.GHCR_REPO }}:${{ steps.get-tag.outputs.tag }} \
             ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-assemble-amd64 \
             ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-assemble-arm64
@@ -656,6 +641,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-classify-amd64
+          labels: ${{ github.ref_type == 'branch' && github.ref_name != 'main' && 'quay.expires-after=10w' || '' }}
           build-args: |
             BASEIMAGE=${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-core-amd64
             VERSION=${{ needs.get-version.outputs.version }}
@@ -699,6 +685,7 @@ jobs:
           platforms: linux/arm64
           push: true
           tags: ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-classify-arm64
+          labels: ${{ github.ref_type == 'branch' && github.ref_name != 'main' && 'quay.expires-after=10w' || '' }}
           build-args: |
             BASEIMAGE=${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-core-arm64
             VERSION=${{ needs.get-version.outputs.version }}
@@ -736,18 +723,11 @@ jobs:
 
       - name: Create multi-arch manifest
         run: |
-          # Add expiration annotation for feature branches (copied to Quay by crane)
-          EXPIRE_ANNOTATION=""
-          if [[ "${{ github.ref_type }}" == "branch" && "${{ github.ref_name }}" != "main" ]]; then
-            EXPIRE_ANNOTATION='--annotation index:quay.expires-after=10w'
-          fi
-
           docker buildx imagetools create \
             --annotation "index:org.opencontainers.image.source=https://github.com/broadinstitute/viral-ngs" \
             --annotation "index:org.opencontainers.image.description=Viral genomics analysis tools - metagenomic classification" \
             --annotation "index:org.opencontainers.image.licenses=MIT" \
             --annotation "index:org.opencontainers.image.authors=viral-ngs@broadinstitute.org" \
-            $EXPIRE_ANNOTATION \
             --tag ${{ env.GHCR_REPO }}:${{ steps.get-tag.outputs.tag }} \
             ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-classify-amd64 \
             ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-classify-arm64
@@ -822,6 +802,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-phylo-amd64
+          labels: ${{ github.ref_type == 'branch' && github.ref_name != 'main' && 'quay.expires-after=10w' || '' }}
           build-args: |
             BASEIMAGE=${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-core-amd64
             VERSION=${{ needs.get-version.outputs.version }}
@@ -865,6 +846,7 @@ jobs:
           platforms: linux/arm64
           push: true
           tags: ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-phylo-arm64
+          labels: ${{ github.ref_type == 'branch' && github.ref_name != 'main' && 'quay.expires-after=10w' || '' }}
           build-args: |
             BASEIMAGE=${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-core-arm64
             VERSION=${{ needs.get-version.outputs.version }}
@@ -902,18 +884,11 @@ jobs:
 
       - name: Create multi-arch manifest
         run: |
-          # Add expiration annotation for feature branches (copied to Quay by crane)
-          EXPIRE_ANNOTATION=""
-          if [[ "${{ github.ref_type }}" == "branch" && "${{ github.ref_name }}" != "main" ]]; then
-            EXPIRE_ANNOTATION='--annotation index:quay.expires-after=10w'
-          fi
-
           docker buildx imagetools create \
             --annotation "index:org.opencontainers.image.source=https://github.com/broadinstitute/viral-ngs" \
             --annotation "index:org.opencontainers.image.description=Viral genomics analysis tools - phylogenetics" \
             --annotation "index:org.opencontainers.image.licenses=MIT" \
             --annotation "index:org.opencontainers.image.authors=viral-ngs@broadinstitute.org" \
-            $EXPIRE_ANNOTATION \
             --tag ${{ env.GHCR_REPO }}:${{ steps.get-tag.outputs.tag }} \
             ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-phylo-amd64 \
             ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-phylo-arm64
@@ -988,6 +963,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-mega-amd64
+          labels: ${{ github.ref_type == 'branch' && github.ref_name != 'main' && 'quay.expires-after=10w' || '' }}
           build-args: |
             BASEIMAGE=${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-core-amd64
             VERSION=${{ needs.get-version.outputs.version }}
@@ -1031,6 +1007,7 @@ jobs:
           platforms: linux/arm64
           push: true
           tags: ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-mega-arm64
+          labels: ${{ github.ref_type == 'branch' && github.ref_name != 'main' && 'quay.expires-after=10w' || '' }}
           build-args: |
             BASEIMAGE=${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-core-arm64
             VERSION=${{ needs.get-version.outputs.version }}
@@ -1062,18 +1039,11 @@ jobs:
 
       - name: Create multi-arch manifest
         run: |
-          # Add expiration annotation for feature branches (copied to Quay by crane)
-          EXPIRE_ANNOTATION=""
-          if [[ "${{ github.ref_type }}" == "branch" && "${{ github.ref_name }}" != "main" ]]; then
-            EXPIRE_ANNOTATION='--annotation index:quay.expires-after=10w'
-          fi
-
           docker buildx imagetools create \
             --annotation "index:org.opencontainers.image.source=https://github.com/broadinstitute/viral-ngs" \
             --annotation "index:org.opencontainers.image.description=Viral genomics analysis tools - all tools combined" \
             --annotation "index:org.opencontainers.image.licenses=MIT" \
             --annotation "index:org.opencontainers.image.authors=viral-ngs@broadinstitute.org" \
-            $EXPIRE_ANNOTATION \
             --tag ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }} \
             ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-mega-amd64 \
             ${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-mega-arm64


### PR DESCRIPTION
## Summary

Quay requires `quay.expires-after` to be a Docker image **LABEL** (from Dockerfile or `--label` flag), not an OCI manifest annotation. The previous OCI annotation approach in PR #1027 was correctly setting the annotation on the manifest index, but Quay ignores it.

**Evidence:**
- OCI annotation IS present: `docker buildx imagetools inspect --raw quay.io/...` shows `"quay.expires-after": "10w"`
- But `docker inspect ... | jq '.[0].Config.Labels'` shows no `quay.expires-after` label
- Per [IDBS Engineering blog](https://idbs-engineering.com/containers/2019/08/27/auto-expiry-quayio-tags.html): "The Dockerfile LABEL command can be tagged with the argument quay.expires-after"

## Changes

- Add `labels: quay.expires-after=10w` to all 12 `docker/build-push-action` steps for non-main branches
- Remove the now-unnecessary `EXPIRE_ANNOTATION` logic from manifest creation steps

The label is conditionally applied only for feature branches (not main or tags), causing Quay to auto-expire those images after 10 weeks.

## Test plan

- [ ] CI passes
- [ ] After merge, verify feature branch images have the label:
  ```bash
  docker inspect quay.io/broadinstitute/viral-ngs:<branch>-baseimage | jq '.[0].Config.Labels["quay.expires-after"]'
  # Should return: "10w"
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)