### PR TITLE
fix(deps): upgrade firecloud to 0.16.39 and remove setuptools<80 pin

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -13,45 +13,6 @@
 # =============================================================================
 
 # -----------------------------------------------------------------------------
-# CVE-2026-23949 — jaraco.context path traversal in tarball extraction
-# Severity: HIGH (NVD scored AV:N/S:C — see scoring dispute below)
-# Package: setuptools (vendored at setuptools/_vendor/jaraco/context.py)
-# Installed: setuptools 79.x (vendored jaraco.context 5.3.0)
-# Fix: jaraco.context >= 6.1.0 (installed in conda env, but setuptools
-#      vendors its own copy which we cannot delete — setuptools imports
-#      jaraco.text and jaraco.context at runtime for pkg_resources)
-#
-# JUSTIFICATION:
-#   1. The vulnerability is in archive extraction (tarball() context manager).
-#      setuptools uses this only during "pip install" of source distributions.
-#      Our containers run pip install at BUILD TIME only, from trusted sources
-#      (PyPI, conda-forge). No pip installs happen at runtime.
-#
-#   2. Even if an attacker could trigger pip install at runtime (which would
-#      require code execution inside the container), the path traversal only
-#      writes files WITHIN the container. The attacker already has code
-#      execution — they can write files anywhere in the container without
-#      needing this vulnerability. It grants no new capability.
-#
-#   3. Containers are ephemeral batch jobs. Any files written (malicious or
-#      otherwise) are destroyed when the job completes. There is no
-#      persistence, no lateral movement, and no host boundary crossing.
-#
-#   4. NVD SCORING DISPUTE: NVD scored this AV:N/AC:L/PR:N/UI:N/S:C/C:H,
-#      which assumes a network-facing service extracting untrusted archives
-#      where the traversal crosses a trust boundary. In our deployment model,
-#      there is no network-facing service, the archives come from trusted
-#      sources, and the "boundary" is a container that will be destroyed.
-#      The Rego policy cannot filter this because NVD mis-scored the attack
-#      vector as Network (AV:N) rather than Local (AV:L).
-#
-# RESOLUTION: Will self-resolve when setuptools releases a version with
-#   updated vendored dependencies (jaraco.context >= 6.1.0).
-# ADDED: 2026-03-19
-# -----------------------------------------------------------------------------
-CVE-2026-23949
-
-# -----------------------------------------------------------------------------
 # CVE-2020-25649 — jackson-databind XXE in DOMDeserializer
 # Severity: HIGH (AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N)
 # Package: com.fasterxml.jackson.core:jackson-databind 2.10.5

--- a/docker/Dockerfile.baseimage
+++ b/docker/Dockerfile.baseimage
@@ -73,14 +73,14 @@ RUN /tmp/install-conda-deps.sh /tmp/requirements/baseimage.txt && \
     rm -rf /opt/conda/lib/python3.12/site-packages/docs && \
     rm -rf /tmp/requirements /tmp/install-conda-deps.sh
 
-# Install firecloud via pip instead of conda because the conda noarch
-# package bundles x86_64-only wheels (cryptography, cffi, grpcio, etc.)
-# that overwrite conda's native packages and break on arm64 (#1042).
-# Requires setuptools<80 due to firecloud's use of deprecated setuptools
-# APIs (broadinstitute/fiss#192).
+# Install firecloud via pip instead of conda because the bioconda noarch
+# package has an overly restrictive python<3.12 constraint that prevents
+# installation on Python 3.12, even though firecloud works fine with 3.12.
+# The PyPI version (>=0.16.39) also fixes setuptools 80 compatibility
+# (broadinstitute/fiss#192), allowing setuptools to upgrade to latest.
+# Use --no-build-isolation to let pip see conda-provided dependencies.
 RUN pip install --no-cache-dir --upgrade pip wheel && \
-    pip install --no-cache-dir 'setuptools<80' && \
-    pip install --no-cache-dir --no-build-isolation 'firecloud>=0.16.35'
+    pip install --no-cache-dir --no-build-isolation 'firecloud>=0.16.39'
 
 WORKDIR /opt/viral-ngs/source
 

