### PR TITLE
Fix arm64 cryptography ImportError by pip-installing firecloud

### DIFF
--- a/docker/Dockerfile.baseimage
+++ b/docker/Dockerfile.baseimage
@@ -68,12 +68,22 @@ COPY docker/install-conda-deps.sh /tmp/
 RUN /tmp/install-conda-deps.sh /tmp/requirements/baseimage.txt && \
     rm -rf /tmp/requirements /tmp/install-conda-deps.sh
 
+# Install firecloud via pip instead of conda because the conda noarch
+# package bundles x86_64-only wheels (cryptography, cffi, grpcio, etc.)
+# that overwrite conda's native packages and break on arm64 (#1042).
+# Requires setuptools<80 due to firecloud's use of deprecated setuptools
+# APIs (broadinstitute/fiss#192).
+RUN pip install --no-cache-dir 'setuptools<80' && \
+    pip install --no-cache-dir --no-build-isolation 'firecloud>=0.16.35'
+
 WORKDIR /opt/viral-ngs/source
 
 # Verify installation
 RUN python --version && \
     micromamba --version && \
     miniwdl --version && \
-    udocker --allow-root version
+    udocker --allow-root version && \
+    python -c "from cryptography.hazmat.bindings._rust import _openssl; print('cryptography Rust binding OK')" && \
+    python -c "from firecloud import api as fapi; print('firecloud OK')"
 
 CMD ["/bin/bash"]

--- a/docker/requirements/baseimage.txt
+++ b/docker/requirements/baseimage.txt
@@ -11,9 +11,10 @@ udocker>=1.3.16
 
 # Cloud CLIs
 awscli>=1.32.0
-firecloud>=0.16.35
 google-cloud-sdk>=556.0.0
 google-cloud-storage>=2.14.0
+# Note: firecloud is installed via pip in Dockerfile.baseimage because the
+# conda noarch package bundles x86_64-only wheels that break on arm64 (#1042)
 
 # General utilities
 csvkit>=1.0.4


### PR DESCRIPTION
## Summary

Fixes #1042.

- Move `firecloud` from conda (`baseimage.txt`) to a pip install in `Dockerfile.baseimage`
- The `firecloud` conda package (`pyh7cba7a3_0`) is noarch and bundles x86_64-only pip wheels (cryptography 39.0.1, cffi, grpcio, google_crc32c, etc.) that overwrite conda's properly-resolved native packages, causing `ImportError` for `_rust.abi3.so` on arm64
- Pip-installing firecloud lets pip resolve all its Python dependencies with native platform wheels
- Requires `setuptools<80` + `--no-build-isolation` due to firecloud's use of deprecated setuptools APIs ([broadinstitute/fiss#192](https://github.com/broadinstitute/fiss/issues/192))
- Adds build-time import verification for cryptography and firecloud to catch this class of failure early

## Test plan

- [x] Reproduced the original failure locally on Mac arm64 (cryptography 39.0.1 with missing `_rust.abi3.so`)
- [x] Verified fix locally: baseimage builds and passes verification on arm64
- [x] Verified core image builds on top without conflicts
- [x] `cryptography` (46.0.5), `firecloud`, and `google_crc32c` all import correctly on arm64
- [ ] CI builds pass for both amd64 and arm64