### PR TITLE
CI: Fix Trivy scan disk space issues and separate secret scanning

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,19 @@
+name: Free Disk Space
+description: Remove pre-installed software from GitHub Actions runners to free ~10GB disk space
+
+runs:
+  using: composite
+  steps:
+    - name: Free up disk space
+      shell: bash
+      run: |
+        echo "=== Before cleanup ==="
+        df -h
+        # Remove pre-installed software to free ~10GB
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo docker image prune -af
+        echo "=== After cleanup ==="
+        df -h

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -39,6 +39,9 @@ jobs:
           # precedent CVE-fix commits (e.g., to mirror past mitigation patterns exactly).
           fetch-depth: 0
 
+      - name: Free up disk space
+        uses: ./.github/actions/free-disk-space
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -63,6 +66,7 @@ jobs:
           ignore-unfixed: true
           trivyignores: '.trivyignore'
           ignore-policy: '.trivy-ignore-policy.rego'
+          scanners: 'vuln'  # vuln only - secret scanning handled by docker.yml scan-secrets job
 
       - name: Run Trivy vulnerability scanner (JSON)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0 — see note above
@@ -75,6 +79,7 @@ jobs:
           ignore-unfixed: true
           trivyignores: '.trivyignore'
           ignore-policy: '.trivy-ignore-policy.rego'
+          scanners: 'vuln'  # vuln only - secret scanning handled by docker.yml scan-secrets job
 
       - name: Log scan result count
         if: always()

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -67,6 +67,7 @@ jobs:
           trivyignores: '.trivyignore'
           ignore-policy: '.trivy-ignore-policy.rego'
           scanners: 'vuln'  # vuln only - secret scanning handled by docker.yml scan-secrets job
+          timeout: '20m0s'  # Increase timeout for large images
 
       - name: Run Trivy vulnerability scanner (JSON)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0 — see note above
@@ -80,6 +81,7 @@ jobs:
           trivyignores: '.trivyignore'
           ignore-policy: '.trivy-ignore-policy.rego'
           scanners: 'vuln'  # vuln only - secret scanning handled by docker.yml scan-secrets job
+          timeout: '20m0s'  # Increase timeout for large images
 
       - name: Log scan result count
         if: always()

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1006,6 +1006,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Free up disk space for container scans
+        run: |
+          echo "=== Before cleanup ==="
+          df -h
+          # Remove pre-installed software to free ~10GB
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune -af
+          echo "=== After cleanup ==="
+          df -h
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -1035,6 +1048,7 @@ jobs:
           ignore-unfixed: true
           trivyignores: '.trivyignore'
           ignore-policy: '.trivy-ignore-policy.rego'
+          scanners: 'vuln'  # vuln only - secret scanning disabled to reduce disk usage
 
       - name: Run Trivy vulnerability scanner (JSON)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0 — see note above
@@ -1047,6 +1061,7 @@ jobs:
           ignore-unfixed: true
           trivyignores: '.trivyignore'
           ignore-policy: '.trivy-ignore-policy.rego'
+          scanners: 'vuln'  # vuln only - secret scanning disabled to reduce disk usage
 
       - name: Log scan result count
         if: always()
@@ -1069,6 +1084,72 @@ jobs:
         with:
           name: trivy-${{ matrix.flavor }}
           path: trivy-results.json
