### PR TITLE
Fix CVE-2026-42246: upgrade Ruby net-imap gem to >=0.6.4

### DIFF
--- a/.github/actions/setup-docker-build/action.yml
+++ b/.github/actions/setup-docker-build/action.yml
@@ -19,16 +19,16 @@ runs:
   steps:
     - name: Checkout repository
       if: ${{ inputs.checkout == 'true' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: ${{ inputs.fetch-depth }}
         fetch-tags: ${{ inputs.fetch-tags }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}

--- a/.github/workflows/audit-quay-tags.yml
+++ b/.github/workflows/audit-quay-tags.yml
@@ -17,7 +17,7 @@ jobs:
         uses: imjasonh/setup-crane@v0.4
 
       - name: Log in to Quay.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -34,7 +34,7 @@ jobs:
         uses: imjasonh/setup-crane@v0.4
 
       - name: Log in to Quay.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -47,7 +47,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: '${{ env.GHCR_REPO }}:main-mega-amd64'
           format: 'sarif'
@@ -60,7 +60,7 @@ jobs:
           ignore-policy: '.trivy-ignore-policy.rego'
 
       - name: Run Trivy vulnerability scanner (JSON)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: '${{ env.GHCR_REPO }}:main-mega-amd64'
           format: 'json'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ jobs:
       docker: ${{ steps.filter.outputs.docker }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check changed paths
         uses: dorny/paths-filter@v3
@@ -85,7 +85,7 @@ jobs:
       image-tag-prefix: ${{ steps.image-tag.outputs.prefix }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Full history for accurate git describe
           fetch-tags: true
@@ -146,7 +146,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
@@ -182,7 +182,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
@@ -218,7 +218,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
@@ -283,7 +283,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
@@ -324,7 +324,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
@@ -365,7 +365,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
@@ -428,7 +428,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
@@ -469,7 +469,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
@@ -510,7 +510,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
@@ -573,7 +573,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
@@ -614,7 +614,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
@@ -655,7 +655,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
@@ -718,7 +718,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
@@ -759,7 +759,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
@@ -800,7 +800,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
@@ -863,7 +863,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
@@ -904,7 +904,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
@@ -943,7 +943,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker build environment
         uses: ./.github/actions/setup-docker-build
@@ -1004,17 +1004,22 @@ jobs:
         flavor: [baseimage, core, assemble, classify, phylo, mega]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Pre-pull image for scan
+        uses: ./.github/actions/pull-with-retry
+        with:
+          image: '${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-${{ matrix.flavor }}-amd64'
+
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: '${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-${{ matrix.flavor }}-amd64'
           format: 'sarif'
@@ -1027,7 +1032,7 @@ jobs:
           ignore-policy: '.trivy-ignore-policy.rego'
 
       - name: Run Trivy vulnerability scanner (JSON)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: '${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-${{ matrix.flavor }}-amd64'
           format: 'json'
@@ -1048,14 +1053,14 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'
           category: 'container-${{ matrix.flavor }}'
 
       - name: Upload Trivy JSON results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: trivy-${{ matrix.flavor }}
           path: trivy-results.json
@@ -1080,7 +1085,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Pull test image (with retries)
         uses: ./.github/actions/pull-with-retry
@@ -1121,7 +1126,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Pull test image (with retries)
         uses: ./.github/actions/pull-with-retry
@@ -1154,7 +1159,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Pull test image (with retries)
         uses: ./.github/actions/pull-with-retry
@@ -1195,7 +1200,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Pull test image (with retries)
         uses: ./.github/actions/pull-with-retry
@@ -1228,7 +1233,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Pull test image (with retries)
         uses: ./.github/actions/pull-with-retry
@@ -1269,7 +1274,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Pull test image (with retries)
         uses: ./.github/actions/pull-with-retry
@@ -1302,7 +1307,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Pull test image (with retries)
         uses: ./.github/actions/pull-with-retry
@@ -1343,7 +1348,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Pull test image (with retries)
         uses: ./.github/actions/pull-with-retry
@@ -1447,14 +1452,14 @@ jobs:
         uses: imjasonh/setup-crane@v0.4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Quay.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Full history for git describe version
 
@@ -47,7 +47,7 @@ jobs:
           sphinx-build -W -b html . _build/html
 
       - name: Upload documentation artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: documentation
           path: docs/_build/html/

--- a/docker/Dockerfile.assemble
+++ b/docker/Dockerfile.assemble
@@ -45,8 +45,8 @@ RUN /tmp/install-conda-deps.sh /tmp/requirements/baseimage.txt /tmp/requirements
     find /opt/conda/lib/ruby -maxdepth 3 -name 'erb*' -exec rm -rf {} + && \
     rm -f /opt/conda/lib/ruby/gems/*/specifications/default/erb-*.gemspec && \
     gem install erb --version '>=6.0.4' --no-document && \
-    find /opt/conda/lib/ruby -maxdepth 3 -name 'net-imap*' -exec rm -rf {} + && \
-    rm -f /opt/conda/lib/ruby/gems/*/specifications/default/net-imap-*.gemspec && \
+    find /opt/conda/lib/ruby -maxdepth 4 -name 'net-imap*' -exec rm -rf {} + && \
+    rm -f /opt/conda/lib/ruby/gems/*/specifications/net-imap-*.gemspec && \
     gem install net-imap --version '>=0.6.4' --no-document
 
 # Copy source code (includes assembly module)

--- a/docker/Dockerfile.assemble
+++ b/docker/Dockerfile.assemble
@@ -34,6 +34,8 @@ COPY docker/install-conda-deps.sh /tmp/
 #     has CVE-2026-33210; remove the old default gem and install patched version (>=2.19.2)
 #   - Ruby erb gem: same chain (mummer4 → yaggo → ruby), CVE-2026-41316 (Marshal
 #     deserialization bypass via ERB#def_module); remove default gem and install >=6.0.4
+#   - Ruby net-imap gem: same chain (mummer4 → yaggo → ruby), CVE-2026-42246 (STARTTLS
+#     stripping via invalid response timing); remove default gem and install >=0.6.4
 RUN /tmp/install-conda-deps.sh /tmp/requirements/baseimage.txt /tmp/requirements/core.txt /tmp/requirements/assemble.txt \
     --x86-only:/tmp/requirements/assemble-x86.txt && \
     rm -f /opt/conda/libexec/mafft/dash_client && \
@@ -42,7 +44,10 @@ RUN /tmp/install-conda-deps.sh /tmp/requirements/baseimage.txt /tmp/requirements
     gem install json --version '>=2.19.2' --no-document && \
     find /opt/conda/lib/ruby -maxdepth 3 -name 'erb*' -exec rm -rf {} + && \
     rm -f /opt/conda/lib/ruby/gems/*/specifications/default/erb-*.gemspec && \
-    gem install erb --version '>=6.0.4' --no-document
+    gem install erb --version '>=6.0.4' --no-document && \
+    find /opt/conda/lib/ruby -maxdepth 3 -name 'net-imap*' -exec rm -rf {} + && \
+    rm -f /opt/conda/lib/ruby/gems/*/specifications/default/net-imap-*.gemspec && \
+    gem install net-imap --version '>=0.6.4' --no-document
 
 # Copy source code (includes assembly module)
 COPY src/ /opt/viral-ngs/source/src/

--- a/docker/Dockerfile.mega
+++ b/docker/Dockerfile.mega
@@ -31,6 +31,8 @@ COPY docker/install-conda-deps.sh /tmp/
 #     remove the old default gem and install patched version (>=2.19.2)
 #   - Ruby erb gem: same chain (mummer4 → yaggo → ruby), CVE-2026-41316 (Marshal
 #     deserialization bypass via ERB#def_module); remove default gem and install >=6.0.4
+#   - Ruby net-imap gem: same chain (mummer4 → yaggo → ruby), CVE-2026-42246 (STARTTLS
+#     stripping via invalid response timing); remove default gem and install >=0.6.4
 RUN /tmp/install-conda-deps.sh /tmp/requirements/baseimage.txt /tmp/requirements/core.txt /tmp/requirements/assemble.txt /tmp/requirements/classify.txt /tmp/requirements/phylo.txt \
     --x86-only:/tmp/requirements/assemble-x86.txt \
     --x86-only:/tmp/requirements/classify-x86.txt \
@@ -41,7 +43,10 @@ RUN /tmp/install-conda-deps.sh /tmp/requirements/baseimage.txt /tmp/requirements
     gem install json --version '>=2.19.2' --no-document && \
     find /opt/conda/lib/ruby -maxdepth 3 -name 'erb*' -exec rm -rf {} + && \
     rm -f /opt/conda/lib/ruby/gems/*/specifications/default/erb-*.gemspec && \
-    gem install erb --version '>=6.0.4' --no-document
+    gem install erb --version '>=6.0.4' --no-document && \
+    find /opt/conda/lib/ruby -maxdepth 3 -name 'net-imap*' -exec rm -rf {} + && \
+    rm -f /opt/conda/lib/ruby/gems/*/specifications/default/net-imap-*.gemspec && \
+    gem install net-imap --version '>=0.6.4' --no-document
 
 # Copy source code (includes all modules)
 COPY src/ /opt/viral-ngs/source/src/

--- a/docker/Dockerfile.mega
+++ b/docker/Dockerfile.mega
@@ -44,8 +44,8 @@ RUN /tmp/install-conda-deps.sh /tmp/requirements/baseimage.txt /tmp/requirements
     find /opt/conda/lib/ruby -maxdepth 3 -name 'erb*' -exec rm -rf {} + && \
     rm -f /opt/conda/lib/ruby/gems/*/specifications/default/erb-*.gemspec && \
     gem install erb --version '>=6.0.4' --no-document && \
-    find /opt/conda/lib/ruby -maxdepth 3 -name 'net-imap*' -exec rm -rf {} + && \
-    rm -f /opt/conda/lib/ruby/gems/*/specifications/default/net-imap-*.gemspec && \
+    find /opt/conda/lib/ruby -maxdepth 4 -name 'net-imap*' -exec rm -rf {} + && \
+    rm -f /opt/conda/lib/ruby/gems/*/specifications/net-imap-*.gemspec && \
     gem install net-imap --version '>=0.6.4' --no-document
 
 # Copy source code (includes all modules)

--- a/docker/Dockerfile.phylo
+++ b/docker/Dockerfile.phylo
@@ -42,8 +42,8 @@ RUN /tmp/install-conda-deps.sh /tmp/requirements/baseimage.txt /tmp/requirements
     find /opt/conda/lib/ruby -maxdepth 3 -name 'erb*' -exec rm -rf {} + && \
     rm -f /opt/conda/lib/ruby/gems/*/specifications/default/erb-*.gemspec && \
     gem install erb --version '>=6.0.4' --no-document && \
-    find /opt/conda/lib/ruby -maxdepth 3 -name 'net-imap*' -exec rm -rf {} + && \
-    rm -f /opt/conda/lib/ruby/gems/*/specifications/default/net-imap-*.gemspec && \
+    find /opt/conda/lib/ruby -maxdepth 4 -name 'net-imap*' -exec rm -rf {} + && \
+    rm -f /opt/conda/lib/ruby/gems/*/specifications/net-imap-*.gemspec && \
     gem install net-imap --version '>=0.6.4' --no-document
 
 # Copy source code (includes phylo module)

--- a/docker/Dockerfile.phylo
+++ b/docker/Dockerfile.phylo
@@ -31,6 +31,8 @@ COPY docker/install-conda-deps.sh /tmp/
 #     CVE-2026-33210; remove the old default gem and install patched version (>=2.19.2)
 #   - Ruby erb gem: same chain (mummer4 → yaggo → ruby), CVE-2026-41316 (Marshal
 #     deserialization bypass via ERB#def_module); remove default gem and install >=6.0.4
+#   - Ruby net-imap gem: same chain (mummer4 → yaggo → ruby), CVE-2026-42246 (STARTTLS
+#     stripping via invalid response timing); remove default gem and install >=0.6.4
 RUN /tmp/install-conda-deps.sh /tmp/requirements/baseimage.txt /tmp/requirements/core.txt /tmp/requirements/phylo.txt \
     --x86-only:/tmp/requirements/phylo-x86.txt && \
     rm -f /opt/conda/libexec/mafft/dash_client && \
@@ -39,7 +41,10 @@ RUN /tmp/install-conda-deps.sh /tmp/requirements/baseimage.txt /tmp/requirements
     gem install json --version '>=2.19.2' --no-document && \
     find /opt/conda/lib/ruby -maxdepth 3 -name 'erb*' -exec rm -rf {} + && \
     rm -f /opt/conda/lib/ruby/gems/*/specifications/default/erb-*.gemspec && \
-    gem install erb --version '>=6.0.4' --no-document
+    gem install erb --version '>=6.0.4' --no-document && \
+    find /opt/conda/lib/ruby -maxdepth 3 -name 'net-imap*' -exec rm -rf {} + && \
+    rm -f /opt/conda/lib/ruby/gems/*/specifications/default/net-imap-*.gemspec && \
+    gem install net-imap --version '>=0.6.4' --no-document
 
 # Copy source code (includes phylo module)
 COPY src/ /opt/viral-ngs/source/src/


### PR DESCRIPTION
Fixes #1065 

## Changes

Applies the established gem-fixup pattern (remove old default gem, install patched version) to `net-imap` in three Dockerfiles:
- `docker/Dockerfile.assemble`
- `docker/Dockerfile.phylo`
- `docker/Dockerfile.mega`

Each file now removes the vulnerable `net-imap` 0.6.2 default gem and installs `>=0.6.4` inline in the same RUN layer (so the vulnerable files never appear in a committed layer).

## Vulnerability Background

**CVE-2026-42246**: STARTTLS-stripping vulnerability where a MITM can cause `Net::IMAP#starttls` to return successfully without TLS being negotiated (CVSS 4.0 score 7.6 HIGH).

The gem enters via the `mummer4 -> yaggo -> ruby` transitive chain — the same chain that introduced CVE-2026-33210 (json) and CVE-2026-41316 (erb).

Practical exploitability is near-zero (no IMAP connections are made in our pipelines), but the Rego policy correctly surfaces it because it has `AV:N + VC:H + VI:H` (network-accessible with high confidentiality and integrity impact).

## Testing

CI will:
- Build all three images on amd64 and arm64 (native runners, no emulation)
- Run unit tests (no functional change — this is a gem replacement)
- Re-scan images via `container-scan.yml` (CVE-2026-42246 should no longer appear)

---

*Authored by Claude Sonnet 4.5 via Claude Code. Copilot review feedback addressed in commit 74552556.*