### PR TITLE
Add PERL5LIB for sequip in Dockerfile.assemble

### DIFF
--- a/docker/Dockerfile.assemble
+++ b/docker/Dockerfile.assemble
@@ -18,6 +18,10 @@ LABEL org.opencontainers.image.source="https://github.com/broadinstitute/viral-n
 # Enable conda environment activation for RUN commands
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 
+# Workaround: add sequip lib directory to PERL5LIB
+# NOTE: sequip version here must match the version in requirements/assemble.txt
+ENV PERL5LIB=$PERL5LIB:/opt/conda/share/sequip-0.11/lib
+
 # Copy requirements and dependency installation script
 COPY docker/requirements/baseimage.txt docker/requirements/core.txt docker/requirements/assemble.txt /tmp/requirements/
 COPY docker/install-conda-deps.sh /tmp/


### PR DESCRIPTION
## Summary
- Adds PERL5LIB environment variable to Dockerfile.assemble to enable the sequip Perl library

This mirrors the workaround from the old viral-assemble repository ([reference](https://github.com/broadinstitute/viral-assemble/blob/master/Dockerfile)) to ensure the sequip Perl library can be found. The path is updated for the micromamba-based environment (`/opt/conda` instead of the old `/opt/miniconda/envs/viral-ngs-env` path).

## Test plan
- [ ] Verify Docker build succeeds for assemble image
- [ ] Verify `echo $PERL5LIB` includes `/opt/conda/share/sequip-0.11/lib` in the running container
- [ ] Verify Perl can find sequip: `perl -e 'use sequip::easel_ifile; print "OK\n"'`

🤖 Generated with [Claude Code](https://claude.ai/code)