### PR TITLE
Fix CVE-2026-41316: upgrade Ruby erb gem to >=6.0.4

### DIFF
--- a/docker/Dockerfile.assemble
+++ b/docker/Dockerfile.assemble
@@ -32,12 +32,17 @@ COPY docker/install-conda-deps.sh /tmp/
 #   - mafft's dash_client: Go 1.22.1 binary with Go stdlib CVEs; we never use --dash mode
 #   - Ruby json gem: mummer4/sequip pull in Ruby (via yaggo), whose bundled json gem
 #     has CVE-2026-33210; remove the old default gem and install patched version (>=2.19.2)
+#   - Ruby erb gem: same chain (mummer4 → yaggo → ruby), CVE-2026-41316 (Marshal
+#     deserialization bypass via ERB#def_module); remove default gem and install >=6.0.4
 RUN /tmp/install-conda-deps.sh /tmp/requirements/baseimage.txt /tmp/requirements/core.txt /tmp/requirements/assemble.txt \
     --x86-only:/tmp/requirements/assemble-x86.txt && \
     rm -f /opt/conda/libexec/mafft/dash_client && \
     find /opt/conda/lib/ruby -maxdepth 3 -name 'json*' -not -path '*/psych/*' -exec rm -rf {} + && \
     rm -f /opt/conda/lib/ruby/gems/*/specifications/default/json-*.gemspec && \
-    gem install json --version '>=2.19.2' --no-document
+    gem install json --version '>=2.19.2' --no-document && \
+    find /opt/conda/lib/ruby -maxdepth 3 -name 'erb*' -exec rm -rf {} + && \
+    rm -f /opt/conda/lib/ruby/gems/*/specifications/default/erb-*.gemspec && \
+    gem install erb --version '>=6.0.4' --no-document
 
 # Copy source code (includes assembly module)
 COPY src/ /opt/viral-ngs/source/src/

--- a/docker/Dockerfile.mega
+++ b/docker/Dockerfile.mega
@@ -29,6 +29,8 @@ COPY docker/install-conda-deps.sh /tmp/
 #   - mafft's dash_client: Go 1.22.1 binary with Go stdlib CVEs; we never use --dash mode
 #   - Ruby json gem: mummer4 → yaggo → Ruby, whose bundled json gem has CVE-2026-33210;
 #     remove the old default gem and install patched version (>=2.19.2)
+#   - Ruby erb gem: same chain (mummer4 → yaggo → ruby), CVE-2026-41316 (Marshal
+#     deserialization bypass via ERB#def_module); remove default gem and install >=6.0.4
 RUN /tmp/install-conda-deps.sh /tmp/requirements/baseimage.txt /tmp/requirements/core.txt /tmp/requirements/assemble.txt /tmp/requirements/classify.txt /tmp/requirements/phylo.txt \
     --x86-only:/tmp/requirements/assemble-x86.txt \
     --x86-only:/tmp/requirements/classify-x86.txt \
@@ -36,7 +38,10 @@ RUN /tmp/install-conda-deps.sh /tmp/requirements/baseimage.txt /tmp/requirements
     rm -f /opt/conda/libexec/mafft/dash_client && \
     find /opt/conda/lib/ruby -maxdepth 3 -name 'json*' -not -path '*/psych/*' -exec rm -rf {} + && \
     rm -f /opt/conda/lib/ruby/gems/*/specifications/default/json-*.gemspec && \
-    gem install json --version '>=2.19.2' --no-document
+    gem install json --version '>=2.19.2' --no-document && \
+    find /opt/conda/lib/ruby -maxdepth 3 -name 'erb*' -exec rm -rf {} + && \
+    rm -f /opt/conda/lib/ruby/gems/*/specifications/default/erb-*.gemspec && \
+    gem install erb --version '>=6.0.4' --no-document
 
 # Copy source code (includes all modules)
 COPY src/ /opt/viral-ngs/source/src/

--- a/docker/Dockerfile.phylo
+++ b/docker/Dockerfile.phylo
@@ -29,12 +29,17 @@ COPY docker/install-conda-deps.sh /tmp/
 #   - mafft's dash_client: Go 1.22.1 binary with Go stdlib CVEs; we never use --dash mode
 #   - Ruby json gem: mummer4 pulls in yaggo → Ruby, whose bundled json gem has
 #     CVE-2026-33210; remove the old default gem and install patched version (>=2.19.2)
