### PR TITLE
Add Claude-powered CVE triage to scheduled scan

### DIFF
--- a/.agents/skills/claude-on-vertex-ci/SKILL.md
+++ b/.agents/skills/claude-on-vertex-ci/SKILL.md
@@ -1,0 +1,220 @@
+# Claude on Vertex AI from GitHub Actions
+
+Reusable infrastructure for invoking Claude (via [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action))
+on Google Vertex AI from GitHub Actions workflows in this repo. Authentication
+is via Workload Identity Federation — no long-lived secrets.
+
+## When to Use
+
+Add a new Claude-in-CI use case (PR review, CVE triage, dependency-update
+analysis, automated docs generation, etc.) when:
+
+- The task is well-suited to an LLM with tool use (reading files, running CLI
+  commands, calling `gh`)
+- The task fires on a GitHub event (schedule, workflow_dispatch, push, PR)
+- You want an issue, PR comment, or artifact as the output
+
+The first use case (and template) is the **CVE triage step in
+`container-scan.yml`** — see `.agents/skills/container-vulns/SKILL.md`.
+
+## What's Already Provisioned
+
+**GCP project: `viral-seq-ai`**
+
+| Resource | Identifier |
+|---|---|
+| Workload Identity Pool | `github-actions-pool` (global) |
+| OIDC provider | `broadinstitute-github` |
+| Provider attribute condition | `assertion.repository_owner == 'broadinstitute'` |
+| Required APIs | `aiplatform.googleapis.com`, `iamcredentials.googleapis.com` |
+
+**Service accounts (one per use case):**
+
+| SA email | Use case | Workflow |
+|---|---|---|
+| `viral-ngs-cve-triage@viral-seq-ai.iam.gserviceaccount.com` | Weekly CVE triage | `.github/workflows/container-scan.yml` |
+
+The pool + provider are reusable across use cases. Add a new SA per use case
+(principle of least privilege; easier to audit and disable individually).
+
+## Adding a New Claude-in-CI Use Case
+
+You need GCP IAM Admin on `viral-seq-ai` for steps 1–3.
+
+### 1. Create a service account scoped to the use case
+
+```bash
+gcloud iam service-accounts create <use-case-name> \
+  --project=viral-seq-ai \
+  --display-name="<Human-readable name>" \
+  --description="Used by <workflow-file>.yml to invoke Claude on Vertex AI for <purpose>"
+```
+
+### 2. Grant minimum roles
+
+Vertex invocation requires both:
+
+```bash
+gcloud projects add-iam-policy-binding viral-seq-ai \
+  --member="serviceAccount:<use-case-name>@viral-seq-ai.iam.gserviceaccount.com" \
+  --role="roles/aiplatform.user" \
+  --condition=None
+
+gcloud projects add-iam-policy-binding viral-seq-ai \
+  --member="serviceAccount:<use-case-name>@viral-seq-ai.iam.gserviceaccount.com" \
+  --role="roles/serviceusage.serviceUsageConsumer" \
+  --condition=None
+```
+
+### 3. Bind the GitHub repo to the SA via WIF
+
+```bash
+PROJECT_NUMBER=$(gcloud projects describe viral-seq-ai --format='value(projectNumber)')
+
+gcloud iam service-accounts add-iam-policy-binding \
+  <use-case-name>@viral-seq-ai.iam.gserviceaccount.com \
+  --project=viral-seq-ai \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github-actions-pool/attribute.repository/broadinstitute/viral-ngs"
+```
+
+For tighter scope, use `attribute.ref` (branch) or `attribute.workflow` (specific
+workflow file) in place of (or in addition to) `attribute.repository`.
+
+### 4. Set GitHub repo variables
+
+If the new use case lives alongside the CVE triage one, you can reuse
+`GCP_PROJECT_ID` and `GCP_WIP_PROVIDER`. The SA email differs per use case —
+either create a use-case-specific variable (e.g., `GCP_PR_REVIEW_SA_EMAIL`) or
+hard-code it in the workflow file.
+
+```bash
+gh variable set GCP_<USECASE>_SA_EMAIL \
+  --body "<use-case-name>@viral-seq-ai.iam.gserviceaccount.com" \
+  --repo broadinstitute/viral-ngs
+```
+
+### 5. Add the workflow steps
+
+See the canonical pattern below.
+
+## Canonical Workflow Pattern
+
+```yaml
+permissions:
+  id-token: write   # for OIDC token to GCP via WIF
+  # plus whatever else your workflow needs (contents: read, issues: write, etc.)
+
+steps:
+  - name: Checkout repository
+    uses: actions/checkout@v4
+    with:
+      # If Claude needs git history (`git log --grep`, `git show`), use 0.
+      # Otherwise the default shallow clone is fine.
+      fetch-depth: 0
+
+  - name: Authenticate to GCP via Workload Identity Federation
+    uses: google-github-actions/auth@v2
+    with:
+      workload_identity_provider: ${{ vars.GCP_WIP_PROVIDER }}
+      service_account: ${{ vars.GCP_<USECASE>_SA_EMAIL }}
+
+  - name: Claude on Vertex AI
+    # Pin to commit SHA for supply-chain safety; bump when picking up new releases.
+    uses: anthropics/claude-code-action@<FULL_40_CHAR_SHA>  # v1
+    env:
+      CLAUDE_CODE_USE_VERTEX: '1'
+      CLOUD_ML_REGION: global              # Sonnet 4.6 supports the global endpoint
+      ANTHROPIC_VERTEX_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+    with:
+      use_vertex: 'true'
+      github_token: ${{ secrets.GITHUB_TOKEN }}    # avoids needing the Claude Code GitHub App
+      claude_args: '--model claude-sonnet-4-6 --max-turns 30'
+      settings: |
+        {
+          "permissions": {
+            "allow": [
+              "Read",
+              "Write",
+              "Bash(git log:*)",
+              "Bash(grep:*)",
+              "Bash(jq:*)"
+              # ... add only what the prompt actually needs
+            ]
+          }
+        }
+      prompt: |
+        <Your prompt here. Claude sees the GH workspace as cwd.>
+```
+
+## Gotchas (Things We Learned the Hard Way)
+
+- **`iamcredentials.googleapis.com` must be enabled.** WIF impersonation calls
+  this API; without it you get `IAM Service Account Credentials API has not
+  been used in project ... before or it is disabled` from the Claude action,
+  AFTER auth appears to succeed. Confusing.
+
+- **Use `@v1`, not `@beta`.** `claude-code-action@beta` is the older API shape
+  with separate `direct_prompt`, `max_turns`, `allowed_tools` inputs. `@v1`
+  consolidates everything into `prompt` + `claude_args` + `settings`. Pin to a
+  commit SHA, not the floating tag.
+
+- **Both `use_vertex: 'true'` AND `CLAUDE_CODE_USE_VERTEX=1` are needed** —
+  the input goes to the action wrapper, the env var goes to the underlying
+  `claude-code` CLI.
+
+- **Pass `github_token: ${{ secrets.GITHUB_TOKEN }}`** to skip the Claude
+  Code GitHub App requirement. Without this you get
+  `Error: Claude Code is not installed on this repository`.
+
+- **The permission DSL doesn't take path globs on `Write` or paths on `Bash`
+  command names.** `Write(/tmp/issues/**)` and `Bash(mkdir:/tmp/issues*)` are
+  silently rejected and Claude hits `permission_denials_count > 0`. The
+  `Bash(<cmd>:*)` pattern is for the *args after the command*, not paths
+  embedded in the command name. For now, use unrestricted `Write` and rely
+  on prompt instructions to constrain output paths.
+
+- **Region `global` (recommended) gives dynamic routing across regions for
+  Sonnet 4.6.** Pin to a specific region (e.g., `us-east5`, `europe-west1`)
+  only if you need data-residency control.
+
+- **`fetch-depth: 0` if Claude needs git history.** Default `actions/checkout`
+  is shallow (depth=1); `git log --all --grep` and `git show <sha>` will
+  produce empty results without unshallowing.
+
+- **Always `jq`-query authoritative data sources in the prompt.** When Claude
+  has multiple ways to learn a fact (training data vs reading a workspace
+  file), tell it explicitly which is canonical and require the tool call.
+  Otherwise it sometimes infers from training data.
+
+## Cost / Safety
+
+- **Cost gate:** invoke Claude only when the workflow has real work to do
+  (e.g., new CVEs detected, PR opened by non-bot). Don't invoke on every
+  schedule tick unconditionally.
+- **Turn cap:** `--max-turns 30` is generous for triage-style tasks; tighten
+  if you can. Observed: 6–10 turns for one-CVE analyses.
+- **Cost order of magnitude:** Sonnet 4.6 ≈ $0.10–1 per non-trivial task
+  (one-CVE analysis with full repo reading). Opus 4.7 is ~5× more expensive
+  for marginal quality gain on most CI tasks.
+- **Provider gate:** the OIDC provider attribute condition limits token
+  minting to repos owned by `broadinstitute`. Other GitHub orgs cannot use
+  this pool.
+- **SA gate:** each SA's `workloadIdentityUser` binding limits which repos
+  can impersonate it. Default scope: `attribute.repository/broadinstitute/viral-ngs`.
+  Tighten with `attribute.ref` or `attribute.workflow` if needed.
+- **Tool allowlist:** only allow tools the prompt actually uses. Avoid wildcard
+  `Bash(*:*)` — name specific commands like `Bash(git log:*)`.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `.github/workflows/container-scan.yml` | First use case (CVE triage); reference for the workflow pattern |
+| `.agents/skills/container-vulns/SKILL.md` | The CVE triage playbook this infra serves |
+
+## References
+
+- [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action)
+- [Claude Code on Google Vertex AI](https://code.claude.com/docs/en/google-vertex-ai)
+- [`google-github-actions/auth`](https://github.com/google-github-actions/auth) (WIF action)

--- a/.agents/skills/container-vulns/SKILL.md
+++ b/.agents/skills/container-vulns/SKILL.md
@@ -8,7 +8,11 @@ in the viral-ngs Docker image hierarchy.
 Container images are scanned for vulnerabilities using [Trivy](https://aquasecurity.github.io/trivy/):
 
 - **On every PR/push**: `docker.yml` scans each image flavor after build (SARIF -> GitHub Security tab, JSON -> artifact)
-- **Weekly schedule**: `container-scan.yml` scans the latest published images
+- **Weekly schedule**: `container-scan.yml` scans the latest published images. When new
+  fixable HIGH/CRITICAL CVEs are detected (i.e. CVE IDs not already present in any open
+  or closed GH issue title), the workflow invokes Claude Sonnet 4.6 on Vertex AI to
+  triage each one and files a GitHub issue per CVE (labels: `security`, `cve`). The
+  Vertex/WIF infra used here is documented in `.agents/skills/claude-on-vertex-ci/SKILL.md`.
 - Scans filter to **CRITICAL/HIGH** severity, **ignore-unfixed**, and apply a Rego policy (`.trivy-ignore-policy.rego`)
 - Per-CVE exceptions go in `.trivyignore` with mandatory justification comments
 

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -167,15 +167,15 @@ jobs:
 
       - name: Claude analysis on Vertex AI
         if: steps.triage.outputs.cve_ids != ''
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         env:
           CLAUDE_CODE_USE_VERTEX: '1'
           CLOUD_ML_REGION: global
           ANTHROPIC_VERTEX_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
         with:
-          claude_args: |
-            --model claude-sonnet-4-6
-            --max-turns 30
+          use_vertex: 'true'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: '--model claude-sonnet-4-6 --max-turns 30'
           settings: |
             {
               "permissions": {

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -34,6 +34,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Full history so the Claude analysis step can `git log --grep` and `git show`
+          # precedent CVE-fix commits (e.g., to mirror past mitigation patterns exactly).
+          fetch-depth: 0
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -99,7 +103,8 @@ jobs:
         id: triage
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TEST_CVE_ID: ${{ inputs.test_cve_id }}
+          # Use github.event.inputs (not inputs) so this is well-defined on schedule too.
+          TEST_CVE_ID: ${{ github.event.inputs.test_cve_id || '' }}
         run: |
           set -euo pipefail
 
@@ -156,7 +161,7 @@ jobs:
           service_account: ${{ vars.GCP_SA_EMAIL }}
 
       - name: Ensure issue labels exist
-        if: steps.triage.outputs.cve_ids != '' && inputs.dry_run != true
+        if: steps.triage.outputs.cve_ids != '' && (github.event.inputs.dry_run || 'false') != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -167,7 +172,9 @@ jobs:
 
       - name: Claude analysis on Vertex AI
         if: steps.triage.outputs.cve_ids != ''
-        uses: anthropics/claude-code-action@v1
+        # Pinned to commit SHA (== v1 as of 2026-04-27) for supply-chain safety;
+        # bump this SHA when picking up new claude-code-action releases.
+        uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434  # v1
         env:
           CLAUDE_CODE_USE_VERTEX: '1'
           CLOUD_ML_REGION: global
@@ -181,15 +188,16 @@ jobs:
               "permissions": {
                 "allow": [
                   "Read",
-                  "Write",
+                  "Write(/tmp/issues/**)",
+                  "Bash(mkdir:/tmp/issues*)",
                   "Bash(git log:*)",
                   "Bash(git show:*)",
                   "Bash(git rev-parse:*)",
+                  "Bash(git grep:*)",
                   "Bash(grep:*)",
                   "Bash(find:*)",
                   "Bash(jq:*)",
                   "Bash(ls:*)",
-                  "Bash(mkdir:*)",
                   "Bash(cat:*)",
                   "Bash(head:*)",
                   "Bash(tail:*)"
@@ -230,9 +238,18 @@ jobs:
                applied to similar packages.
             6. `docker/requirements/*.txt` — conda dependency lists. Use `grep` to find
                which file pulls in the affected package.
-            7. Recent git history — `git log --all --oneline --grep <package>`,
-               `git log --all --oneline --grep CVE-`, and `git show <sha>` to inspect prior
-               fix patterns. ALWAYS verify a commit SHA exists before citing it.
+            7. Recent git history — full history is available (the workflow checks out
+               with `fetch-depth: 0`). Use:
+                 - `git log --all --oneline --grep <package>` to find prior commits
+                   touching the affected package
+                 - `git log --all --oneline --grep CVE-` to find prior CVE-fix commits
+                 - **`git show <sha>` to inspect the FULL DIFF of any precedent fix you
+                   plan to cite. Read the diff, not just the commit message.** Many fixes
+                   combine multiple elements (e.g., file removal + reinstall) — your
+                   recommendation must mirror ALL elements of the precedent, not just the
+                   headline change.
+                 - ALWAYS verify a commit SHA exists with `git show <sha>` before citing it
+                   in the report.
 
             ## Required structure for each report
 
@@ -278,27 +295,43 @@ jobs:
           if-no-files-found: warn
 
       - name: File GitHub issues
-        if: steps.triage.outputs.cve_ids != '' && inputs.dry_run != true
+        if: steps.triage.outputs.cve_ids != '' && (github.event.inputs.dry_run || 'false') != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TEST_MODE: ${{ steps.triage.outputs.test_mode }}
         run: |
           set -uo pipefail
+          shopt -s nullglob
 
-          if [ ! -d /tmp/issues ] || [ -z "$(ls -A /tmp/issues 2>/dev/null)" ]; then
-            echo "::error::No analysis files in /tmp/issues — Claude may have failed silently"
+          if [ ! -d /tmp/issues ]; then
+            echo "::error::/tmp/issues does not exist — Claude analysis step likely failed"
+            exit 1
+          fi
+
+          md_files=(/tmp/issues/*.md)
+          if [ ${#md_files[@]} -eq 0 ]; then
+            echo "::error::No .md analysis files in /tmp/issues — Claude may have failed silently"
             exit 1
           fi
 
           failed=0
-          for f in /tmp/issues/*.md; do
+          for f in "${md_files[@]}"; do
             cve=$(basename "$f" .md)
             title=$(head -1 "$f" | sed 's/^# *//')
             body=$(tail -n +2 "$f")
 
-            labels="security,cve"
+            # Dedup-integrity guard: title MUST contain the CVE ID, otherwise the next
+            # scheduled run won't recognize it as already-triaged via title-substring search.
+            if ! echo "$title" | grep -qF "$cve"; then
+              echo "::error::Issue title for $cve does not contain the CVE ID — refusing to file (would break dedup)"
+              echo "  Title was: $title"
+              failed=$((failed+1))
+              continue
+            fi
+
+            label_args=(--label security --label cve)
             if [ "$TEST_MODE" = "true" ]; then
-              labels="$labels,test"
+              label_args+=(--label test)
             fi
 
             echo "Creating issue for $cve: $title"
@@ -306,7 +339,7 @@ jobs:
                 --repo "$GITHUB_REPOSITORY" \
                 --title "$title" \
                 --body "$body" \
-                --label "$labels"; then
+                "${label_args[@]}"; then
               echo "::error::Failed to create issue for $cve"
               failed=$((failed+1))
             fi

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -284,6 +284,10 @@ jobs:
                containers, no network-facing services, no untrusted user input at runtime),
                is this actually reachable? Be honest and specific.
             7. **References** — GHSA URL, NVD URL, vendor advisory.
+            8. **Attribution footer** — at the very end of the report, add a horizontal
+               rule (`---`) on its own line, then this exact paragraph (italicized):
+
+               `*This analysis and report were authored entirely by Claude Sonnet 4.6 (running on Google Vertex AI via the `container-scan.yml` triage pipeline). Independently verify the CVSS data, dependency chain, recommended fix, and commit SHAs before acting on this report.*`
 
             ## Constraints
 

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -222,9 +222,17 @@ jobs:
 
             ## Required reading (do this BEFORE writing reports)
 
-            1. `trivy-results.json` (in the workspace root) — authoritative metadata for every
-               CVE flagged in the current scan. ALWAYS check here first for CVE details
-               (severity, vector, package path, fix version, references). Use `jq` to query.
+            1. `trivy-results.json` (in the workspace root) — **the authoritative source for
+               CVSS score, CVSS vector, package path, fix version, and references.** Query
+               it with `jq` before writing any report. Example:
+               ```
+               jq '.Results[]?.Vulnerabilities[]? | select(.VulnerabilityID == "<CVE-ID>")' trivy-results.json
+               ```
+               You MUST cite the exact CVSS score and vector from this file in the
+               "Vulnerability details" section — do NOT infer or estimate them from your
+               own knowledge if the CVE is present in the JSON. If the CVE is NOT in the
+               JSON (test mode, or scan-target divergence), explicitly say so in the report
+               and use your training knowledge as a clearly-labeled fallback.
             2. `.agents/skills/container-vulns/SKILL.md` — read fully. This is the repo's
                container-vulnerability playbook and tells you what the maintainers consider
                actionable vs. accepted risk.

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -188,8 +188,8 @@ jobs:
               "permissions": {
                 "allow": [
                   "Read",
-                  "Write(/tmp/issues/**)",
-                  "Bash(mkdir:/tmp/issues*)",
+                  "Write",
+                  "Bash(mkdir:*)",
                   "Bash(git log:*)",
                   "Bash(git show:*)",
                   "Bash(git rev-parse:*)",

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -5,6 +5,17 @@ on:
     # Weekly scan of main branch mega image every Monday at 06:00 UTC
     - cron: '0 6 * * 1'
   workflow_dispatch:
+    inputs:
+      test_cve_id:
+        description: 'Optional: bypass new-CVE detection and force-analyze this specific CVE ID (for testing the Claude pipeline)'
+        required: false
+        type: string
+        default: ''
+      dry_run:
+        description: 'Run Claude analysis but do NOT file GitHub issues (artifact still uploaded)'
+        required: false
+        type: boolean
+        default: false
 
 permissions: {}
 
@@ -18,6 +29,8 @@ jobs:
       contents: read
       packages: read
       security-events: write
+      issues: write     # for filing CVE issues
+      id-token: write   # for OIDC token to GCP via WIF
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -49,7 +62,7 @@ jobs:
           format: 'json'
           output: 'trivy-results.json'
           severity: 'CRITICAL,HIGH'
-          exit-code: '1'
+          exit-code: '0'   # don't fail here — Claude pipeline + final-step gate handles signaling
           ignore-unfixed: true
           trivyignores: '.trivyignore'
           ignore-policy: '.trivy-ignore-policy.rego'
@@ -75,3 +88,237 @@ jobs:
         with:
           name: trivy-mega-scheduled
           path: trivy-results.json
+
+      # === Claude triage pipeline ===
+      # If new fixable HIGH/CRITICAL CVEs are found, hand them to Claude (Sonnet 4.6
+      # on Vertex AI) for analysis, then file GitHub issues. Source of truth for
+      # "new" is GH issues themselves: a CVE is new if no existing issue (open OR
+      # closed) has the CVE ID in its title.
+
+      - name: Identify new fixable CVEs
+        id: triage
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TEST_CVE_ID: ${{ inputs.test_cve_id }}
+        run: |
+          set -euo pipefail
+
+          # Test mode: bypass scan-diff and use the provided CVE ID directly.
+          if [ -n "${TEST_CVE_ID:-}" ]; then
+            echo "::notice::Test mode active — analyzing TEST_CVE_ID=$TEST_CVE_ID"
+            echo "cve_ids=$TEST_CVE_ID" >> "$GITHUB_OUTPUT"
+            echo "test_mode=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Production mode: parse trivy JSON for fixable HIGH/CRITICAL CVEs.
+          all_cves=$(jq -r '
+            [.Results[]?.Vulnerabilities[]?
+              | select((.Severity == "HIGH" or .Severity == "CRITICAL")
+                       and (.FixedVersion // "") != "")
+              | .VulnerabilityID]
+            | unique[]
+          ' trivy-results.json)
+
+          if [ -z "$all_cves" ]; then
+            echo "::notice::No fixable HIGH/CRITICAL CVEs in scan."
+            echo "cve_ids=" >> "$GITHUB_OUTPUT"
+            echo "test_mode=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Dedup against existing GH issues (open + closed) by title-substring search.
+          new_cves=()
+          for cve in $all_cves; do
+            count=$(gh search issues \
+              --repo "$GITHUB_REPOSITORY" \
+              --state=all \
+              "\"$cve\" in:title" \
+              --json url --jq 'length')
+            if [ "$count" = "0" ]; then
+              new_cves+=("$cve")
+              echo "  NEW: $cve"
+            else
+              echo "  existing issue for $cve, skipping"
+            fi
+          done
+
+          new_list="${new_cves[*]:-}"
+          echo "::notice::Found ${#new_cves[@]} new fixable CVE(s)"
+          echo "cve_ids=$new_list" >> "$GITHUB_OUTPUT"
+          echo "test_mode=false" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to GCP via Workload Identity Federation
+        if: steps.triage.outputs.cve_ids != ''
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIP_PROVIDER }}
+          service_account: ${{ vars.GCP_SA_EMAIL }}
+
+      - name: Ensure issue labels exist
+        if: steps.triage.outputs.cve_ids != '' && inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Idempotent: gh label create exits non-zero if label exists; ignore that.
+          gh label create security    --color B60205 --description "Security-related issue"            --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+          gh label create cve         --color B60205 --description "CVE tracked in container scans"    --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+          gh label create test        --color FBCA04 --description "Test issue (filed by workflow_dispatch test_cve_id)" --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+
+      - name: Claude analysis on Vertex AI
+        if: steps.triage.outputs.cve_ids != ''
+        uses: anthropics/claude-code-action@beta
+        env:
+          CLAUDE_CODE_USE_VERTEX: '1'
+          CLOUD_ML_REGION: global
+          ANTHROPIC_VERTEX_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+        with:
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 30
+          settings: |
+            {
+              "permissions": {
+                "allow": [
+                  "Read",
+                  "Write",
+                  "Bash(git log:*)",
+                  "Bash(git show:*)",
+                  "Bash(git rev-parse:*)",
+                  "Bash(grep:*)",
+                  "Bash(find:*)",
+                  "Bash(jq:*)",
+                  "Bash(ls:*)",
+                  "Bash(mkdir:*)",
+                  "Bash(cat:*)",
+                  "Bash(head:*)",
+                  "Bash(tail:*)"
+                ]
+              }
+            }
+          prompt: |
+            You are triaging container vulnerabilities for the broadinstitute/viral-ngs repo.
+
+            ## Your task
+
+            For each CVE ID listed below, write a triage report to `/tmp/issues/<CVE-ID>.md`.
+            The reports will be filed verbatim as GitHub issues by the next workflow step.
+
+            **CVE IDs to analyze:** ${{ steps.triage.outputs.cve_ids }}
+
+            **Test mode:** ${{ steps.triage.outputs.test_mode }}
+            (If `true`, the CVE was supplied manually via `test_cve_id` and may not appear in
+            the current scan's `trivy-results.json`. Use your training knowledge in that case
+            and add a `> _Test analysis_` blockquote at the top of the report so reviewers
+            know it was generated for pipeline validation, not from a real scan finding.)
+
+            ## Required reading (do this BEFORE writing reports)
+
+            1. `trivy-results.json` (in the workspace root) — authoritative metadata for every
+               CVE flagged in the current scan. ALWAYS check here first for CVE details
+               (severity, vector, package path, fix version, references). Use `jq` to query.
+            2. `.agents/skills/container-vulns/SKILL.md` — read fully. This is the repo's
+               container-vulnerability playbook and tells you what the maintainers consider
+               actionable vs. accepted risk.
+            3. `.trivyignore` — existing per-CVE exceptions with their justifications. Mirror
+               the writing style and depth of justification when you recommend `.trivyignore`
+               additions.
+            4. `.trivy-ignore-policy.rego` — Rego policy for class-level CVE filtering.
+               Understand what it filters and why.
+            5. `docker/Dockerfile.*` — container build files showing dep installs and inline
+               mitigations. Look for prior fixups (`find ... -exec rm`, `gem install`, etc.)
+               applied to similar packages.
+            6. `docker/requirements/*.txt` — conda dependency lists. Use `grep` to find
+               which file pulls in the affected package.
+            7. Recent git history — `git log --all --oneline --grep <package>`,
+               `git log --all --oneline --grep CVE-`, and `git show <sha>` to inspect prior
+               fix patterns. ALWAYS verify a commit SHA exists before citing it.
+
+            ## Required structure for each report
+
+            File path: `/tmp/issues/<CVE-ID>.md` (filename MUST match the CVE ID exactly).
+            **First line MUST be a single H1 used as the issue title:**
+            `# [CVE-YYYY-NNNN] <package>: <one-line description>`
+
+            Then sections (use H2 `##` headers):
+
+            1. **Summary** — 2–3 sentences: what it is, severity, where it came from.
+            2. **Vulnerability details** — CVSS score + vector + plain-English meaning;
+               2–4 sentences explaining the bug technically.
+            3. **Dependency chain** — name the direct conda package or Docker layer that
+               pulls this in. Trace transitive deps where you can. If you can't determine
+               this confidently, say so explicitly — do NOT guess.
+            4. **Why the Rego policy didn't suppress it** — explain in terms of the AV/PR/UI/S
+               vector classes the policy filters and why this CVE's vector doesn't match.
+            5. **Recommended fix** — concrete and actionable. Options:
+                - Version bump (which file, which floor)
+                - Inline Dockerfile mitigation (which Dockerfile, what RUN-block addition)
+                - `.trivyignore` entry (with justification matching the existing style)
+               Cite historical precedent when applicable: `(mirror the fix in commit <sha>)`.
+            6. **Practical exploitability** — in this deployment model (ephemeral batch
+               containers, no network-facing services, no untrusted user input at runtime),
+               is this actually reachable? Be honest and specific.
+            7. **References** — GHSA URL, NVD URL, vendor advisory.
+
+            ## Constraints
+
+            - `mkdir -p /tmp/issues` first.
+            - One file per CVE.
+            - Be concise. Each report should be readable in 1–2 minutes (target: 300–600 words).
+            - Do NOT hallucinate package versions, file paths, or commit SHAs. Verify with
+              tools when in doubt.
+            - If you finish all reports with budget remaining, do NOT pad — stop.
+
+      - name: Upload Claude analysis as artifact
+        if: steps.triage.outputs.cve_ids != '' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-cve-analysis
+          path: /tmp/issues/
+          if-no-files-found: warn
+
+      - name: File GitHub issues
+        if: steps.triage.outputs.cve_ids != '' && inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TEST_MODE: ${{ steps.triage.outputs.test_mode }}
+        run: |
+          set -uo pipefail
+
+          if [ ! -d /tmp/issues ] || [ -z "$(ls -A /tmp/issues 2>/dev/null)" ]; then
+            echo "::error::No analysis files in /tmp/issues — Claude may have failed silently"
+            exit 1
+          fi
+
+          failed=0
+          for f in /tmp/issues/*.md; do
+            cve=$(basename "$f" .md)
+            title=$(head -1 "$f" | sed 's/^# *//')
+            body=$(tail -n +2 "$f")
+
+            labels="security,cve"
+            if [ "$TEST_MODE" = "true" ]; then
+              labels="$labels,test"
+            fi
+
+            echo "Creating issue for $cve: $title"
+            if ! gh issue create \
+                --repo "$GITHUB_REPOSITORY" \
+                --title "$title" \
+                --body "$body" \
+                --label "$labels"; then
+              echo "::error::Failed to create issue for $cve"
+              failed=$((failed+1))
+            fi
+          done
+
+          if [ $failed -gt 0 ]; then
+            echo "::error::$failed issue(s) failed to create"
+            exit 1
+          fi
+
+      - name: Fail job if new CVEs were found (production mode only)
+        if: steps.triage.outputs.cve_ids != '' && steps.triage.outputs.test_mode != 'true'
+        run: |
+          echo "::error::Scan found new fixable HIGH/CRITICAL CVEs. See filed issues for details."
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -514,6 +514,9 @@ Available skills:
 - **regression-testing** -- End-to-end assembly regression testing against Terra submissions
 - **dsub-batch-jobs** -- Running one-off compute jobs on GCP via dsub
 - **container-vulns** -- Container vulnerability scanning, triage, and mitigation
+- **claude-on-vertex-ci** -- Invoking Claude (via claude-code-action) on Vertex AI from
+  GitHub Actions workflows. Covers the WIF infra in `viral-seq-ai`, how to add a new
+  Claude-in-CI use case, the canonical workflow YAML pattern, and gotchas.
 
 ---
 


### PR DESCRIPTION
## Summary

When the weekly Trivy scan finds new fixable HIGH/CRITICAL CVEs, hand them to Claude Sonnet 4.6 (on Vertex AI) for triage and file one GitHub issue per CVE. Inspired by the workflow we just did manually for CVE-2026-41316 (PR #1060): read the trivy JSON, trace the dep chain, check the Rego policy + `.trivyignore` for prior decisions, look at past commits for fix patterns, recommend a mitigation.

The "is this CVE new?" check uses GH issues themselves as source of truth — a CVE is new if no existing issue (open or closed) has the CVE ID in its title. So closing an issue (via fix-PR `Closes #N` or manually) naturally means "we addressed it"; the next scan won't re-file.

This also lays groundwork for future Claude-in-CI use cases (PR review, dep-update analysis, etc.) — the WIF pool + OIDC provider are reusable; per-use-case service accounts are cheap to add.

## Architecture

**GCP `viral-seq-ai` (already provisioned):**
- WIF pool: `github-actions-pool` (global)
- OIDC provider: `broadinstitute-github` (gated by `repository_owner == broadinstitute`)
- Service account: `viral-ngs-cve-triage@viral-seq-ai.iam.gserviceaccount.com`
- SA roles: `roles/aiplatform.user`, `roles/serviceusage.serviceUsageConsumer`
- WIF binding: scoped to `attribute.repository/broadinstitute/viral-ngs`

**GitHub repo variables (already set):**
- `GCP_PROJECT_ID` = `viral-seq-ai`
- `GCP_WIP_PROVIDER` = full WIF provider resource path
- `GCP_SA_EMAIL` = SA email above

**Workflow shape (after the existing Trivy steps):**
1. Identify new fixable CVEs (test mode passes input through; prod mode parses trivy JSON + dedups against `gh search issues … in:title`)
2. `google-github-actions/auth@v2` (WIF, no long-lived secret)
3. Ensure issue labels exist (`security`, `cve`, `test`)
4. `anthropics/claude-code-action@<SHA>` (pinned to v1) with Vertex env vars, Sonnet 4.6, 30-turn cap, read-only tool allowlist. Claude reads the SKILL.md, `.trivyignore`, Rego policy, Dockerfiles, and `git log` for prior fix patterns, then writes `/tmp/issues/<CVE-ID>.md` per CVE
5. Upload `/tmp/issues/` as artifact (`always()`)
6. File issues via `gh issue create` (skipped if `dry_run=true`)
7. Final step fails the job if new CVEs were found in production mode (preserves the loud-signal behavior of the existing workflow)

## workflow_dispatch testing inputs

- **`test_cve_id`** — bypass the new-CVE diff and force-analyze a specific CVE ID. Useful for end-to-end validation against a known-real CVE.
- **`dry_run`** — run Claude analysis and upload it as a workflow artifact, but skip `gh issue create`. Lets us inspect the output before committing to creating real issues.

## Cost / safety

- Claude only invoked when there are new CVEs (the diff step gates it)
- 30-turn cap per run; expected ~5–10 turns per CVE (observed: ~6–8)
- Sonnet 4.6 → est. $0.10–1 per CVE; 5-CVE-week well under $5
- SA can only call Vertex AI APIs and consume services — no GCS, IAM, BigQuery, etc.
- Provider only accepts OIDC tokens from `broadinstitute/*` repos
- SA only impersonable from `broadinstitute/viral-ngs` (any branch / workflow — easy to tighten later)
- Workflow checks out with `fetch-depth: 0` so Claude can `git log --grep` and `git show` precedent CVE-fix commits to mirror past mitigation patterns exactly

## Test plan

- [x] Dry-run end-to-end against a known CVE — artifact quality good (run [24999949466](https://github.com/broadinstitute/viral-ngs/actions/runs/24999949466))
- [x] Live test — Claude filed [#1062](https://github.com/broadinstitute/viral-ngs/issues/1062) with `security`, `cve`, `test` labels (run [25000408421](https://github.com/broadinstitute/viral-ngs/actions/runs/25000408421))
- [x] Coordinated with PR #1060 (erb gem fix) — `Closes #1062` added and merged
- [ ] Subsequent scheduled run on `main` post-merge should find zero new CVEs and exit 0 silently

## Notable iteration during review

- Addressed all 9 [Copilot review comments](https://github.com/broadinstitute/viral-ngs/pull/1061/files): deep clone (so Claude can use git history), `github.event.inputs.X` for schedule-trigger safety, glob/nullglob safety, dedup-integrity title guard, repeated `--label` flags, action pinned to commit SHA. (One thread left intentionally open: `Write` tool path-scoping — Claude Code's permission DSL doesn't accept the `Write(path/**)` form I tried; revisit with deny-rules in a follow-up.)
- Tightened the prompt twice based on dry-run artifact inspection: (a) require `git show <sha>` on precedent commit's full diff so the recommendation mirrors all elements (not just the headline change), (b) require querying `trivy-results.json` with `jq` for canonical CVSS data instead of inferring from training knowledge.
- Added an attribution footer to each generated issue body so maintainers can tell at a glance which reports are machine-authored.

## Related

- PR #1060 — manual fix for CVE-2026-41316 that prompted this work (merged)
- Issue #1062 — first end-to-end test of this pipeline; auto-closed by the #1060 merge

---

*Workflow design, GCP setup, prompt iteration, code, and PR body authored collaboratively in a Claude Code session with Claude Opus 4.7. Final review and merge by a human maintainer. The CVE-triage runtime that this workflow invokes uses Claude Sonnet 4.6 on Google Vertex AI. (Per [AGENTS.md](../blob/main/AGENTS.md) agent-attribution guidance.)*
