### PR TITLE
Add firecloud conda dependency to baseimage

### DIFF
--- a/docker/requirements/baseimage.txt
+++ b/docker/requirements/baseimage.txt
@@ -11,6 +11,7 @@ udocker>=1.3.16
 
 # Cloud CLIs
 awscli>=1.32.0
+firecloud>=0.16.35
 google-cloud-sdk>=556.0.0
 google-cloud-storage>=2.14.0
 


### PR DESCRIPTION
## Summary

- Adds `firecloud>=0.16.35` (bioconda, noarch) to `docker/requirements/baseimage.txt`
- Restores the FISS API client that was present in viral-core but missed during the v3 monorepo transition
- Package is 58KB with dependencies (`google-cloud-storage`, `google-auth`) already satisfied by baseimage

## Test plan

- [ ] CI builds baseimage successfully with `firecloud` installed
- [ ] Verify `python -c "import firecloud"` works in the built image
- [ ] Run `load_illumina_fastqs_deplete` with `insert_demux_outputs_into_terra_tables = true` to confirm end-to-end fix

Fixes #1038