+
+  # Secret scanning job - scans mega images on both architectures
+  # Runs in parallel with vulnerability scanning above
+  scan-secrets:
+    needs: [get-version, build-mega-amd64, build-mega-arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Free up disk space for secret scans
+        run: |
+          echo "=== Before cleanup ==="
+          df -h
+          # Remove pre-installed software to free ~10GB
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune -af
+          echo "=== After cleanup ==="
+          df -h
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pre-pull mega image for secret scan
+        uses: ./.github/actions/pull-with-retry
+        with:
+          image: '${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-mega-${{ matrix.arch }}'
+
+      - name: Run Trivy secret scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0 — see vuln scanner note
+        with:
+          image-ref: '${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-mega-${{ matrix.arch }}'
+          format: 'sarif'
+          output: 'trivy-secrets.sarif'
+          scanners: 'secret'  # Secret scanning only
+          exit-code: '1'  # Fail if secrets found
+
+      - name: Log secret scan result count
+        if: always()
+        run: |
+          if [ -f trivy-secrets.sarif ]; then
+            COUNT=$(jq '[.runs[].results[]] | length' trivy-secrets.sarif)
+            echo "::notice::Trivy found $COUNT secrets in mega-${{ matrix.arch }}"
+          fi
+
+      - name: Upload Trivy secret scan results to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: 'trivy-secrets.sarif'
+          category: 'secrets-mega-${{ matrix.arch }}'
 
   # ============================================================================
   # TEST JOBS - Run after corresponding manifests are created

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1006,18 +1006,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Free up disk space for container scans
-        run: |
-          echo "=== Before cleanup ==="
-          df -h
-          # Remove pre-installed software to free ~10GB
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo docker image prune -af
-          echo "=== After cleanup ==="
-          df -h
+      - name: Free up disk space
+        uses: ./.github/actions/free-disk-space
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -1102,18 +1092,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Free up disk space for secret scans
-        run: |
-          echo "=== Before cleanup ==="
-          df -h
-          # Remove pre-installed software to free ~10GB
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo docker image prune -af
-          echo "=== After cleanup ==="
-          df -h
+      - name: Free up disk space
+        uses: ./.github/actions/free-disk-space
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -1173,6 +1153,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Free up disk space
+        uses: ./.github/actions/free-disk-space
+
       - name: Pull test image (with retries)
         uses: ./.github/actions/pull-with-retry
         with:
@@ -1214,6 +1197,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Free up disk space
+        uses: ./.github/actions/free-disk-space
+
       - name: Pull test image (with retries)
         uses: ./.github/actions/pull-with-retry
         with:
@@ -1247,6 +1233,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+
+      - name: Free up disk space
+        uses: ./.github/actions/free-disk-space
       - name: Pull test image (with retries)
         uses: ./.github/actions/pull-with-retry
         with:
@@ -1288,6 +1277,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+
+      - name: Free up disk space
+        uses: ./.github/actions/free-disk-space
       - name: Pull test image (with retries)
         uses: ./.github/actions/pull-with-retry
         with:
@@ -1321,6 +1313,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+
+      - name: Free up disk space
+        uses: ./.github/actions/free-disk-space
       - name: Pull test image (with retries)
         uses: ./.github/actions/pull-with-retry
         with:
@@ -1362,6 +1357,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+
+      - name: Free up disk space
+        uses: ./.github/actions/free-disk-space
       - name: Pull test image (with retries)
         uses: ./.github/actions/pull-with-retry
         with:
@@ -1395,6 +1393,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+
+      - name: Free up disk space
+        uses: ./.github/actions/free-disk-space
       - name: Pull test image (with retries)
         uses: ./.github/actions/pull-with-retry
         with:
@@ -1436,6 +1437,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+
+      - name: Free up disk space
+        uses: ./.github/actions/free-disk-space
       - name: Pull test image (with retries)
         uses: ./.github/actions/pull-with-retry
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1039,6 +1039,7 @@ jobs:
           trivyignores: '.trivyignore'
           ignore-policy: '.trivy-ignore-policy.rego'
           scanners: 'vuln'  # vuln only - secret scanning disabled to reduce disk usage
+          timeout: '20m0s'  # Increase timeout for large images (mega takes ~10min)
 
       - name: Run Trivy vulnerability scanner (JSON)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0 — see note above
@@ -1052,6 +1053,7 @@ jobs:
           trivyignores: '.trivyignore'
           ignore-policy: '.trivy-ignore-policy.rego'
           scanners: 'vuln'  # vuln only - secret scanning disabled to reduce disk usage
+          timeout: '20m0s'  # Increase timeout for large images (mega takes ~10min)
 
       - name: Log scan result count
         if: always()
@@ -1115,6 +1117,7 @@ jobs:
           output: 'trivy-secrets.sarif'
           scanners: 'secret'  # Secret scanning only
           exit-code: '1'  # Fail if secrets found
+          timeout: '20m0s'  # Increase timeout for large images
 
       - name: Log secret scan result count
         if: always()


### PR DESCRIPTION
## Problem

The mega container image has grown large enough that Trivy vulnerability scans are failing with `no space left on device` errors on GitHub Actions runners (14GB disk).

This became visible in PR #1072 (centrifuger integration) where one of the two parallel workflow runs failed during the mega image scan.

## Solution

### 1. Created shared disk cleanup composite action
- New `.github/actions/free-disk-space/action.yml` composite action
- Removes pre-installed software (~10GB): .NET SDKs, Android SDKs, GHC, CodeQL
- Prunes unused Docker images
- Single source of truth prevents implementation drift

### 2. Apply disk cleanup to all container scans and test jobs
- **Vulnerability scans**: All flavors in `scan-containers` matrix
- **Secret scans**: Both mega-amd64 and mega-arm64 in new `scan-secrets` job
- **Test jobs**: All x86 and ARM64 test jobs (core, assemble, classify, phylo)
- Applies to **all** jobs in the matrix for future-proofing as images grow

### 3. Separate vulnerability and secret scanning
- Main vulnerability scans: `scanners: 'vuln'` only
  - Applied to both SARIF and JSON scan steps
  - Secret scanning disabled to reduce disk usage significantly
- New parallel `scan-secrets` job runs separately:
  - Scans **only mega images** (amd64 and arm64)
  - Rationale: if secrets exist anywhere in the image hierarchy, they also exist in mega
  - Both architectures scanned since ARM and AMD may pull different upstream dependencies
  - Uses SARIF output uploaded to GitHub Security tab
  - `exit-code: 1` to fail CI if secrets are found
  - Runs in parallel with vulnerability scanning for efficiency

### 4. Update scheduled container scan workflow
- Add disk cleanup step to `container-scan.yml` (daily cron scan)
- Set `scanners: 'vuln'` for both SARIF and JSON scans
- Secret scanning unnecessary for daily scans:
  - Vulnerability database updates daily (reason for daily scan)
  - Secret detection rules don't change daily
  - Secrets caught by PR-time `scan-secrets` job

## Benefits

✅ **Prevents disk exhaustion** - ~10GB freed across all container-heavy jobs  
✅ **Future-proof** - as images grow (like with centrifuger), headroom increases  
✅ **Consistent** - all jobs use shared disk cleanup action, preventing drift  
✅ **Separation of concerns** - vulnerabilities vs secrets handled independently  
✅ **Maintains coverage** - secret detection preserved via dedicated parallel job  
✅ **Efficient** - parallel execution keeps CI time optimal  
✅ **Applies to tests too** - test jobs won't hit disk limits as images grow

## Files Changed

- `.github/actions/free-disk-space/action.yml` - New composite action for disk cleanup
- `.github/workflows/docker.yml` - Use shared action in all scan/test jobs, add `scan-secrets` job
- `.github/workflows/container-scan.yml` - Add disk cleanup + vuln-only scanning

## Testing

This PR's own CI run will validate:
- Disk cleanup works across all job types
- Vulnerability scanning succeeds with reduced disk usage
- Secret scanning works independently on mega images
- Test jobs complete successfully with disk cleanup