### PR TITLE
Fix CVE-2026-44431 and CVE-2026-44432: pin urllib3>=2.7.0

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -2,8 +2,8 @@ name: Scheduled Container Vulnerability Scan
 
 on:
   schedule:
-    # Weekly scan of main branch mega image every Monday at 06:00 UTC
-    - cron: '0 6 * * 1'
+    # Daily scan of main branch mega image at 12:00 UTC
+    - cron: '0 12 * * *'
   workflow_dispatch:
     inputs:
       test_cve_id:

--- a/docker/Dockerfile.baseimage
+++ b/docker/Dockerfile.baseimage
@@ -63,11 +63,14 @@ COPY docker/install-conda-deps.sh /tmp/
 # Remove gcloud-crc32c — Go binary compiled with old Go stdlib (CVEs).
 # Remove gsutil's vendored urllib3 dummyserver — contains a dummy private key
 # that triggers secret-detection scanners (e.g. Trivy).
+# Remove cryptography documentation — contains example private keys that
+# trigger secret-detection scanners (e.g. Trivy).
 # gcloud/gsutil use the conda environment Python, not the bundled one.
 RUN /tmp/install-conda-deps.sh /tmp/requirements/baseimage.txt && \
     rm -rf /opt/conda/share/google-cloud-sdk-*/platform/bundledpythonunix && \
     rm -f /opt/conda/share/google-cloud-sdk-*/bin/gcloud-crc32c && \
     rm -rf /opt/conda/share/google-cloud-sdk-*/platform/gsutil/third_party/urllib3/dummyserver && \
+    rm -rf /opt/conda/lib/python3.12/site-packages/docs && \
     rm -rf /tmp/requirements /tmp/install-conda-deps.sh
 
 # Install firecloud via pip instead of conda because the conda noarch

--- a/docker/requirements/baseimage.txt
+++ b/docker/requirements/baseimage.txt
@@ -22,6 +22,7 @@ jaraco.context>=6.1.0
 pyopenssl>=26.0.0
 pyasn1>=0.6.3
 tornado>=6.5.4
+urllib3>=2.7.0
 
 # General utilities
 csvkit>=1.0.4


### PR DESCRIPTION
## Summary

Fixes #1069 (CVE-2026-44431: sensitive headers forwarded across origins)
Fixes #1070 (CVE-2026-44432: decompression-bomb bypass in streaming API)

Both CVEs affect urllib3 2.6.3 (transitive dependency of `requests`). Both are fixed in urllib3 >= 2.7.0.

## Changes

1. **Pin urllib3>=2.7.0** in `docker/requirements/baseimage.txt` (Python security libraries section)
2. **Remove cryptography docs** from baseimage to fix Trivy secret scan failures (cryptography documentation contains example private keys that trigger Trivy's secret scanner)
3. **Increase container scan frequency** from weekly (Monday 6am UTC) to daily (12pm UTC) to catch new CVEs within 24 hours instead of up to 7 days

## Verification

- urllib3 2.7.0 is available on conda-forge as `noarch` (works on both amd64 and arm64)
- CI docker builds will confirm conda can resolve the pin without solver conflicts
- CI test suite will confirm no regressions from the urllib3 upgrade
- CI Trivy scan will confirm both CVEs no longer appear and secret scan passes
- Daily scans will run at 12pm UTC (7-8am Boston time depending on DST)
