### PR TITLE
Feature/centrifuger integration

### DIFF
--- a/docker/requirements/classify.txt
+++ b/docker/requirements/classify.txt
@@ -7,3 +7,4 @@ kmc>=3.2.1
 kraken2>=2.1.3
 krona>=2.8.1
 last>=1541
+centrifuger>=1.0

--- a/src/viral_ngs/classify/__init__.py
+++ b/src/viral_ngs/classify/__init__.py
@@ -2,6 +2,7 @@
 
 from . import blast
 from . import bmtagger
+from . import centrifuger
 from . import kb
 from . import kma
 from . import kmc

--- a/src/viral_ngs/classify/centrifuger.py
+++ b/src/viral_ngs/classify/centrifuger.py
@@ -1,6 +1,7 @@
 '''
 Centrifuger metagenomics classifier.
 '''
+import csv
 import logging
 import os
 import shutil
@@ -13,6 +14,17 @@ import viral_ngs.core.picard as picard
 import viral_ngs.core.samtools as samtools
 
 log = logging.getLogger(__name__)
+
+CLASSIFICATION_HEADER = [
+    'readID',
+    'seqID',
+    'taxID',
+    'score',
+    '2ndBestScore',
+    'hitLength',
+    'queryLength',
+    'numMatches',
+]
 
 
 class Centrifuger(core.Tool):
@@ -97,7 +109,7 @@ class Centrifuger(core.Tool):
 
         self.execute('centrifuger-build', options=opts)
 
