### PR TITLE
Fix composite actions requiring checkout first

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -145,10 +145,14 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          checkout: 'false'
 
       - name: Build and push (amd64)
         id: build
@@ -175,10 +179,14 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          checkout: 'false'
 
       - name: Build and push (arm64)
         id: build
@@ -278,10 +286,14 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          checkout: 'false'
 
       - name: Build and push (amd64)
         id: build
@@ -313,10 +325,14 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          checkout: 'false'
 
       - name: Build and push (arm64)
         id: build
@@ -419,10 +435,14 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          checkout: 'false'
 
       - name: Build and push (amd64)
         id: build
@@ -454,10 +474,14 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          checkout: 'false'
 
       - name: Build and push (arm64)
         id: build
@@ -560,10 +584,14 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          checkout: 'false'
 
       - name: Build and push (amd64)
         id: build
@@ -595,10 +623,14 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          checkout: 'false'
 
       - name: Build and push (arm64)
         id: build
@@ -701,10 +733,14 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          checkout: 'false'
 
       - name: Build and push (amd64)
         id: build
@@ -736,10 +772,14 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          checkout: 'false'
 
       - name: Build and push (arm64)
         id: build
@@ -842,10 +882,14 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          checkout: 'false'
 
       - name: Build and push (amd64)
         id: build
@@ -877,10 +921,14 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          checkout: 'false'
 
       - name: Build and push (arm64)
         id: build


### PR DESCRIPTION
## Summary
- Fixes build failure from PR #1031 where local composite actions could not be found
- Local composite actions require the repository to be checked out first before the action YAML is available
- Adds explicit actions/checkout@v4 step before using ./.github/actions/setup-docker-build in all build jobs
- Sets checkout: false in the composite action to avoid double checkout

## Test plan
- [ ] All build jobs complete successfully
- [ ] Manifest jobs continue to work
- [ ] Test jobs continue to work