### PR TITLE
Fix artifact upload and reduce Claude permission denials in CVE triage

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -208,7 +208,12 @@ jobs:
                   "Bash(ls:*)",
                   "Bash(cat:*)",
                   "Bash(head:*)",
-                  "Bash(tail:*)"
+                  "Bash(tail:*)",
+                  "Bash(echo:*)",
+                  "Bash(wc:*)",
+                  "Bash(sed:*)",
+                  "Bash(diff:*)",
+                  "Bash(sort:*)"
                 ]
               }
             }
@@ -306,14 +311,6 @@ jobs:
               tools when in doubt.
             - If you finish all reports with budget remaining, do NOT pad — stop.
 
-      - name: Upload Claude analysis as artifact
-        if: steps.triage.outputs.cve_ids != '' && always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: claude-cve-analysis
-          path: .claude-issues/
-          if-no-files-found: warn
-
       - name: File GitHub issues
         if: steps.triage.outputs.cve_ids != '' && (github.event.inputs.dry_run || 'false') != 'true'
         env:
@@ -369,6 +366,14 @@ jobs:
             echo "::error::$failed issue(s) failed to create"
             exit 1
           fi
+
+      - name: Upload Claude analysis as artifact
+        if: steps.triage.outputs.cve_ids != '' && always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: claude-cve-analysis
+          path: .claude-issues/*.md
+          if-no-files-found: warn
 
       - name: Fail job if new CVEs were found (production mode only)
         if: steps.triage.outputs.cve_ids != '' && steps.triage.outputs.test_mode != 'true'


### PR DESCRIPTION
## Summary

- Expand Bash permissions (`echo`, `wc`, `sed`, `diff`, `sort`) in the Claude Code Action settings to eliminate ~5 permission denials per run, reducing wasted turns and cost
- Fix artifact upload glob: `.claude-issues/` → `.claude-issues/*.md` so `upload-artifact@v6` matches files correctly (resolves the "No files found" warning from run 25671433094)
- Reorder steps: file GitHub issues before uploading artifact, since issue creation is the critical path and the upload step already has `always()` guard

## Test plan

- [ ] Merge and trigger `workflow_dispatch` with `test_cve_id=CVE-2026-42246` and `dry_run=true`
- [ ] Verify `permission_denials_count` drops to 0 or near-0
- [ ] Verify artifact upload succeeds without "No files found" warning
- [ ] Verify steps execute in correct order (issues filed before artifact upload)