### PR TITLE
Fix artifact upload: include hidden files for .claude-issues/

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -374,6 +374,7 @@ jobs:
           name: claude-cve-analysis
           path: .claude-issues/*.md
           if-no-files-found: warn
+          include-hidden-files: true
 
       - name: Fail job if new CVEs were found (production mode only)
         if: steps.triage.outputs.cve_ids != '' && steps.triage.outputs.test_mode != 'true'


### PR DESCRIPTION
## Summary

- `upload-artifact@v6` excludes hidden directories (names starting with `.`) by default since Sep 2024
- Since `.claude-issues/` is a dot-directory, all files inside it were silently skipped during artifact upload, causing the "No files were found" warning
- Adding `include-hidden-files: true` fixes this

This is the root cause of the artifact upload warning that persisted through PRs #1064 and #1067 — the glob pattern was never the issue; it was the hidden-directory exclusion.

## Test plan

- [ ] Merge and trigger `workflow_dispatch` with `test_cve_id=CVE-2026-42246` and `dry_run=true`
- [ ] Verify artifact upload succeeds (no "No files found" warning)
- [ ] Verify `claude-cve-analysis` artifact contains the `.md` file