### PR TITLE
ci(container-scan): install gitleaks before cve-autofix secret scan

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -796,6 +796,10 @@ jobs:
             echo "::notice::Claude recommends skipping; decision log will be uploaded as an artifact"
           fi
 
+      - name: Install gitleaks
+        if: steps.decide.outputs.decision == 'proceed'
+        uses: gacts/gitleaks@c9a0338361dc45a01aa7ebaaa5330179f3c62873  # v1.3.2
+
       - name: Open auto-fix PR
         if: steps.decide.outputs.decision == 'proceed'
         env:
@@ -812,7 +816,8 @@ jobs:
           # trivy-results.json is NOT gitignored, so it still needs the explicit exclude.
           git add -A -- ':!trivy-results.json'
           # Scan staged diff for secrets before committing (defence-in-depth).
-          # gitleaks is pre-installed on ubuntu-latest runners.
+          # gitleaks is installed by the "Install gitleaks" step above (it is NOT
+          # pre-installed on GitHub-hosted ubuntu-latest runners).
           git diff --cached | gitleaks detect --pipe --redact --exit-code 1
           if git diff --cached --quiet; then
             echo "::error::PROCEED.md exists but no file changes were staged — Claude declared a fix without making one"


### PR DESCRIPTION
## Problem

The latest manually-dispatched **Scheduled Container Vulnerability Scan** ([run 27282001903](https://github.com/broadinstitute/viral-ngs/actions/runs/27282001903)) failed in the `cve-fix-pr` job at the **Open auto-fix PR** step:

```
gitleaks: command not found
##[error]Process completed with exit code 127.
```

The step runs a defence-in-depth secret scan on the staged diff:

```bash
# gitleaks is pre-installed on ubuntu-latest runners.
git diff --cached | gitleaks detect --pipe --redact --exit-code 1
```

That comment is incorrect — `gitleaks` is **not** part of the GitHub-hosted `ubuntu-latest` image, so the command exited 127 and `set -euo pipefail` aborted the step.

This was a regression from #1087, which introduced the gitleaks line. The `proceed` path wasn't exercised until the next dispatch (3 minutes after #1087 merged), so it broke on first run. The rest of the auto-fix logic worked correctly — Claude decided `proceed`, staged the diff, and reached the gitleaks line before dying.

## Fix

- Add an **Install gitleaks** step (guarded by the same `decision == 'proceed'` condition) before **Open auto-fix PR**, so the binary is on `PATH`.
- Pinned to a full commit SHA (`gacts/gitleaks@c9a0338…` = `v1.3.2`) per this repo's action-pinning convention, rather than a mutable tag.
- Correct the misleading "pre-installed" comment.