+#   - Ruby erb gem: same chain (mummer4 → yaggo → ruby), CVE-2026-41316 (Marshal
+#     deserialization bypass via ERB#def_module); remove default gem and install >=6.0.4
 RUN /tmp/install-conda-deps.sh /tmp/requirements/baseimage.txt /tmp/requirements/core.txt /tmp/requirements/phylo.txt \
     --x86-only:/tmp/requirements/phylo-x86.txt && \
     rm -f /opt/conda/libexec/mafft/dash_client && \
     find /opt/conda/lib/ruby -maxdepth 3 -name 'json*' -not -path '*/psych/*' -exec rm -rf {} + && \
     rm -f /opt/conda/lib/ruby/gems/*/specifications/default/json-*.gemspec && \
-    gem install json --version '>=2.19.2' --no-document
+    gem install json --version '>=2.19.2' --no-document && \
+    find /opt/conda/lib/ruby -maxdepth 3 -name 'erb*' -exec rm -rf {} + && \
+    rm -f /opt/conda/lib/ruby/gems/*/specifications/default/erb-*.gemspec && \
+    gem install erb --version '>=6.0.4' --no-document
 
 # Copy source code (includes phylo module)
 COPY src/ /opt/viral-ngs/source/src/


### PR DESCRIPTION
## Summary

The weekly scheduled container scan (`container-scan.yml`) flagged a new HIGH-severity fixable CVE in the mega image: **CVE-2026-41316** in the Ruby `erb` default gem ([failing run](https://github.com/broadinstitute/viral-ngs/actions/runs/24980746920)).

- **Severity:** HIGH (CVSS 3.1: 8.1, vector `AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H`)
- **Advisory:** [GHSA-q339-8rmv-2mhv](https://github.com/ruby/erb/security/advisories/GHSA-q339-8rmv-2mhv)
- **Installed:** `erb` 6.0.1 (Ruby default gem)
- **Fixed in:** 4.0.3.1, 4.0.4.1, 6.0.1.1, **6.0.4**

### Vulnerability

Ruby 2.7.0 added an `@_init` instance-variable guard in `ERB#result` and `ERB#run` to prevent code execution when an ERB object is reconstructed via `Marshal.load` (deserialization). The patch missed three other public methods that also `eval()` the `@src` instance variable: `ERB#def_method`, `ERB#def_module`, and `ERB#def_class`. An attacker who can pass untrusted Marshal data to `Marshal.load` in a Ruby app that has `erb` loaded can call `ERB#def_module` (zero-arg, default parameters) as a code-execution sink, bypassing the `@_init` protection entirely.

### Dependency chain

`mummer4 → yaggo → ruby` (default gem). Identical entry point to the recently-patched `json` gem CVE-2026-33210. No viral-ngs code invokes Ruby at runtime; `erb` is only present because it's a Ruby stdlib component shipped via the default-gem mechanism.

### Fix

Mirrors the prior `json` gem fix in commit `fe939b2b` / `44c3d2fb` exactly. In each of `Dockerfile.assemble`, `Dockerfile.phylo`, `Dockerfile.mega` (still in the same `RUN` layer as the conda install, so vulnerable files never appear in a committed layer):

1. `find /opt/conda/lib/ruby -maxdepth 3 -name 'erb*' -exec rm -rf {} +`
2. `rm -f /opt/conda/lib/ruby/gems/*/specifications/default/erb-*.gemspec`
3. `gem install erb --version '>=6.0.4' --no-document`

Comment block above each `RUN` updated with a bullet for the new mitigation.

### Glob-safety note

Unlike the `json` fix (which excluded `*/psych/*` because `psych` bundles a `json` adapter), `-name 'erb*'` is used unfiltered. I'm not aware of any other Ruby stdlib/gem name beginning with `erb`. **Reviewer:** flag if you know of an exception.

## Test plan

- [x] `docker.yml` CI builds all three images successfully (assemble, phylo, mega) on amd64 and arm64
- [x] Trivy step in `docker.yml` confirms CVE-2026-41316 is no longer flagged (all `scan-containers (*)` checks green)
- [ ] Once merged, the next weekly `container-scan.yml` run on `main-mega-amd64` exits 0

Closes #1062

---

*Code, commit message, and PR body drafted collaboratively in a Claude Code session with Claude Opus 4.7. Final review and merge by a human maintainer. (Per [AGENTS.md](../blob/main/AGENTS.md) agent-attribution guidance.)*
