### PR TITLE
ci(container-scan): make gitleaks install-only (run: false)

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -799,6 +799,12 @@ jobs:
       - name: Install gitleaks
         if: steps.decide.outputs.decision == 'proceed'
         uses: gacts/gitleaks@c9a0338361dc45a01aa7ebaaa5330179f3c62873  # v1.3.2
+        with:
+          # Install the binary onto PATH only; do NOT let the action run its own
+          # scan. By default this action scans the entire repo history, which
+          # trips on pre-existing historical findings unrelated to the auto-fix
+          # diff. We scan just the staged diff ourselves in the next step.
+          run: false
 
       - name: Open auto-fix PR
         if: steps.decide.outputs.decision == 'proceed'


### PR DESCRIPTION
## Problem

After #1088 merged, the next manual dispatch of **Scheduled Container Vulnerability Scan** ([run 27283277584](https://github.com/broadinstitute/viral-ngs/actions/runs/27283277584)) still failed in `cve-fix-pr` — this time at the new **Install gitleaks** step.

Root cause: `gacts/gitleaks` doesn't *just* install the binary. By default it also **runs a full-history repo scan**:

```
[command]/tmp/gitleaks-8.30.1/gitleaks ... --source <repo> detect
...
6944 commits scanned.
WRN leaks found: 3
##[warning]⛔ GitLeaks encountered leaks
```

The 3 findings are all **pre-existing history**, unrelated to the auto-fix diff:
- `.coveralls.yml:2` — coveralls `repo_token` (2019)
- `easy-deploy/Vagrantfile:35` — SSH private-key *path* (2015), flagged twice across commits

The action exits non-zero on those, killing the step.

## Fix

Set `run: false` on the action. Confirmed from the action source that this gates **only** the scan — install + `addPath()` (which puts the binary on `PATH`) always run:

```js
await doInstall(version);   // always: download + addPath  → binary on PATH
await doCheck(version);     // always: which("gitleaks")
if (input.run) {            // run: false skips ONLY this
  await doRun(version);     // ← the full-history scan that failed
}
```

So the binary still lands on `PATH`, and the **intended** secret scan continues to run in the next step against just the staged auto-fix diff:

```bash
git diff --cached | gitleaks detect --pipe --redact --exit-code 1
```

The action stays pinned to a full commit SHA (`gacts/gitleaks@c9a0338…` = v1.3.2).

> Note: the historical `.coveralls.yml` / `Vagrantfile` findings are out of scope here (they're not real live secrets — a CI token from 2019 and an SSH key file *path*), but could be cleaned up / allowlisted separately if desired.