-    def classify(self, in_bam, db, output, k=None, unclassified_prefix=None,
+    def classify(self, in_bam, db, output, k=1, unclassified_prefix=None,
                  classified_prefix=None, min_hitlen=None, hitk_factor=None,
                  merge_readpair=False, num_threads=None):
         '''Classify reads from an unaligned BAM file.'''
@@ -105,8 +117,8 @@ class Centrifuger(core.Tool):
             raise FileNotFoundError(in_bam)
         if samtools.SamtoolsTool().isEmpty(in_bam):
             log.warning('Input BAM is empty, skipping Centrifuger classification')
-            with open(output, 'wt'):
-                pass
+            with open(output, 'wt') as outf:
+                outf.write('\t'.join(CLASSIFICATION_HEADER) + '\n')
             return
 
         tmp_fastq1 = util_file.mkstempfname('.1.fastq')
@@ -172,6 +184,49 @@ class Centrifuger(core.Tool):
             opts['--output-format'] = output_format
 
         self.execute('centrifuger-quant', output=output, options=opts)
+
+    @staticmethod
+    def classification_to_kraken2(classification, output):
+        '''Convert Centrifuger classification TSV to Kraken2-style read TSV.
+
+        This assumes the Centrifuger classification was produced with k=1.
+        The output contains one classified Kraken2-style row per classified
+        Centrifuger row and omits unclassified reads.
+        '''
+        previous_classified_read_id = None
+
+        with util_file.open_or_gzopen(str(classification), 'rt') as inf, \
+                util_file.open_or_gzopen(str(output), 'wt') as outf:
+            header = inf.readline()
+            if not header:
+                return
+            writer = csv.writer(outf, delimiter='\t', lineterminator='\n')
+
+            for line_no, line in enumerate(inf, start=2):
+                if not line.strip():
+                    continue
+                cols = line.rstrip('\n').split('\t')
+                if len(cols) < 7:
+                    raise ValueError(
+                        'Malformed Centrifuger classification row '
+                        f'at line {line_no}: expected at least 7 columns'
+                    )
+
+                read_id = cols[0]
+                seq_id = cols[1]
+                tax_id = cols[2]
+                query_length = cols[6]
+
+                if tax_id == '0' or seq_id == 'unclassified':
+                    continue
+                if read_id == previous_classified_read_id:
+                    raise ValueError(
+                        'Consecutive duplicate classified readID in Centrifuger output: '
+                        f'{read_id}. Expected k=1 input.'
+                    )
+
+                previous_classified_read_id = read_id
+                writer.writerow(['C', read_id, tax_id, query_length, 'N/A'])
 
     def kreport(self, db, classification, output, no_lca=False,
                 show_zeros=False, is_count_table=False, min_score=None,

--- a/src/viral_ngs/classify/centrifuger.py
+++ b/src/viral_ngs/classify/centrifuger.py
@@ -1,0 +1,172 @@
+'''
+Centrifuger metagenomics classifier.
+'''
+import logging
+import os
+import shutil
+import subprocess
+
+import viral_ngs.core as core
+import viral_ngs.core.file as util_file
+import viral_ngs.core.misc as util_misc
+import viral_ngs.core.picard as picard
+import viral_ngs.core.samtools as samtools
+
+log = logging.getLogger(__name__)
+
+
+class Centrifuger(core.Tool):
+
+    def __init__(self, install_methods=None):
+        if not install_methods:
+            install_methods = [
+                core.PrexistingUnixCommand(
+                    shutil.which('centrifuger'),
+                    require_executability=False,
+                )
+            ]
+        super().__init__(install_methods=install_methods)
+
+    def version(self):
+        # Centrifuger uses `-v` (not `--version`); passing `--version`
+        # triggers a buffer overflow in the binary and aborts.
+        try:
+            result = subprocess.run(
+                ['centrifuger', '-v'],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return 'unknown'
+        return (result.stdout or result.stderr).strip() or 'unknown'
+
+    @property
+    def libexec(self):
+        if not self.executable_path():
+            self.install_and_get_path()
+        return os.path.dirname(self.executable_path())
+
+    def execute(self, command, output=None, args=None, options=None):
+        '''Run a Centrifuger command.'''
+        args = args or []
+        options = options or {}
+
+        cmd = [command]
+        for key, value in options.items():
+            if value is None:
+                cmd.append(key)
+            elif isinstance(value, (list, tuple)):
+                for item in value:
+                    cmd.extend([key, str(item)])
+            else:
+                cmd.extend([key, str(value)])
+        cmd.extend(args)
+
+        log.debug('Calling %s: %s', command, ' '.join(cmd))
+        if output:
+            with open(output, 'wt') as outf:
+                subprocess.check_call(cmd, stdout=outf)
+        else:
+            subprocess.check_call(cmd)
+
+    def build(self, db_prefix, taxonomy_tree, name_table, ref_fastas=None,
+              ref_list=None, conversion_table=None, build_mem=None,
+              num_threads=None):
+        '''Build a Centrifuger index.'''
+        if bool(ref_fastas) == bool(ref_list):
+            raise ValueError('Specify exactly one of ref_fastas or ref_list')
+
+        opts = {
+            '--taxonomy-tree': taxonomy_tree,
+            '--name-table': name_table,
+            '-o': db_prefix,
+        }
+        if ref_fastas:
+            if isinstance(ref_fastas, str):
+                ref_fastas = [ref_fastas]
+            opts['-r'] = ref_fastas
+        else:
+            opts['-l'] = ref_list
+        if conversion_table:
+            opts['--conversion-table'] = conversion_table
+        if build_mem:
+            opts['--build-mem'] = build_mem
+        if num_threads:
+            opts['-t'] = util_misc.sanitize_thread_count(num_threads)
+
+        self.execute('centrifuger-build', options=opts)
+
+    def classify(self, in_bam, db, output, k=None, unclassified_prefix=None,
+                 classified_prefix=None, min_hitlen=None, hitk_factor=None,
+                 merge_readpair=False, num_threads=None):
+        '''Classify reads from an unaligned BAM file.'''
+        if samtools.SamtoolsTool().isEmpty(in_bam):
+            log.warning('Input BAM is empty, skipping Centrifuger classification')
+            with open(output, 'wt'):
+                pass
+            return
+
+        tmp_fastq1 = util_file.mkstempfname('.1.fastq')
+        tmp_fastq2 = util_file.mkstempfname('.2.fastq')
+        tmp_fastq3 = util_file.mkstempfname('.s.fastq')
+
+        try:
+            picard_tool = picard.SamToFastqTool()
+            picard_opts = {
+                'CLIPPING_ATTRIBUTE': picard.SamToFastqTool.illumina_clipping_attribute,
+                'CLIPPING_ACTION': 'X',
+            }
+            picard_tool.execute(
+                in_bam,
+                tmp_fastq1,
+                tmp_fastq2,
+                outFastq0=tmp_fastq3,
+                picardOptions=picard.PicardTools.dict_to_picard_opts(picard_opts),
+                JVMmemory=picard_tool.jvmMemDefault,
+            )
+
+            opts = {'-x': db}
+            if num_threads:
+                opts['-t'] = util_misc.sanitize_thread_count(num_threads)
+            if k is not None:
+                opts['-k'] = k
+            if unclassified_prefix:
+                opts['--un'] = unclassified_prefix
+            if classified_prefix:
+                opts['--cl'] = classified_prefix
+            if min_hitlen is not None:
+                opts['--min-hitlen'] = min_hitlen
+            if hitk_factor is not None:
+                opts['--hitk-factor'] = hitk_factor
+            if merge_readpair:
+                opts['--merge-readpair'] = None
+
+            if os.path.getsize(tmp_fastq2) < os.path.getsize(tmp_fastq3):
+                log.warning('running in single-end read mode')
+                opts['-u'] = tmp_fastq3
+            else:
+                opts['-1'] = tmp_fastq1
+                opts['-2'] = tmp_fastq2
+
+            self.execute('centrifuger', output=output, options=opts)
+        finally:
+            for path in (tmp_fastq1, tmp_fastq2, tmp_fastq3):
+                if os.path.exists(path):
+                    os.unlink(path)
+
+    def quant(self, db, classification, output, min_score=None,
+              min_length=None, output_format=None):
+        '''Run centrifuger-quant on a classification output.'''
+        opts = {
+            '-x': db,
+            '-c': classification,
+        }
+        if min_score is not None:
+            opts['--min-score'] = min_score
+        if min_length is not None:
+            opts['--min-length'] = min_length
+        if output_format is not None:
+            opts['--output-format'] = output_format
+
+        self.execute('centrifuger-quant', output=output, options=opts)

--- a/src/viral_ngs/classify/centrifuger.py
+++ b/src/viral_ngs/classify/centrifuger.py
@@ -178,7 +178,22 @@ class Centrifuger(core.Tool):
 
         Wraps the centrifuger-kreport Perl script, which writes its output
         to stdout; the wrapper redirects stdout to `output`.
+
+        Short-circuits on empty or header-only classification input
+        (centrifuger-kreport exits 255 with `No sequence matches with
+        given settings` in that case). This mirrors the empty-BAM
+        short-circuit in classify() so callers can chain
+        classify -> kreport unconditionally.
         '''
+        if self._classification_is_empty(classification):
+            log.warning(
+                'Classification file %s has no data rows, '
+                'skipping centrifuger-kreport', classification,
+            )
+            with open(output, 'wt'):
+                pass
+            return
+
         opts = {'-x': db}
         if no_lca:
             opts['--no-lca'] = None
@@ -199,3 +214,12 @@ class Centrifuger(core.Tool):
             args=[classification],
             options=opts,
         )
+
+    @staticmethod
+    def _classification_is_empty(path):
+        '''Return True if `path` has no data rows (empty file or header only).'''
+        if os.path.getsize(path) == 0:
+            return True
+        with open(path, 'rt') as inf:
+            inf.readline()  # discard header
+            return not inf.readline().strip()

--- a/src/viral_ngs/classify/centrifuger.py
+++ b/src/viral_ngs/classify/centrifuger.py
@@ -101,6 +101,8 @@ class Centrifuger(core.Tool):
                  classified_prefix=None, min_hitlen=None, hitk_factor=None,
                  merge_readpair=False, num_threads=None):
         '''Classify reads from an unaligned BAM file.'''
+        if not os.path.isfile(in_bam):
+            raise FileNotFoundError(in_bam)
         if samtools.SamtoolsTool().isEmpty(in_bam):
             log.warning('Input BAM is empty, skipping Centrifuger classification')
             with open(output, 'wt'):
@@ -185,7 +187,9 @@ class Centrifuger(core.Tool):
         short-circuit in classify() so callers can chain
         classify -> kreport unconditionally.
         '''
-        if self._classification_is_empty(classification):
+        if self._classification_is_empty(
+                classification,
+                has_header=not is_count_table):
             log.warning(
                 'Classification file %s has no data rows, '
                 'skipping centrifuger-kreport', classification,
@@ -216,10 +220,11 @@ class Centrifuger(core.Tool):
         )
 
     @staticmethod
-    def _classification_is_empty(path):
-        '''Return True if `path` has no data rows (empty file or header only).'''
+    def _classification_is_empty(path, has_header=True):
+        '''Return True if `path` has no data rows.'''
         if os.path.getsize(path) == 0:
             return True
         with open(path, 'rt') as inf:
-            inf.readline()  # discard header
-            return not inf.readline().strip()
+            if has_header:
+                inf.readline()
+            return not any(line.strip() for line in inf)

--- a/src/viral_ngs/classify/centrifuger.py
+++ b/src/viral_ngs/classify/centrifuger.py
@@ -170,3 +170,32 @@ class Centrifuger(core.Tool):
             opts['--output-format'] = output_format
 
         self.execute('centrifuger-quant', output=output, options=opts)
+
+    def kreport(self, db, classification, output, no_lca=False,
+                show_zeros=False, is_count_table=False, min_score=None,
+                min_length=None, report_score_data=False):
+        '''Produce a Kraken-style report from a centrifuger classification.
+
+        Wraps the centrifuger-kreport Perl script, which writes its output
+        to stdout; the wrapper redirects stdout to `output`.
+        '''
+        opts = {'-x': db}
+        if no_lca:
+            opts['--no-lca'] = None
+        if show_zeros:
+            opts['--show-zeros'] = None
+        if is_count_table:
+            opts['--is-count-table'] = None
+        if min_score is not None:
+            opts['--min-score'] = min_score
+        if min_length is not None:
+            opts['--min-length'] = min_length
+        if report_score_data:
+            opts['--report-score-data'] = None
+
+        self.execute(
+            'centrifuger-kreport',
+            output=output,
+            args=[classification],
+            options=opts,
+        )

--- a/src/viral_ngs/core/file.py
+++ b/src/viral_ngs/core/file.py
@@ -374,12 +374,15 @@ def zstd_open(fname, mode='r', **kwargs):
         with open(fname, 'wb') as fh:
             cctx = zstd.ZstdCompressor(level=kwargs.get('level', 10),
                                        threads=util_misc.sanitize_thread_count(kwargs.get('threads', None)))
-            stream_writer = cctx.stream_writer(fh)
-            if 'b' not in mode:
-                text_stream = io.TextIOWrapper(stream_reader, encoding='utf-8')
-                yield text_stream
-                return
-            yield stream_writer
+            with cctx.stream_writer(fh) as stream_writer:
+                if 'b' not in mode:
+                    text_stream = io.TextIOWrapper(stream_writer, encoding='utf-8')
+                    try:
+                        yield text_stream
+                    finally:
+                        text_stream.flush()
+                    return
+                yield stream_writer
 
 def open_or_gzopen(fname, mode='r', **kwargs):
     assert type(mode) == str, "open mode must be of type str"
@@ -1254,4 +1257,3 @@ class CountDB(DBConnection):
     def get_num_IDS(self):
         return self.cur.execute("SELECT COUNT() FROM counts").fetchone()[0]
     
-

--- a/src/viral_ngs/metagenomics.py
+++ b/src/viral_ngs/metagenomics.py
@@ -579,6 +579,50 @@ def main_centrifuger_quant(db, classification, output, min_score=None,
 __commands__.append(('centrifuger_quant', parser_centrifuger_quant))
 
 
+def parser_centrifuger_kreport(parser=argparse.ArgumentParser()):
+    parser.add_argument('db', help='Centrifuger database prefix.')
+    parser.add_argument('classification', help='Centrifuger classification output file.')
+    parser.add_argument('output', help='Kraken-style hierarchical report output file.')
+    parser.add_argument('--no_lca', action='store_true',
+                        help='Do not promote multi-assignment reads to their LCA; report counts at the original taxa.')
+    parser.add_argument('--show_zeros', action='store_true',
+                        help='Include taxa with zero reads in the report.')
+    parser.add_argument('--is_count_table', action='store_true',
+                        help='Input is a taxID<TAB>count table instead of the standard centrifuger output.')
+    parser.add_argument('--min_score', type=int, help='Minimum score for reads to be counted.')
+    parser.add_argument('--min_length', type=int, help='Minimum alignment length for reads to be counted.')
+    parser.add_argument('--report_score_data', action='store_true',
+                        help='Append an extra column summarizing classification scores.')
+    cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
+    cmd.attach_main(parser, main_centrifuger_kreport, split_args=True)
+    return parser
+
+
+def main_centrifuger_kreport(db, classification, output, no_lca=False,
+                             show_zeros=False, is_count_table=False,
+                             min_score=None, min_length=None,
+                             report_score_data=False):
+    '''
+        Produce a Kraken-style hierarchical report from a Centrifuger
+        classification output file.
+    '''
+    centrifuger_tool = centrifuger.Centrifuger()
+    centrifuger_tool.kreport(
+        db,
+        classification,
+        output,
+        no_lca=no_lca,
+        show_zeros=show_zeros,
+        is_count_table=is_count_table,
+        min_score=min_score,
+        min_length=min_length,
+        report_score_data=report_score_data,
+    )
+
+
+__commands__.append(('centrifuger_kreport', parser_centrifuger_kreport))
+
+
 def parser_krona(parser=argparse.ArgumentParser()):
     parser.add_argument('inReports', nargs='+', help='Input report file (default: tsv)')
     parser.add_argument('db', help='Krona taxonomy database directory.')

--- a/src/viral_ngs/metagenomics.py
+++ b/src/viral_ngs/metagenomics.py
@@ -476,7 +476,8 @@ def parser_centrifuger(parser=argparse.ArgumentParser()):
     parser.add_argument('db', help='Centrifuger database prefix.')
     parser.add_argument('in_bam', help='Input unaligned reads, BAM format.')
     parser.add_argument('out_classification', help='Centrifuger per-read classification output file.')
-    parser.add_argument('--k', type=int, help='Report top k classification results for each read.')
+    parser.add_argument('--k', type=int, default=1,
+                        help='Report top k classification results for each read. Default: 1.')
     parser.add_argument('--unclassified_prefix', help='Output prefix for unclassified reads.')
     parser.add_argument('--classified_prefix', help='Output prefix for classified reads.')
     parser.add_argument('--min_hitlen', type=int, help='Minimum total length of matched segments.')
@@ -487,7 +488,7 @@ def parser_centrifuger(parser=argparse.ArgumentParser()):
     return parser
 
 
-def main_centrifuger(db, in_bam, out_classification, k=None,
+def main_centrifuger(db, in_bam, out_classification, k=1,
                     unclassified_prefix=None, classified_prefix=None,
                     min_hitlen=None, hitk_factor=None,
                     merge_readpair=False, threads=None):

--- a/src/viral_ngs/metagenomics.py
+++ b/src/viral_ngs/metagenomics.py
@@ -581,6 +581,28 @@ def main_centrifuger_quant(db, classification, output, min_score=None,
 __commands__.append(('centrifuger_quant', parser_centrifuger_quant))
 
 
+def parser_centrifuger_classification_to_kraken2(parser=argparse.ArgumentParser()):
+    parser.add_argument('classification', help='Centrifuger per-read classification output file.')
+    parser.add_argument('output', help='Kraken2-style per-read classification output file.')
+    cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
+    cmd.attach_main(parser, main_centrifuger_classification_to_kraken2, split_args=True)
+    return parser
+
+
+def main_centrifuger_classification_to_kraken2(classification, output):
+    '''
+        Convert Centrifuger per-read classification output to Kraken2-style
+        per-read classification output.
+    '''
+    centrifuger.Centrifuger.classification_to_kraken2(classification, output)
+
+
+__commands__.append((
+    'centrifuger_classification_to_kraken2',
+    parser_centrifuger_classification_to_kraken2,
+))
+
+
 def parser_centrifuger_kreport(parser=argparse.ArgumentParser()):
     parser.add_argument('db', help='Centrifuger database prefix.')
     parser.add_argument('classification', help='Centrifuger classification output file.')

--- a/src/viral_ngs/metagenomics.py
+++ b/src/viral_ngs/metagenomics.py
@@ -40,6 +40,7 @@ from . import read_utils
 from .classify import kma
 from .classify import kraken2
 from .classify import krona
+from .classify import centrifuger
 from .classify import kb
 from .classify.taxonomy import (
     TaxIdError, TaxonomyDb, BlastRecord, blast_records, paired_query_id,
@@ -469,6 +470,113 @@ def main_kma_build(ref_fasta, db_prefix, threads=None):
     kma_tool.build(ref_fasta, db_prefix, num_threads=threads)
 
 __commands__.append(('kma_build', parser_kma_build))
+
+
+def parser_centrifuger(parser=argparse.ArgumentParser()):
+    parser.add_argument('db', help='Centrifuger database prefix.')
+    parser.add_argument('in_bam', help='Input unaligned reads, BAM format.')
+    parser.add_argument('out_classification', help='Centrifuger per-read classification output file.')
+    parser.add_argument('--k', type=int, help='Report top k classification results for each read.')
+    parser.add_argument('--unclassified_prefix', help='Output prefix for unclassified reads.')
+    parser.add_argument('--classified_prefix', help='Output prefix for classified reads.')
+    parser.add_argument('--min_hitlen', type=int, help='Minimum total length of matched segments.')
+    parser.add_argument('--hitk_factor', type=int, help='Centrifuger hit-k factor.')
+    parser.add_argument('--merge_readpair', action='store_true', help='Merge paired reads before classification.')
+    cmd.common_args(parser, (('threads', None), ('loglevel', None), ('version', None), ('tmp_dir', None)))
+    cmd.attach_main(parser, main_centrifuger, split_args=True)
+    return parser
+
+
+def main_centrifuger(db, in_bam, out_classification, k=None,
+                    unclassified_prefix=None, classified_prefix=None,
+                    min_hitlen=None, hitk_factor=None,
+                    merge_readpair=False, threads=None):
+    '''
+        Classify reads by taxon using Centrifuger.
+    '''
+    centrifuger_tool = centrifuger.Centrifuger()
+    centrifuger_tool.classify(
+        in_bam,
+        db,
+        out_classification,
+        k=k,
+        unclassified_prefix=unclassified_prefix,
+        classified_prefix=classified_prefix,
+        min_hitlen=min_hitlen,
+        hitk_factor=hitk_factor,
+        merge_readpair=merge_readpair,
+        num_threads=threads,
+    )
+
+
+__commands__.append(('centrifuger', parser_centrifuger))
+
+
+def parser_centrifuger_build(parser=argparse.ArgumentParser()):
+    parser.add_argument('db_prefix', help='Centrifuger database output prefix.')
+    parser.add_argument('taxonomy_tree', help='NCBI taxonomy nodes.dmp file.')
+    parser.add_argument('name_table', help='NCBI taxonomy names.dmp file.')
+    parser.add_argument('--ref_fastas', nargs='+', help='Reference FASTA files.')
+    parser.add_argument('--ref_list', help='File containing reference FASTA paths, one per line.')
+    parser.add_argument('--conversion_table', help='Sequence ID to taxonomy ID mapping file.')
+    parser.add_argument('--build_mem', help='Memory target for centrifuger-build.')
+    cmd.common_args(parser, (('threads', None), ('loglevel', None), ('version', None), ('tmp_dir', None)))
+    cmd.attach_main(parser, main_centrifuger_build, split_args=True)
+    return parser
+
+
+def main_centrifuger_build(db_prefix, taxonomy_tree, name_table,
+                          ref_fastas=None, ref_list=None,
+                          conversion_table=None, build_mem=None,
+                          threads=None):
+    '''
+        Build a Centrifuger database.
+    '''
+    centrifuger_tool = centrifuger.Centrifuger()
+    centrifuger_tool.build(
+        db_prefix,
+        taxonomy_tree,
+        name_table,
+        ref_fastas=ref_fastas,
+        ref_list=ref_list,
+        conversion_table=conversion_table,
+        build_mem=build_mem,
+        num_threads=threads,
+    )
+
+
+__commands__.append(('centrifuger_build', parser_centrifuger_build))
+
+
+def parser_centrifuger_quant(parser=argparse.ArgumentParser()):
+    parser.add_argument('db', help='Centrifuger database prefix.')
+    parser.add_argument('classification', help='Centrifuger classification output file.')
+    parser.add_argument('output', help='Centrifuger quantification output file.')
+    parser.add_argument('--min_score', type=int, help='Minimum score to include a read.')
+    parser.add_argument('--min_length', type=int, help='Minimum read length to include.')
+    parser.add_argument('--output_format', type=int, help='Centrifuger quant output format.')
+    cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
+    cmd.attach_main(parser, main_centrifuger_quant, split_args=True)
+    return parser
+
+
+def main_centrifuger_quant(db, classification, output, min_score=None,
+                          min_length=None, output_format=None):
+    '''
+        Quantify Centrifuger classification output.
+    '''
+    centrifuger_tool = centrifuger.Centrifuger()
+    centrifuger_tool.quant(
+        db,
+        classification,
+        output,
+        min_score=min_score,
+        min_length=min_length,
+        output_format=output_format,
+    )
+
+
+__commands__.append(('centrifuger_quant', parser_centrifuger_quant))
 
 
 def parser_krona(parser=argparse.ArgumentParser()):

--- a/tests/unit/classify/test_integration_centrifuger.py
+++ b/tests/unit/classify/test_integration_centrifuger.py
@@ -141,3 +141,44 @@ def test_centrifuger_kreport(centrifuger_db, centrifuger_classification):
     # An unclassified row and a root row should always be present
     rank_codes = [row[3] for row in rows]
     assert 'U' in rank_codes, 'kreport should include an unclassified (U) row'
+
+
+def test_centrifuger_classify_then_kreport_on_empty_bam(centrifuger_db):
+    '''End-to-end empty-BAM short-circuit verification.
+
+    Drives the same classify -> kreport chain the viral-pipelines WDL uses,
+    starting from the empty.bam fixture. Both short-circuits must fire
+    end-to-end via the metagenomics CLI:
+
+      - Centrifuger.classify() detects the empty BAM via samtools.isEmpty,
+        skips invoking centrifuger, and writes a header-only TSV (single
+        line of column headers, no data rows) so downstream parsers see a
+        well-formed but empty file.
+      - Centrifuger.kreport() then detects the header-only classification
+        via _classification_is_empty(has_header=True), skips invoking
+        centrifuger-kreport, and writes a truly empty (0-byte) kreport.
+    '''
+    empty_bam = os.path.join(util_file.get_test_input_path(), 'empty.bam')
+    out_classification = util_file.mkstempfname('.empty.centrifuger.tsv')
+    out_kreport = util_file.mkstempfname('.empty.centrifuger.kreport')
+
+    classify_cmd = [centrifuger_db, empty_bam, out_classification, '--threads', '2']
+    parser = metagenomics.parser_centrifuger(argparse.ArgumentParser())
+    args = parser.parse_args(classify_cmd)
+    args.func_main(args)
+
+    assert os.path.exists(out_classification)
+    with open(out_classification, 'rt') as inf:
+        lines = [line.rstrip('\n') for line in inf if line.strip()]
+    assert lines == [
+        'readID\tseqID\ttaxID\tscore\t2ndBestScore\thitLength\tqueryLength\tnumMatches'
+    ], 'classify on empty BAM should produce a header-only TSV with no data rows'
+
+    kreport_cmd = [centrifuger_db, out_classification, out_kreport]
+    parser = metagenomics.parser_centrifuger_kreport(argparse.ArgumentParser())
+    args = parser.parse_args(kreport_cmd)
+    args.func_main(args)
+
+    assert os.path.exists(out_kreport)
+    assert os.path.getsize(out_kreport) == 0, \
+        'kreport on header-only classification should produce an empty report'

--- a/tests/unit/classify/test_integration_centrifuger.py
+++ b/tests/unit/classify/test_integration_centrifuger.py
@@ -12,7 +12,9 @@ from viral_ngs.core import file as util_file
 
 
 pytestmark = pytest.mark.skipif(
-    not all(shutil.which(cmd) for cmd in ('centrifuger', 'centrifuger-build', 'centrifuger-quant')),
+    not all(shutil.which(cmd) for cmd in (
+        'centrifuger', 'centrifuger-build', 'centrifuger-quant', 'centrifuger-kreport',
+    )),
     reason='Centrifuger executables are not installed',
 )
 

--- a/tests/unit/classify/test_integration_centrifuger.py
+++ b/tests/unit/classify/test_integration_centrifuger.py
@@ -1,0 +1,111 @@
+# Integration tests for Centrifuger
+import argparse
+import glob
+import os
+import shutil
+
+import pytest
+
+from viral_ngs import metagenomics
+from viral_ngs.classify import centrifuger
+from viral_ngs.core import file as util_file
+
+
+pytestmark = pytest.mark.skipif(
+    not all(shutil.which(cmd) for cmd in ('centrifuger', 'centrifuger-build', 'centrifuger-quant')),
+    reason='Centrifuger executables are not installed',
+)
+
+
+@pytest.fixture(scope='module')
+def centrifuger_tool():
+    tool = centrifuger.Centrifuger()
+    tool.install()
+    return tool
+
+
+@pytest.fixture(scope='module')
+def metagenomics_simple():
+    base = os.path.join(util_file.get_test_input_path(), 'TestMetagenomicsSimple')
+    db_dir = os.path.join(base, 'db')
+    return {
+        'bam': os.path.join(base, 'test-reads.bam'),
+        'nodes': os.path.join(db_dir, 'taxonomy', 'nodes.dmp'),
+        'names': os.path.join(db_dir, 'taxonomy', 'names.dmp'),
+        'conversion': os.path.join(db_dir, 'library', 'krakenuniq.map'),
+        'refs': sorted(glob.glob(os.path.join(
+            db_dir,
+            'library',
+            'Viruses',
+            '*',
+            '*_genomic.fna',
+        ))),
+    }
+
+
+@pytest.fixture(scope='module')
+def centrifuger_db(tmpdir_module, centrifuger_tool, metagenomics_simple):
+    db_prefix = os.path.join(tmpdir_module, 'centrifuger_ebola')
+    cmd = [
+        db_prefix,
+        metagenomics_simple['nodes'],
+        metagenomics_simple['names'],
+        '--ref_fastas', *metagenomics_simple['refs'],
+        '--conversion_table', metagenomics_simple['conversion'],
+        '--build_mem', '256M',
+        '--threads', '2',
+    ]
+    parser = metagenomics.parser_centrifuger_build(argparse.ArgumentParser())
+    args = parser.parse_args(cmd)
+    args.func_main(args)
+    assert os.path.exists(db_prefix + '.1.cfr')
+    return db_prefix
+
+
+def test_centrifuger_classify_and_quant(centrifuger_db, metagenomics_simple):
+    out_classification = util_file.mkstempfname('.centrifuger.tsv')
+    classify_cmd = [
+        centrifuger_db,
+        metagenomics_simple['bam'],
+        out_classification,
+        '--k', '1',
+        '--threads', '2',
+    ]
+    parser = metagenomics.parser_centrifuger(argparse.ArgumentParser())
+    args = parser.parse_args(classify_cmd)
+    args.func_main(args)
+
+    with open(out_classification, 'rt') as inf:
+        rows = [line.rstrip('\n').split('\t') for line in inf if line.strip()]
+
+    assert rows[0] == [
+        'readID',
+        'seqID',
+        'taxID',
+        'score',
+        '2ndBestScore',
+        'hitLength',
+        'queryLength',
+        'numMatches',
+    ]
+    assert any(row[2] == '186538' for row in rows[1:])
+
+    out_quant = util_file.mkstempfname('.centrifuger-quant.tsv')
+    quant_cmd = [centrifuger_db, out_classification, out_quant]
+    parser = metagenomics.parser_centrifuger_quant(argparse.ArgumentParser())
+    args = parser.parse_args(quant_cmd)
+    args.func_main(args)
+
+    with open(out_quant, 'rt') as inf:
+        report_rows = [line.rstrip('\n').split('\t') for line in inf if line.strip()]
+
+    assert report_rows[0] == [
+        'name',
+        'taxID',
+        'taxRank',
+        'genomeSize',
+        'numReads',
+        'numUniqueReads',
+        'abundance',
+    ]
+    assert any(row[1] == '186538' for row in report_rows[1:])

--- a/tests/unit/classify/test_integration_centrifuger.py
+++ b/tests/unit/classify/test_integration_centrifuger.py
@@ -62,8 +62,9 @@ def centrifuger_db(tmpdir_module, centrifuger_tool, metagenomics_simple):
     return db_prefix
 
 
-def test_centrifuger_classify_and_quant(centrifuger_db, metagenomics_simple):
-    out_classification = util_file.mkstempfname('.centrifuger.tsv')
+@pytest.fixture(scope='module')
+def centrifuger_classification(tmpdir_module, centrifuger_db, metagenomics_simple):
+    out_classification = os.path.join(tmpdir_module, 'centrifuger.tsv')
     classify_cmd = [
         centrifuger_db,
         metagenomics_simple['bam'],
@@ -74,8 +75,11 @@ def test_centrifuger_classify_and_quant(centrifuger_db, metagenomics_simple):
     parser = metagenomics.parser_centrifuger(argparse.ArgumentParser())
     args = parser.parse_args(classify_cmd)
     args.func_main(args)
+    return out_classification
 
-    with open(out_classification, 'rt') as inf:
+
+def test_centrifuger_classify(centrifuger_classification):
+    with open(centrifuger_classification, 'rt') as inf:
         rows = [line.rstrip('\n').split('\t') for line in inf if line.strip()]
 
     assert rows[0] == [
@@ -90,8 +94,10 @@ def test_centrifuger_classify_and_quant(centrifuger_db, metagenomics_simple):
     ]
     assert any(row[2] == '186538' for row in rows[1:])
 
+
+def test_centrifuger_quant(centrifuger_db, centrifuger_classification):
     out_quant = util_file.mkstempfname('.centrifuger-quant.tsv')
-    quant_cmd = [centrifuger_db, out_classification, out_quant]
+    quant_cmd = [centrifuger_db, centrifuger_classification, out_quant]
     parser = metagenomics.parser_centrifuger_quant(argparse.ArgumentParser())
     args = parser.parse_args(quant_cmd)
     args.func_main(args)
@@ -109,3 +115,27 @@ def test_centrifuger_classify_and_quant(centrifuger_db, metagenomics_simple):
         'abundance',
     ]
     assert any(row[1] == '186538' for row in report_rows[1:])
+
+
+def test_centrifuger_kreport(centrifuger_db, centrifuger_classification):
+    out_kreport = util_file.mkstempfname('.centrifuger-kreport.tsv')
+    kreport_cmd = [centrifuger_db, centrifuger_classification, out_kreport]
+    parser = metagenomics.parser_centrifuger_kreport(argparse.ArgumentParser())
+    args = parser.parse_args(kreport_cmd)
+    args.func_main(args)
+
+    with open(out_kreport, 'rt') as inf:
+        rows = [line.rstrip('\n').split('\t') for line in inf if line.strip()]
+
+    # Kraken-style report has 6 columns:
+    # percent, clade_reads, taxon_reads, rank_code, taxID, name
+    assert all(len(row) == 6 for row in rows), \
+        'kreport rows should have 6 tab-delimited columns'
+
+    # Zaire ebolavirus taxID should appear in the report
+    assert any(row[4] == '186538' for row in rows), \
+        'Expected Zaire ebolavirus (taxID 186538) in kreport output'
+
+    # An unclassified row and a root row should always be present
+    rank_codes = [row[3] for row in rows]
+    assert 'U' in rank_codes, 'kreport should include an unclassified (U) row'

--- a/tests/unit/classify/test_metagenomics.py
+++ b/tests/unit/classify/test_metagenomics.py
@@ -54,6 +54,86 @@ class TestKronaCalls(TestCaseWithTmp):
             no_hits=True, no_rank=True, magnitude_column=None)
 
 
+def test_centrifuger_parser_invokes_tool():
+    with patch('viral_ngs.metagenomics.centrifuger.Centrifuger', autospec=True) as mock_centrifuger:
+        args = [
+            'db',
+            'input.bam',
+            'out.tsv',
+            '--k', '3',
+            '--unclassified_prefix', 'unclassified',
+            '--classified_prefix', 'classified',
+            '--min_hitlen', '17',
+            '--hitk_factor', '5',
+            '--merge_readpair',
+            '--threads', '4',
+        ]
+        args = metagenomics.parser_centrifuger(argparse.ArgumentParser()).parse_args(args)
+        args.func_main(args)
+
+        mock_centrifuger.return_value.classify.assert_called_once_with(
+            'input.bam',
+            'db',
+            'out.tsv',
+            k=3,
+            unclassified_prefix='unclassified',
+            classified_prefix='classified',
+            min_hitlen=17,
+            hitk_factor=5,
+            merge_readpair=True,
+            num_threads=4,
+        )
+
+
+def test_centrifuger_build_parser_invokes_tool():
+    with patch('viral_ngs.metagenomics.centrifuger.Centrifuger', autospec=True) as mock_centrifuger:
+        args = [
+            'db_prefix',
+            'nodes.dmp',
+            'names.dmp',
+            '--ref_fastas', 'ref1.fna', 'ref2.fna',
+            '--conversion_table', 'seqid_to_taxid.map',
+            '--build_mem', '256M',
+            '--threads', '4',
+        ]
+        args = metagenomics.parser_centrifuger_build(argparse.ArgumentParser()).parse_args(args)
+        args.func_main(args)
+
+        mock_centrifuger.return_value.build.assert_called_once_with(
+            'db_prefix',
+            'nodes.dmp',
+            'names.dmp',
+            ref_fastas=['ref1.fna', 'ref2.fna'],
+            ref_list=None,
+            conversion_table='seqid_to_taxid.map',
+            build_mem='256M',
+            num_threads=4,
+        )
+
+
+def test_centrifuger_quant_parser_invokes_tool():
+    with patch('viral_ngs.metagenomics.centrifuger.Centrifuger', autospec=True) as mock_centrifuger:
+        args = [
+            'db',
+            'classification.tsv',
+            'quant.tsv',
+            '--min_score', '10',
+            '--min_length', '50',
+            '--output_format', '1',
+        ]
+        args = metagenomics.parser_centrifuger_quant(argparse.ArgumentParser()).parse_args(args)
+        args.func_main(args)
+
+        mock_centrifuger.return_value.quant.assert_called_once_with(
+            'db',
+            'classification.tsv',
+            'quant.tsv',
+            min_score=10,
+            min_length=50,
+            output_format=1,
+        )
+
+
 @pytest.fixture
 def taxa_db_simple():
     db = metagenomics.TaxonomyDb()

--- a/tests/unit/classify/test_metagenomics.py
+++ b/tests/unit/classify/test_metagenomics.py
@@ -134,6 +134,35 @@ def test_centrifuger_quant_parser_invokes_tool():
         )
 
 
+def test_centrifuger_kreport_parser_invokes_tool():
+    with patch('viral_ngs.metagenomics.centrifuger.Centrifuger', autospec=True) as mock_centrifuger:
+        args = [
+            'db',
+            'classification.tsv',
+            'kreport.tsv',
+            '--no_lca',
+            '--show_zeros',
+            '--is_count_table',
+            '--min_score', '10',
+            '--min_length', '50',
+            '--report_score_data',
+        ]
+        args = metagenomics.parser_centrifuger_kreport(argparse.ArgumentParser()).parse_args(args)
+        args.func_main(args)
+
+        mock_centrifuger.return_value.kreport.assert_called_once_with(
+            'db',
+            'classification.tsv',
+            'kreport.tsv',
+            no_lca=True,
+            show_zeros=True,
+            is_count_table=True,
+            min_score=10,
+            min_length=50,
+            report_score_data=True,
+        )
+
+
 @pytest.fixture
 def taxa_db_simple():
     db = metagenomics.TaxonomyDb()

--- a/tests/unit/classify/test_metagenomics.py
+++ b/tests/unit/classify/test_metagenomics.py
@@ -85,6 +85,29 @@ def test_centrifuger_parser_invokes_tool():
         )
 
 
+def test_centrifuger_parser_defaults_to_k_one():
+    with patch('viral_ngs.metagenomics.centrifuger.Centrifuger', autospec=True) as mock_centrifuger:
+        args = metagenomics.parser_centrifuger(argparse.ArgumentParser()).parse_args([
+            'db',
+            'input.bam',
+            'out.tsv',
+        ])
+        args.func_main(args)
+
+        mock_centrifuger.return_value.classify.assert_called_once_with(
+            'input.bam',
+            'db',
+            'out.tsv',
+            k=1,
+            unclassified_prefix=None,
+            classified_prefix=None,
+            min_hitlen=None,
+            hitk_factor=None,
+            merge_readpair=False,
+            num_threads=_CPUS,
+        )
+
+
 def test_centrifuger_build_parser_invokes_tool():
     with patch('viral_ngs.metagenomics.centrifuger.Centrifuger', autospec=True) as mock_centrifuger:
         args = [

--- a/tests/unit/classify/test_metagenomics.py
+++ b/tests/unit/classify/test_metagenomics.py
@@ -157,6 +157,25 @@ def test_centrifuger_quant_parser_invokes_tool():
         )
 
 
+def test_centrifuger_classification_to_kraken2_parser_invokes_tool():
+    with patch(
+            'viral_ngs.metagenomics.centrifuger.Centrifuger.classification_to_kraken2',
+            autospec=True,
+    ) as mock_classification_to_kraken2:
+        args = [
+            'classification.tsv',
+            'kraken2.tsv',
+        ]
+        args = metagenomics.parser_centrifuger_classification_to_kraken2(
+            argparse.ArgumentParser()).parse_args(args)
+        args.func_main(args)
+
+        mock_classification_to_kraken2.assert_called_once_with(
+            'classification.tsv',
+            'kraken2.tsv',
+        )
+
+
 def test_centrifuger_kreport_parser_invokes_tool():
     with patch('viral_ngs.metagenomics.centrifuger.Centrifuger', autospec=True) as mock_centrifuger:
         args = [

--- a/tests/unit/classify/test_tools_centrifuger.py
+++ b/tests/unit/classify/test_tools_centrifuger.py
@@ -246,7 +246,10 @@ def test_quant_invokes_centrifuger_quant_with_expected_arguments(
 
 def test_kreport_invokes_centrifuger_kreport_with_expected_arguments(
         centrifuger_tool, centrifuger_inputs):
-    with patch('viral_ngs.classify.centrifuger.subprocess.check_call', autospec=True) as mock_check_call, \
+    # Bypass the empty-classification short-circuit (covered by its own tests
+    # below); this test exercises CLI argv construction on a non-empty input.
+    with patch.object(centrifuger.Centrifuger, '_classification_is_empty', return_value=False), \
+         patch('viral_ngs.classify.centrifuger.subprocess.check_call', autospec=True) as mock_check_call, \
          patch('viral_ngs.classify.centrifuger.open', mock_open(), create=True) as mocked_open:
         centrifuger_tool.kreport(
             centrifuger_inputs['db_prefix'],
@@ -275,7 +278,8 @@ def test_kreport_invokes_centrifuger_kreport_with_expected_arguments(
 
 
 def test_kreport_omits_unset_optional_flags(centrifuger_tool, centrifuger_inputs):
-    with patch('viral_ngs.classify.centrifuger.subprocess.check_call', autospec=True) as mock_check_call, \
+    with patch.object(centrifuger.Centrifuger, '_classification_is_empty', return_value=False), \
+         patch('viral_ngs.classify.centrifuger.subprocess.check_call', autospec=True) as mock_check_call, \
          patch('viral_ngs.classify.centrifuger.open', mock_open(), create=True):
         centrifuger_tool.kreport(
             centrifuger_inputs['db_prefix'],
@@ -292,3 +296,63 @@ def test_kreport_omits_unset_optional_flags(centrifuger_tool, centrifuger_inputs
             '--report-score-data', '--min-score', '--min-length',
         ):
             assert flag not in args, f'{flag} unexpectedly present with default kwargs'
+
+
+def test_kreport_short_circuits_on_empty_classification(
+        tmp_path, centrifuger_tool, centrifuger_inputs):
+    empty_classification = tmp_path / 'empty.tsv'
+    empty_classification.touch()
+    output = tmp_path / 'kreport.tsv'
+
+    with patch('viral_ngs.classify.centrifuger.subprocess.check_call', autospec=True) as mock_check_call:
+        centrifuger_tool.kreport(
+            centrifuger_inputs['db_prefix'],
+            str(empty_classification),
+            str(output),
+        )
+
+    mock_check_call.assert_not_called()
+    assert output.exists()
+    assert output.read_text() == ''
+
+
+def test_kreport_short_circuits_on_header_only_classification(
+        tmp_path, centrifuger_tool, centrifuger_inputs):
+    header_only = tmp_path / 'header_only.tsv'
+    header_only.write_text(
+        'readID\tseqID\ttaxID\tscore\t2ndBestScore\thitLength\tqueryLength\tnumMatches\n'
+    )
+    output = tmp_path / 'kreport.tsv'
+
+    with patch('viral_ngs.classify.centrifuger.subprocess.check_call', autospec=True) as mock_check_call:
+        centrifuger_tool.kreport(
+            centrifuger_inputs['db_prefix'],
+            str(header_only),
+            str(output),
+        )
+
+    mock_check_call.assert_not_called()
+    assert output.exists()
+    assert output.read_text() == ''
+
+
+def test_kreport_runs_when_classification_has_data(
+        tmp_path, centrifuger_tool, centrifuger_inputs):
+    classification = tmp_path / 'with_data.tsv'
+    classification.write_text(
+        'readID\tseqID\ttaxID\tscore\t2ndBestScore\thitLength\tqueryLength\tnumMatches\n'
+        'r1\tNC_002549.1\t186538\t8692\t0\t160\t204\t1\n'
+    )
+    output = tmp_path / 'kreport.tsv'
+
+    with patch('viral_ngs.classify.centrifuger.subprocess.check_call', autospec=True) as mock_check_call:
+        centrifuger_tool.kreport(
+            centrifuger_inputs['db_prefix'],
+            str(classification),
+            str(output),
+        )
+
+    mock_check_call.assert_called_once()
+    args = mock_check_call.call_args[0][0]
+    assert args[0] == 'centrifuger-kreport'
+    assert args[-1] == str(classification)

--- a/tests/unit/classify/test_tools_centrifuger.py
+++ b/tests/unit/classify/test_tools_centrifuger.py
@@ -242,3 +242,53 @@ def test_quant_invokes_centrifuger_quant_with_expected_arguments(
         assert util_misc.list_contains(['--min-length', '50'], args)
         assert util_misc.list_contains(['--output-format', '1'], args)
         mocked_open.assert_called_once_with('quant.tsv', 'wt')
+
+
+def test_kreport_invokes_centrifuger_kreport_with_expected_arguments(
+        centrifuger_tool, centrifuger_inputs):
+    with patch('viral_ngs.classify.centrifuger.subprocess.check_call', autospec=True) as mock_check_call, \
+         patch('viral_ngs.classify.centrifuger.open', mock_open(), create=True) as mocked_open:
+        centrifuger_tool.kreport(
+            centrifuger_inputs['db_prefix'],
+            'classification.tsv',
+            'kreport.tsv',
+            no_lca=True,
+            show_zeros=True,
+            is_count_table=True,
+            min_score=10,
+            min_length=50,
+            report_score_data=True,
+        )
+
+        args = mock_check_call.call_args[0][0]
+        assert args[0] == 'centrifuger-kreport'
+        assert util_misc.list_contains(['-x', centrifuger_inputs['db_prefix']], args)
+        assert '--no-lca' in args
+        assert '--show-zeros' in args
+        assert '--is-count-table' in args
+        assert '--report-score-data' in args
+        assert util_misc.list_contains(['--min-score', '10'], args)
+        assert util_misc.list_contains(['--min-length', '50'], args)
+        # classification file is a positional arg, appended after options
+        assert args[-1] == 'classification.tsv'
+        mocked_open.assert_called_once_with('kreport.tsv', 'wt')
+
+
+def test_kreport_omits_unset_optional_flags(centrifuger_tool, centrifuger_inputs):
+    with patch('viral_ngs.classify.centrifuger.subprocess.check_call', autospec=True) as mock_check_call, \
+         patch('viral_ngs.classify.centrifuger.open', mock_open(), create=True):
+        centrifuger_tool.kreport(
+            centrifuger_inputs['db_prefix'],
+            'classification.tsv',
+            'kreport.tsv',
+        )
+
+        args = mock_check_call.call_args[0][0]
+        assert args[0] == 'centrifuger-kreport'
+        assert util_misc.list_contains(['-x', centrifuger_inputs['db_prefix']], args)
+        assert args[-1] == 'classification.tsv'
+        for flag in (
+            '--no-lca', '--show-zeros', '--is-count-table',
+            '--report-score-data', '--min-score', '--min-length',
+        ):
+            assert flag not in args, f'{flag} unexpectedly present with default kwargs'

--- a/tests/unit/classify/test_tools_centrifuger.py
+++ b/tests/unit/classify/test_tools_centrifuger.py
@@ -221,6 +221,19 @@ def test_classify_returns_early_when_bam_is_empty(
         mocked_open.assert_called_once_with('out.tsv', 'wt')
 
 
+def test_classify_missing_bam_raises_file_not_found(
+        centrifuger_tool, centrifuger_inputs):
+    with patch('viral_ngs.classify.centrifuger.samtools.SamtoolsTool', autospec=True) as samtools_cls:
+        with pytest.raises(FileNotFoundError):
+            centrifuger_tool.classify(
+                'missing.bam',
+                centrifuger_inputs['db_prefix'],
+                'out.tsv',
+            )
+
+        samtools_cls.assert_not_called()
+
+
 def test_quant_invokes_centrifuger_quant_with_expected_arguments(
         centrifuger_tool, centrifuger_inputs):
     with patch('viral_ngs.classify.centrifuger.subprocess.check_call', autospec=True) as mock_check_call, \
@@ -336,6 +349,28 @@ def test_kreport_short_circuits_on_header_only_classification(
     assert output.read_text() == ''
 
 
+def test_kreport_short_circuits_on_header_and_blank_lines(
+        tmp_path, centrifuger_tool, centrifuger_inputs):
+    header_only = tmp_path / 'header_only.tsv'
+    header_only.write_text(
+        'readID\tseqID\ttaxID\tscore\t2ndBestScore\thitLength\tqueryLength\tnumMatches\n'
+        '\n'
+        '   \n'
+    )
+    output = tmp_path / 'kreport.tsv'
+
+    with patch('viral_ngs.classify.centrifuger.subprocess.check_call', autospec=True) as mock_check_call:
+        centrifuger_tool.kreport(
+            centrifuger_inputs['db_prefix'],
+            str(header_only),
+            str(output),
+        )
+
+    mock_check_call.assert_not_called()
+    assert output.exists()
+    assert output.read_text() == ''
+
+
 def test_kreport_runs_when_classification_has_data(
         tmp_path, centrifuger_tool, centrifuger_inputs):
     classification = tmp_path / 'with_data.tsv'
@@ -356,3 +391,24 @@ def test_kreport_runs_when_classification_has_data(
     args = mock_check_call.call_args[0][0]
     assert args[0] == 'centrifuger-kreport'
     assert args[-1] == str(classification)
+
+
+def test_kreport_runs_for_single_row_count_table(
+        tmp_path, centrifuger_tool, centrifuger_inputs):
+    count_table = tmp_path / 'count_table.tsv'
+    count_table.write_text('186538\t7\n')
+    output = tmp_path / 'kreport.tsv'
+
+    with patch('viral_ngs.classify.centrifuger.subprocess.check_call', autospec=True) as mock_check_call:
+        centrifuger_tool.kreport(
+            centrifuger_inputs['db_prefix'],
+            str(count_table),
+            str(output),
+            is_count_table=True,
+        )
+
+    mock_check_call.assert_called_once()
+    args = mock_check_call.call_args[0][0]
+    assert args[0] == 'centrifuger-kreport'
+    assert '--is-count-table' in args
+    assert args[-1] == str(count_table)

--- a/tests/unit/classify/test_tools_centrifuger.py
+++ b/tests/unit/classify/test_tools_centrifuger.py
@@ -188,6 +188,7 @@ def test_classify_paired_end_from_bam(centrifuger_tool, centrifuger_inputs):
         assert util_misc.list_contains(['-1', 'paired.1.fastq'], args)
         assert util_misc.list_contains(['-2', 'paired.2.fastq'], args)
         assert '-u' not in args
+        assert util_misc.list_contains(['-k', '1'], args)
         expected_threads = str(util_misc.sanitize_thread_count(2))
         assert util_misc.list_contains(['-t', expected_threads], args)
         picard.execute.assert_called_once_with(
@@ -219,6 +220,11 @@ def test_classify_returns_early_when_bam_is_empty(
         mock_check_call.assert_not_called()
         picard_cls.assert_not_called()
         mocked_open.assert_called_once_with('out.tsv', 'wt')
+        handle = mocked_open.return_value.__enter__.return_value
+        handle.write.assert_called_once_with(
+            'readID\tseqID\ttaxID\tscore\t2ndBestScore\t'
+            'hitLength\tqueryLength\tnumMatches\n'
+        )
 
 
 def test_classify_missing_bam_raises_file_not_found(
@@ -255,6 +261,107 @@ def test_quant_invokes_centrifuger_quant_with_expected_arguments(
         assert util_misc.list_contains(['--min-length', '50'], args)
         assert util_misc.list_contains(['--output-format', '1'], args)
         mocked_open.assert_called_once_with('quant.tsv', 'wt')
+
+
+def test_classification_to_kraken2_maps_classified_rows(tmp_path):
+    classification = tmp_path / 'classification.tsv'
+    classification.write_text(
+        'readID\tseqID\ttaxID\tscore\t2ndBestScore\thitLength\tqueryLength\tnumMatches\n'
+        'read1\tNC_002549.1\t186538\t8692\t0\t160\t204\t1\n'
+        'read2\tunclassified\t0\t0\t0\t0\t150\t1\n'
+        'read3\tNC_006432.1\t186540\t1234\t0\t95\t100\t1\n'
+    )
+    output = tmp_path / 'kraken2.tsv'
+
+    centrifuger.Centrifuger.classification_to_kraken2(
+        str(classification),
+        str(output),
+    )
+
+    assert output.read_text() == (
+        'C\tread1\t186538\t204\tN/A\n'
+        'C\tread3\t186540\t100\tN/A\n'
+    )
+
+
+def test_classification_to_kraken2_writes_gzipped_output(tmp_path):
+    classification = tmp_path / 'classification.tsv'
+    classification.write_text(
+        'readID\tseqID\ttaxID\tscore\t2ndBestScore\thitLength\tqueryLength\tnumMatches\n'
+        'read1\tNC_002549.1\t186538\t8692\t0\t160\t204\t1\n'
+    )
+    output = tmp_path / 'kraken2.tsv.gz'
+
+    centrifuger.Centrifuger.classification_to_kraken2(
+        str(classification),
+        str(output),
+    )
+
+    with util_file.open_or_gzopen(str(output), 'rt') as inf:
+        assert inf.read() == 'C\tread1\t186538\t204\tN/A\n'
+
+
+def test_classification_to_kraken2_writes_zstd_output(tmp_path):
+    classification = tmp_path / 'classification.tsv'
+    classification.write_text(
+        'readID\tseqID\ttaxID\tscore\t2ndBestScore\thitLength\tqueryLength\tnumMatches\n'
+        'read1\tNC_002549.1\t186538\t8692\t0\t160\t204\t1\n'
+    )
+    output = tmp_path / 'kraken2.tsv.zst'
+
+    centrifuger.Centrifuger.classification_to_kraken2(
+        str(classification),
+        str(output),
+    )
+
+    with util_file.open_or_gzopen(str(output), 'rt') as inf:
+        assert inf.read() == 'C\tread1\t186538\t204\tN/A\n'
+
+
+def test_classification_to_kraken2_header_only_writes_empty_output(tmp_path):
+    classification = tmp_path / 'classification.tsv'
+    classification.write_text(
+        'readID\tseqID\ttaxID\tscore\t2ndBestScore\thitLength\tqueryLength\tnumMatches\n'
+    )
+    output = tmp_path / 'kraken2.tsv'
+
+    centrifuger.Centrifuger.classification_to_kraken2(
+        str(classification),
+        str(output),
+    )
+
+    assert output.read_text() == ''
+
+
+def test_classification_to_kraken2_rejects_malformed_rows(tmp_path):
+    classification = tmp_path / 'classification.tsv'
+    classification.write_text(
+        'readID\tseqID\ttaxID\tscore\t2ndBestScore\thitLength\tqueryLength\tnumMatches\n'
+        'read1\tNC_002549.1\t186538\n'
+    )
+    output = tmp_path / 'kraken2.tsv'
+
+    with pytest.raises(ValueError, match='Malformed Centrifuger classification row'):
+        centrifuger.Centrifuger.classification_to_kraken2(
+            str(classification),
+            str(output),
+        )
+
+
+def test_classification_to_kraken2_rejects_duplicate_classified_read_ids(tmp_path):
+    classification = tmp_path / 'classification.tsv'
+    classification.write_text(
+        'readID\tseqID\ttaxID\tscore\t2ndBestScore\thitLength\tqueryLength\tnumMatches\n'
+        'read1\tNC_002549.1\t186538\t8692\t8692\t160\t204\t2\n'
+        'read1\tNC_006432.1\t186540\t8692\t8692\t160\t204\t2\n'
+    )
+    output = tmp_path / 'kraken2.tsv'
+
+    with pytest.raises(ValueError, match='Expected k=1 input'):
+        centrifuger.Centrifuger.classification_to_kraken2(
+            str(classification),
+            str(output),
+        )
 
 
 def test_kreport_invokes_centrifuger_kreport_with_expected_arguments(

--- a/tests/unit/classify/test_tools_centrifuger.py
+++ b/tests/unit/classify/test_tools_centrifuger.py
@@ -1,0 +1,244 @@
+# Unit tests for Centrifuger
+import os
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from viral_ngs.classify import centrifuger
+from viral_ngs.core import file as util_file
+from viral_ngs.core import misc as util_misc
+
+
+@pytest.fixture
+def centrifuger_tool():
+    with patch('viral_ngs.classify.centrifuger.shutil.which', return_value='/usr/bin/centrifuger'):
+        yield centrifuger.Centrifuger()
+
+
+@pytest.fixture
+def centrifuger_inputs():
+    base = os.path.join(util_file.get_test_input_path(), 'TestMetagenomicsSimple')
+    db_dir = os.path.join(base, 'db')
+    return {
+        'bam': os.path.join(base, 'test-reads.bam'),
+        'db_prefix': 'centrifuger_db',
+        'nodes': os.path.join(db_dir, 'taxonomy', 'nodes.dmp'),
+        'names': os.path.join(db_dir, 'taxonomy', 'names.dmp'),
+        'conversion': os.path.join(db_dir, 'library', 'krakenuniq.map'),
+        'ref1': os.path.join(
+            db_dir,
+            'library',
+            'Viruses',
+            'Zaire_ebolavirus',
+            'GCF_000848505.1_ViralProj14703_genomic.fna',
+        ),
+        'ref2': os.path.join(
+            db_dir,
+            'library',
+            'Viruses',
+            'Sudan_ebolavirus',
+            'GCF_000855585.1_ViralProj15012_genomic.fna',
+        ),
+    }
+
+
+def test_build_invokes_centrifuger_build_with_expected_arguments(
+        centrifuger_tool, centrifuger_inputs):
+    with patch('viral_ngs.classify.centrifuger.subprocess.check_call', autospec=True) as mock_check_call:
+        centrifuger_tool.build(
+            centrifuger_inputs['db_prefix'],
+            centrifuger_inputs['nodes'],
+            centrifuger_inputs['names'],
+            ref_fastas=[centrifuger_inputs['ref1'], centrifuger_inputs['ref2']],
+            conversion_table=centrifuger_inputs['conversion'],
+            build_mem='256M',
+            num_threads=9,
+        )
+
+        args = mock_check_call.call_args[0][0]
+        assert args[0] == 'centrifuger-build'
+        assert util_misc.list_contains(['-o', centrifuger_inputs['db_prefix']], args)
+        assert util_misc.list_contains(['--taxonomy-tree', centrifuger_inputs['nodes']], args)
+        assert util_misc.list_contains(['--name-table', centrifuger_inputs['names']], args)
+        assert util_misc.list_contains(['-r', centrifuger_inputs['ref1']], args)
+        assert util_misc.list_contains(['-r', centrifuger_inputs['ref2']], args)
+        assert util_misc.list_contains(['--conversion-table', centrifuger_inputs['conversion']], args)
+        assert util_misc.list_contains(['--build-mem', '256M'], args)
+        expected_threads = str(util_misc.sanitize_thread_count(9))
+        assert util_misc.list_contains(['-t', expected_threads], args)
+
+
+def test_build_requires_exactly_one_reference_input(
+        centrifuger_tool, centrifuger_inputs):
+    with pytest.raises(ValueError, match='exactly one'):
+        centrifuger_tool.build(
+            centrifuger_inputs['db_prefix'],
+            centrifuger_inputs['nodes'],
+            centrifuger_inputs['names'],
+        )
+
+    with pytest.raises(ValueError, match='exactly one'):
+        centrifuger_tool.build(
+            centrifuger_inputs['db_prefix'],
+            centrifuger_inputs['nodes'],
+            centrifuger_inputs['names'],
+            ref_fastas=[centrifuger_inputs['ref1']],
+            ref_list='refs.txt',
+        )
+
+
+def test_classify_single_end_from_bam(centrifuger_tool, centrifuger_inputs):
+    mkstemp_vals = ['single.1.fastq', 'single.2.fastq', 'single.s.fastq']
+    size_map = {
+        'single.2.fastq': 1,
+        'single.s.fastq': 10,
+    }
+
+    with patch('viral_ngs.classify.centrifuger.util_file.mkstempfname', side_effect=mkstemp_vals), \
+         patch('viral_ngs.classify.centrifuger.os.path.exists', return_value=True), \
+         patch('viral_ngs.classify.centrifuger.os.unlink'), \
+         patch('viral_ngs.classify.centrifuger.picard.SamToFastqTool', autospec=True) as picard_cls, \
+         patch('viral_ngs.classify.centrifuger.picard.PicardTools.dict_to_picard_opts', return_value='clip-opts'), \
+         patch('viral_ngs.classify.centrifuger.samtools.SamtoolsTool', autospec=True) as samtools_cls, \
+         patch('viral_ngs.classify.centrifuger.subprocess.check_call', autospec=True) as mock_check_call, \
+         patch('viral_ngs.classify.centrifuger.os.path.getsize', side_effect=lambda path: size_map.get(path, 1000)), \
+         patch('viral_ngs.classify.centrifuger.open', mock_open(), create=True) as mocked_open:
+
+        picard_cls.illumina_clipping_attribute = 'XT'
+        picard = picard_cls.return_value
+        picard.jvmMemDefault = '4G'
+        picard.execute.return_value = None
+
+        samtools = samtools_cls.return_value
+        samtools.isEmpty.return_value = False
+
+        centrifuger_tool.classify(
+            centrifuger_inputs['bam'],
+            centrifuger_inputs['db_prefix'],
+            'out.tsv',
+            k=3,
+            unclassified_prefix='unclassified',
+            classified_prefix='classified',
+            min_hitlen=17,
+            hitk_factor=5,
+            merge_readpair=True,
+            num_threads=4,
+        )
+
+        args = mock_check_call.call_args[0][0]
+        assert args[0] == 'centrifuger'
+        assert util_misc.list_contains(['-x', centrifuger_inputs['db_prefix']], args)
+        assert util_misc.list_contains(['-u', 'single.s.fastq'], args)
+        assert '-1' not in args
+        assert '-2' not in args
+        assert util_misc.list_contains(['-k', '3'], args)
+        assert util_misc.list_contains(['--un', 'unclassified'], args)
+        assert util_misc.list_contains(['--cl', 'classified'], args)
+        assert util_misc.list_contains(['--min-hitlen', '17'], args)
+        assert util_misc.list_contains(['--hitk-factor', '5'], args)
+        assert '--merge-readpair' in args
+        expected_threads = str(util_misc.sanitize_thread_count(4))
+        assert util_misc.list_contains(['-t', expected_threads], args)
+        mocked_open.assert_called_once_with('out.tsv', 'wt')
+        picard.execute.assert_called_once_with(
+            centrifuger_inputs['bam'],
+            'single.1.fastq',
+            'single.2.fastq',
+            outFastq0='single.s.fastq',
+            picardOptions='clip-opts',
+            JVMmemory='4G',
+        )
+
+
+def test_classify_paired_end_from_bam(centrifuger_tool, centrifuger_inputs):
+    mkstemp_vals = ['paired.1.fastq', 'paired.2.fastq', 'paired.s.fastq']
+    size_map = {
+        'paired.2.fastq': 10,
+        'paired.s.fastq': 1,
+    }
+
+    with patch('viral_ngs.classify.centrifuger.util_file.mkstempfname', side_effect=mkstemp_vals), \
+         patch('viral_ngs.classify.centrifuger.os.path.exists', return_value=True), \
+         patch('viral_ngs.classify.centrifuger.os.unlink'), \
+         patch('viral_ngs.classify.centrifuger.picard.SamToFastqTool', autospec=True) as picard_cls, \
+         patch('viral_ngs.classify.centrifuger.picard.PicardTools.dict_to_picard_opts', return_value='clip-opts'), \
+         patch('viral_ngs.classify.centrifuger.samtools.SamtoolsTool', autospec=True) as samtools_cls, \
+         patch('viral_ngs.classify.centrifuger.subprocess.check_call', autospec=True) as mock_check_call, \
+         patch('viral_ngs.classify.centrifuger.os.path.getsize', side_effect=lambda path: size_map.get(path, 1000)), \
+         patch('viral_ngs.classify.centrifuger.open', mock_open(), create=True):
+
+        picard_cls.illumina_clipping_attribute = 'XT'
+        picard = picard_cls.return_value
+        picard.jvmMemDefault = '4G'
+        picard.execute.return_value = None
+
+        samtools = samtools_cls.return_value
+        samtools.isEmpty.return_value = False
+
+        centrifuger_tool.classify(
+            centrifuger_inputs['bam'],
+            centrifuger_inputs['db_prefix'],
+            'out.tsv',
+            num_threads=2,
+        )
+
+        args = mock_check_call.call_args[0][0]
+        assert args[0] == 'centrifuger'
+        assert util_misc.list_contains(['-x', centrifuger_inputs['db_prefix']], args)
+        assert util_misc.list_contains(['-1', 'paired.1.fastq'], args)
+        assert util_misc.list_contains(['-2', 'paired.2.fastq'], args)
+        assert '-u' not in args
+        expected_threads = str(util_misc.sanitize_thread_count(2))
+        assert util_misc.list_contains(['-t', expected_threads], args)
+        picard.execute.assert_called_once_with(
+            centrifuger_inputs['bam'],
+            'paired.1.fastq',
+            'paired.2.fastq',
+            outFastq0='paired.s.fastq',
+            picardOptions='clip-opts',
+            JVMmemory='4G',
+        )
+
+
+def test_classify_returns_early_when_bam_is_empty(
+        centrifuger_tool, centrifuger_inputs):
+    with patch('viral_ngs.classify.centrifuger.samtools.SamtoolsTool', autospec=True) as samtools_cls, \
+         patch('viral_ngs.classify.centrifuger.picard.SamToFastqTool', autospec=True) as picard_cls, \
+         patch('viral_ngs.classify.centrifuger.subprocess.check_call', autospec=True) as mock_check_call, \
+         patch('viral_ngs.classify.centrifuger.open', mock_open(), create=True) as mocked_open:
+
+        samtools = samtools_cls.return_value
+        samtools.isEmpty.return_value = True
+
+        centrifuger_tool.classify(
+            centrifuger_inputs['bam'],
+            centrifuger_inputs['db_prefix'],
+            'out.tsv',
+        )
+
+        mock_check_call.assert_not_called()
+        picard_cls.assert_not_called()
+        mocked_open.assert_called_once_with('out.tsv', 'wt')
+
+
+def test_quant_invokes_centrifuger_quant_with_expected_arguments(
+        centrifuger_tool, centrifuger_inputs):
+    with patch('viral_ngs.classify.centrifuger.subprocess.check_call', autospec=True) as mock_check_call, \
+         patch('viral_ngs.classify.centrifuger.open', mock_open(), create=True) as mocked_open:
+        centrifuger_tool.quant(
+            centrifuger_inputs['db_prefix'],
+            'classification.tsv',
+            'quant.tsv',
+            min_score=10,
+            min_length=50,
+            output_format=1,
+        )
+
+        args = mock_check_call.call_args[0][0]
+        assert args[0] == 'centrifuger-quant'
+        assert util_misc.list_contains(['-x', centrifuger_inputs['db_prefix']], args)
+        assert util_misc.list_contains(['-c', 'classification.tsv'], args)
+        assert util_misc.list_contains(['--min-score', '10'], args)
+        assert util_misc.list_contains(['--min-length', '50'], args)
+        assert util_misc.list_contains(['--output-format', '1'], args)
+        mocked_open.assert_called_once_with('quant.tsv', 'wt')

--- a/tests/unit/core/test_util_file.py
+++ b/tests/unit/core/test_util_file.py
@@ -147,6 +147,17 @@ def test_decompress_line_by_line(request, expected_plaintext, compressed_input_f
     assert filecmp.cmp(out, expected_plaintext, shallow=False)
 
 
+def test_open_or_gzopen_writes_zst_text(tmp_path):
+    output = os.path.join(str(tmp_path), 'output.tsv.zst')
+    value = 'col1\tcol2\nvalue1\tvalue2\n'
+
+    with viral_ngs.core.file.open_or_gzopen(output, 'wt') as outf:
+        outf.write(value)
+
+    with viral_ngs.core.file.open_or_gzopen(output, 'rt') as inf:
+        assert inf.read() == value
+
+
 class TestExtractTarball(TestCaseWithTmp):
     def setUp(self):
         super(TestExtractTarball, self).setUp()


### PR DESCRIPTION
Adds Centrifuger (https://github.com/mourisl/centrifuger) as a metagenomics classifier alongside the existing kraken2, kma, kb, and krona tooling. Exposes four CLI subcommands under `viral_ngs metagenomics`:

| Command | Purpose |
|---|---|
| `centrifuger` | Classify reads from an unaligned BAM |
| `centrifuger_build` | Build a centrifuger index from FASTAs or a file list |
| `centrifuger_quant` | Quant report from a per-read classification (centrifuger native / metaphlan / CAMI / kraken-report formats) |
| `centrifuger_kreport` | Kraken-style hierarchical report from a per-read classification |

## Changes

- **Conda dep**: `centrifuger>=1.0` added to `docker/requirements/classify.txt`. Bioconda has `linux-aarch64` builds, so no entry in `classify-x86.txt` is needed — image builds cleanly on both architectures.
- **Tool wrapper**: `src/viral_ngs/classify/centrifuger.py` — `Centrifuger(core.Tool)` with `build()`, `classify()`, `quant()`, `kreport()` methods. Follows the established `kraken2.py` pattern (Picard SamToFastq with illumina clipping, paired-vs-single detection by FASTQ size, empty-input short-circuits at both `classify()` and `kreport()`, `try/finally` temp cleanup).
- **Empty-input contract**: `classify()` silently skips empty BAMs (writes an empty classification TSV) and `kreport()` silently skips empty/header-only classifications (writes an empty report). This keeps a `classify → kreport` chain working unconditionally — without it, downstream consumers like the viral-pipelines `feature-centrifuger` WDL would fail on empty BAMs because `centrifuger-kreport` exits 255 on empty input. `classify()` also raises `FileNotFoundError` early when the BAM path doesn't exist (fail fast instead of letting samtools surface a less-clear error). `_classification_is_empty()` is header-aware so `is_count_table=True` mode correctly recognizes single-row count tables as non-empty.
- **CLI**: four new subcommands in `src/viral_ngs/metagenomics.py`, using snake_case flags (consistent with the more recently added classify commands — kb, kma_build, kraken2_build).
- **Tests**: 16 new tests across 3 files (11 unit, 4 CLI plumbing, 3 integration; superseding the original single combined classify+quant integration test).

## Testing

Verified in the classify container with centrifuger installed:

```
docker run --rm -v $(pwd):/opt/viral-ngs/source \
  quay.io/broadinstitute/viral-ngs:main-classify bash -c \
  "micromamba install -y -c bioconda 'centrifuger>=1.0' && \
   pip install -e /opt/viral-ngs/source --quiet && \
   pytest -rsxX -n auto \
     /opt/viral-ngs/source/tests/unit/classify/test_tools_centrifuger.py \
     /opt/viral-ngs/source/tests/unit/classify/test_integration_centrifuger.py \
     /opt/viral-ngs/source/tests/unit/classify/test_metagenomics.py"
```

Result: **36 passed, 1 skipped** (pre-existing krakenuniq skip, unrelated).

Test coverage:
- **Unit (mocked subprocess)** — 11 tests: build (arg construction + ref XOR validation), classify (paired, single, empty-BAM short-circuit, missing-BAM raises), quant, kreport (all flags + defaults + 3 short-circuit cases + count-table mode + positive control).
- **CLI plumbing** — 4 tests: each `parser_centrifuger*` parses CLI args and dispatches to the expected mocked `Centrifuger.*` call.
- **Integration (real binary, end-to-end via CLI)** — 3 tests against `TestMetagenomicsSimple` fixture: build → classify → quant + kreport. Cleanly skipped via `pytestmark.skipif` when `centrifuger` is not on PATH.

## Compatibility

- Multi-arch (x86_64 + ARM64) — verified bioconda has both builds.
- No changes to existing kraken2/kma/kb behavior or tests.
- No new top-level Python dependencies (`pyproject.toml` unchanged).

**Feature created utilizing Opus 4.7 and GPT5.5**