### PR TITLE
fix: prevent cve-autofix pipeline from leaking GCP credential files

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -805,12 +805,15 @@ jobs:
           branch="cve-fix/$(date -u +%Y-%m-%d)-${GITHUB_RUN_ID}"
           git checkout -b "$branch"
           # Stage everything EXCEPT the downloaded trivy-results.json artifact.
-          # .claude-fix-pr/ and .cve-fix-context/ are gitignored, so `git add -A`
-          # already skips them silently — do NOT name them in :! pathspecs, because
-          # `git add` exits 1 ("paths are ignored" advisory) when an exclude pathspec
-          # matches a gitignored path, which kills this step under `set -e`.
+          # .claude-fix-pr/, .cve-fix-context/, and gha-creds-*.json are gitignored,
+          # so `git add -A` skips them silently — do NOT name them in :! pathspecs,
+          # because `git add` exits 1 ("paths are ignored" advisory) when an exclude
+          # pathspec matches a gitignored path, which kills this step under `set -e`.
           # trivy-results.json is NOT gitignored, so it still needs the explicit exclude.
           git add -A -- ':!trivy-results.json'
+          # Scan staged diff for secrets before committing (defence-in-depth).
+          # gitleaks is pre-installed on ubuntu-latest runners.
+          git diff --cached | gitleaks detect --pipe --redact --exit-code 1
           if git diff --cached --quiet; then
             echo "::error::PROCEED.md exists but no file changes were staged — Claude declared a fix without making one"
             exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,10 @@ vulnerability-mitigation-status.md
 .cve-fix-context/
 .claude-fix-pr/
 
+# GCP credential files written to the workspace by google-github-actions/auth
+# (defence-in-depth: even if git add -A runs in a workflow, these are never staged)
+gha-creds-*.json
+
 # GSD planning directory (local-only)
 .planning/*
 


### PR DESCRIPTION
## Summary

- `google-github-actions/auth` writes `gha-creds-*.json` to the runner workspace; the `cve-fix-pr` job's `git add -A` was staging it alongside legitimate fixes, leaking the WIF credential into the PR diff.
- Adds `gha-creds-*.json` to `.gitignore` so the file can never be staged by any workflow, regardless of how `git add` is invoked.
- Adds an inline `gitleaks detect --pipe` scan of the staged diff before `git commit`, so a similar class of mistake is caught before the push rather than after.

## Root cause

The `cve-fix-pr` job authenticates to GCP for Vertex AI access, then hands control to Claude with `Write`/`Edit` permissions and a broad `git add -A`. The credential file written by the auth action lives in `$GITHUB_WORKSPACE` and is not gitignored, so it lands in the commit.

## Changes

- `.gitignore` — add `gha-creds-*.json` pattern with explanatory comment
- `.github/workflows/container-scan.yml` — update `git add` comment to reference the new gitignore entry; add `gitleaks detect --pipe --redact --exit-code 1` scan of the staged diff between `git add` and `git commit`

## Test plan

- [ ] Confirm `gha-creds-*.json` is gitignored: drop a test file matching the pattern into the repo root and verify `git status` does not show it as untracked
- [ ] CI passes on this branch
- [ ] Next auto-fix run does not stage credential files
