### PR TITLE
Container scan: earlier cron, cleaner exit semantics, trivy-action SHA pin

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -2,8 +2,8 @@ name: Scheduled Container Vulnerability Scan
 
 on:
   schedule:
-    # Daily scan of main branch mega image at 12:00 UTC
-    - cron: '0 12 * * *'
+    # Daily scan of main branch mega image at 09:00 UTC
+    - cron: '0 9 * * *'
   workflow_dispatch:
     inputs:
       test_cve_id:
@@ -47,7 +47,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.36.0
+        # Pinned to commit SHA, NOT a floating tag, because aquasecurity/trivy-action
+        # was compromised in March 2026 (all version tags force-pushed to malicious
+        # commits). This SHA is the vetted v0.36.0 release per broadinstitute/py3-bio#12;
+        # do NOT blindly bump to whatever the upstream v0.36.0 tag currently points to —
+        # the tag has been moved since. Verify any new SHA against multiple sources.
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           image-ref: '${{ env.GHCR_REPO }}:main-mega-amd64'
           format: 'sarif'
@@ -60,7 +65,7 @@ jobs:
           ignore-policy: '.trivy-ignore-policy.rego'
 
       - name: Run Trivy vulnerability scanner (JSON)
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0 — see note above
         with:
           image-ref: '${{ env.GHCR_REPO }}:main-mega-amd64'
           format: 'json'
@@ -376,8 +381,19 @@ jobs:
           if-no-files-found: warn
           include-hidden-files: true
 
-      - name: Fail job if new CVEs were found (production mode only)
-        if: steps.triage.outputs.cve_ids != '' && steps.triage.outputs.test_mode != 'true'
+      - name: Summarize CVE discovery
+        # Notice-level only — we do NOT exit 1 here. New CVE discovery is the
+        # expected outcome of a useful scan, not a workflow failure: notifications
+        # are delivered via the filed GitHub issues (security + cve labels), and
+        # PR-time gating is independently enforced by docker.yml's on-build Trivy
+        # scan. Reserving red ✕ for real pipeline breakage (Trivy errored, Claude
+        # over budget, gh API failure, etc.) keeps the Actions page signal honest.
+        if: steps.triage.outputs.cve_ids != ''
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         run: |
-          echo "::error::Scan found new fixable HIGH/CRITICAL CVEs. See filed issues for details."
-          exit 1
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "::notice::Scheduled scan discovered new fixable HIGH/CRITICAL CVE(s) (dry-run; no issues filed): ${{ steps.triage.outputs.cve_ids }}"
+          else
+            echo "::notice::Scheduled scan filed issues for new fixable HIGH/CRITICAL CVE(s): ${{ steps.triage.outputs.cve_ids }}"
+          fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1019,7 +1019,12 @@ jobs:
           image: '${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-${{ matrix.flavor }}-amd64'
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.36.0
+        # Pinned to commit SHA, NOT a floating tag, because aquasecurity/trivy-action
+        # was compromised in March 2026 (all version tags force-pushed to malicious
+        # commits). This SHA is the vetted v0.36.0 release per broadinstitute/py3-bio#12;
+        # do NOT blindly bump to whatever the upstream v0.36.0 tag currently points to —
+        # the tag has been moved since. Verify any new SHA against multiple sources.
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           image-ref: '${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-${{ matrix.flavor }}-amd64'
           format: 'sarif'
@@ -1032,7 +1037,7 @@ jobs:
           ignore-policy: '.trivy-ignore-policy.rego'
 
       - name: Run Trivy vulnerability scanner (JSON)
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0 — see note above
         with:
           image-ref: '${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-${{ matrix.flavor }}-amd64'
           format: 'json'


### PR DESCRIPTION
## Summary

Three non-blocking improvements to the daily container vulnerability pipeline (split from PR #1074):

1. **Earlier cron** — daily scheduled scan moves from `0 12 * * *` to `0 9 * * *` (UTC). Scan + issue-filing now completes earlier in the workday.

2. **Cleaner exit semantics on the scheduled scan** — the trailing `exit 1` on "new CVEs discovered" is replaced with a notice-level summary. New CVE discovery is the expected outcome of a useful scan, not workflow failure: notifications are delivered via the filed `security`+`cve`-labeled issues, and PR-time gating is independently enforced by `docker.yml`'s on-build Trivy scan (`exit-code: '1'` at `docker.yml:1041`, unchanged). Red ✕ on the Actions page is now reserved for real pipeline breakage (Trivy errored, Claude over budget, gh API failure, etc.).

4. **Pin `aquasecurity/trivy-action` to commit SHA** across all four call sites in `container-scan.yml` and `docker.yml` — SHA `ed142fd0673e97e23eac54620cfb913e5ce36c25`, the vetted v0.36.0 release per [broadinstitute/py3-bio#12](https://github.com/broadinstitute/py3-bio/pull/12). The action repo was compromised in March 2026 with version tags force-pushed to malicious commits; pinning to a previously-vetted SHA defends against future tag manipulation. Note: the upstream `v0.36.0` tag has since moved to a different SHA (`a9c7b0f0...`) — exactly the reason not to trust the tag.

## Relation to PR #1074

This PR extracts changes 1, 2, and 4 from PR #1074, which bundled four changes together. The auto-fix PR job change is blocked on IT creating the required GitHub App secrets, so it remains in #1074 for later. After this PR merges, #1074 will be rebased onto this branch and updated to describe only that new feature.

## Test plan

- [ ] Post-merge: confirm next scheduled run in the Actions tab fires at `09:00 UTC`.
- [ ] Post-merge: confirm the on-PR Trivy scan in `docker.yml` still passes (i.e., the pinned SHA resolves identically to the old tag-based reference).
- [ ] Manually trigger a workflow_dispatch with `dry_run=true` and verify the notice message says "dry-run; no issues filed".