--- a/docker/Dockerfile.baseimage
+++ b/docker/Dockerfile.baseimage
@@ -77,7 +77,7 @@ RUN /tmp/install-conda-deps.sh /tmp/requirements/baseimage.txt && \
 # package has an overly restrictive python<3.12 constraint that prevents
 # installation on Python 3.12, even though firecloud works fine with 3.12.
 # The PyPI version (>=0.16.39) also fixes setuptools 80 compatibility
-# (broadinstitute/fiss#192), allowing setuptools to upgrade to latest.
+# (broadinstitute/fiss#200), allowing setuptools to upgrade to latest.
 # Use --no-build-isolation to let pip see conda-provided dependencies.
 RUN pip install --no-cache-dir --upgrade pip wheel && \
     pip install --no-cache-dir --no-build-isolation 'firecloud>=0.16.39'

--- a/docker/requirements/baseimage.txt
+++ b/docker/requirements/baseimage.txt
@@ -14,7 +14,7 @@ awscli>=1.32.0
 google-cloud-sdk>=561.0.0
 google-cloud-storage>=2.14.0
 # Note: firecloud is installed via pip in Dockerfile.baseimage because the
-# conda noarch package bundles x86_64-only wheels that break on arm64 (#1042)
+# bioconda noarch package has an overly restrictive python<3.12 constraint
 
 # Python security libraries (pinned to address CVEs in transitive deps of firecloud)
 cryptography>=46.0.5
@@ -22,6 +22,10 @@ pyopenssl>=26.0.0
 pyasn1>=0.6.3
 tornado>=6.5.4
 urllib3>=2.7.0
+
+# setuptools pinned to eliminate CVE-2026-23949 (jaraco.context path traversal)
+# Versions >=80.10.1 vendor jaraco.context>=6.1.0 with the fix
+setuptools>=80.10.1
 
 # General utilities
 csvkit>=1.0.4

--- a/docker/requirements/baseimage.txt
+++ b/docker/requirements/baseimage.txt
@@ -18,7 +18,6 @@ google-cloud-storage>=2.14.0
 
 # Python security libraries (pinned to address CVEs in transitive deps of firecloud)
 cryptography>=46.0.5
-jaraco.context>=6.1.0
 pyopenssl>=26.0.0
 pyasn1>=0.6.3
 tornado>=6.5.4


### PR DESCRIPTION
## Summary

Simplifies firecloud installation and eliminates CVE-2026-23949 by upgrading firecloud and removing the setuptools version pin.

## Changes

- **Upgrade firecloud** from `>=0.16.35` to `>=0.16.39`
  - Includes setuptools 80+ compatibility fix from [broadinstitute/fiss#200](https://github.com/broadinstitute/fiss/pull/200)
- **Remove `setuptools<80` pin** - no longer needed after firecloud 0.16.39
- **Remove `jaraco.context>=6.1.0` pin** from baseimage.txt
  - setuptools will now upgrade to latest from conda-forge (82.0.1+)
  - Latest setuptools vendors jaraco.context 6.1.0+ with CVE fix
- **Remove CVE-2026-23949 from .trivyignore**
  - Will be eliminated after baseimage rebuild with setuptools 82.0.1+
- **Update comments** to clarify why firecloud uses pip instead of conda
  - Reason: bioconda package has overly restrictive `python<3.12` constraint

## Security Impact

**Eliminates CVE-2026-23949** (jaraco.context path traversal in tarball extraction)
- Current: setuptools 79.0.1 with vendored jaraco.context 5.3.0 (vulnerable)
- After rebuild: setuptools 82.0.1 with vendored jaraco.context 6.1.0+ (fixed)

CVE-2020-25649 (snpEff's jackson-databind) remains in .trivyignore as it requires upstream snpEff to update their bundled dependency.

## Testing

After merging, the baseimage rebuild will:
1. Install firecloud 0.16.39 via pip
2. Allow setuptools to upgrade to 82.0.1+ from conda-forge
3. Pass all existing verification checks (cryptography, firecloud imports)
4. Eliminate CVE-2026-23949 from Trivy scans
