### PR TITLE
Fix --version returning timestamp when CWD lacks VERSION file

### DIFF
--- a/src/viral_ngs/core/version.py
+++ b/src/viral_ngs/core/version.py
@@ -143,19 +143,29 @@ def approx_version_number():
 def get_version():
     global __version__
     if __version__ is None:
-        from_git = call_git_describe()
-        from_file = read_release_version()
+        # First, try importlib.metadata (works for pip-installed packages
+        # regardless of the current working directory)
+        try:
+            from importlib.metadata import version, PackageNotFoundError
+            __version__ = version("viral-ngs")
+        except (ImportError, PackageNotFoundError):
+            pass
 
-        if from_git:
-            if from_file != from_git:
-                write_release_version(from_git)
-            __version__ = from_git
-        else:
-            __version__ = from_file
+        # Fall back to git describe (for development in git clones)
+        if __version__ is None:
+            from_git = call_git_describe()
+            from_file = read_release_version()
 
+            if from_git:
+                if from_file != from_git:
+                    write_release_version(from_git)
+                __version__ = from_git
+            else:
+                __version__ = from_file
+
+        # Last resort fallback
         if __version__ is None:
             __version__ = approx_version_number()
-            #raise ValueError("Cannot find the version number!")
 
     return __version__
 


### PR DESCRIPTION
## Summary

- Fix `--version` (and all CLI entry points) returning a Unix timestamp (e.g. `1771342469`) instead of the semver version (e.g. `3.0.6`) when the working directory does not contain a `VERSION` file
- This affects all Terra/Cromwell runs, where Cromwell sets CWD to its execution directory
- Add `importlib.metadata.version("viral-ngs")` as the first resolution step in `core/version.py:get_version()`, before git describe and VERSION file fallbacks — matching the pattern already used in `viral_ngs/__init__.py`

## Test plan

- [ ] Unit tests pass: `pytest tests/unit` in Docker
- [ ] Manual verification: `python -c "from viral_ngs.core.version import get_version; print(get_version())"` returns a semver string
- [ ] Docker verification (after image rebuild): `docker run --rm -w /tmp <image> assembly --version` returns `3.0.6`, not `1771342469`

🤖 Generated with [Claude Code](https://claude.com/claude-code)