### PR TITLE
Fix gh search issues --state=all crash in CVE triage

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -133,13 +133,21 @@ jobs:
           fi
 
           # Dedup against existing GH issues (open + closed) by title-substring search.
+          # gh search issues --state only accepts "open" or "closed" (not "all"),
+          # so we query each state separately and sum the counts.
           new_cves=()
           for cve in $all_cves; do
-            count=$(gh search issues \
+            open=$(gh search issues \
               --repo "$GITHUB_REPOSITORY" \
-              --state=all \
+              --state open \
               "\"$cve\" in:title" \
               --json url --jq 'length')
+            closed=$(gh search issues \
+              --repo "$GITHUB_REPOSITORY" \
+              --state closed \
+              "\"$cve\" in:title" \
+              --json url --jq 'length')
+            count=$((open + closed))
             if [ "$count" = "0" ]; then
               new_cves+=("$cve")
               echo "  NEW: $cve"


### PR DESCRIPTION
## Summary

- Fixes a latent bug where `gh search issues --state=all` crashes with `invalid argument "all" for "--state" flag` -- `gh search issues` only accepts `open` or `closed`, not `all`
- This caused the "Identify new fixable CVEs" step to fail on the first weekly run that found a new fixable CVE (2026-05-11, run 25655591928), preventing Claude analysis and issue filing from running
- Splits the single query into two (`--state open` + `--state closed`) and sums the counts

## Why this was not caught before

Every previous weekly run either had 0 fixable CVEs (exiting before the dedup loop at line 132) or used `test_cve_id` via `workflow_dispatch` (a different code path at line 116). Today was the first time the production dedup code path was exercised.

## Test plan

- [ ] Merge and trigger `container-scan.yml` via `workflow_dispatch` with `dry_run=true` (no `test_cve_id`) to exercise the production dedup code path
- [ ] Verify the triage step completes without error
- [ ] Verify Claude analysis runs if a new CVE exists, or the step is cleanly skipped if all CVEs are already triaged