### PR TITLE
ci: fix CVE-triage Sonnet 5 compat, bump build-push-action to Node 24, pin Trivy to v0.72.0

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -208,9 +208,14 @@ jobs:
 
       - name: Claude analysis on Vertex AI
         if: steps.triage.outputs.cve_ids != ''
-        # Pinned to commit SHA (== v1 as of 2026-04-27) for supply-chain safety;
-        # bump this SHA when picking up new claude-code-action releases.
-        uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434  # v1
+        # Pinned to commit SHA (== v1.0.179 as of 2026-07-21) for supply-chain
+        # safety; bump this SHA when picking up new claude-code-action releases.
+        # Bumped from 567fe954 (v1, 2026-04-27 / agent-SDK ^0.2.119) because that
+        # pin predates Claude Sonnet 5 support: its SDK still emitted the legacy
+        # `thinking.type.enabled` request shape, which Vertex rejects with HTTP 400
+        # for Sonnet 5 ("Use thinking.type.adaptive and output_config.effort").
+        # v1.0.179 ships agent-SDK ^0.3.216, which speaks the adaptive-thinking API.
+        uses: anthropics/claude-code-action@b76a0776ae74036e77cd11018083743453d7ad35  # v1.0.179
         env:
           CLAUDE_CODE_USE_VERTEX: '1'
           CLOUD_ML_REGION: global
@@ -549,7 +554,7 @@ jobs:
         if: steps.context.outputs.issue_count != '0'
         # Pinned to the same commit SHA as the scan job's Claude step. When
         # bumping, bump both call sites together so they stay aligned.
-        uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434  # v1
+        uses: anthropics/claude-code-action@b76a0776ae74036e77cd11018083743453d7ad35  # v1.0.179
         env:
           CLAUDE_CODE_USE_VERTEX: '1'
           CLOUD_ML_REGION: global

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -69,8 +69,12 @@ jobs:
         # commits). This SHA is the vetted v0.36.0 release per broadinstitute/py3-bio#12;
         # do NOT blindly bump to whatever the upstream v0.36.0 tag currently points to —
         # the tag has been moved since. Verify any new SHA against multiple sources.
+        # `version:` pins the Trivy scanner binary itself (independent of the action
+        # wrapper's SHA above) so it doesn't silently drift if the action's own
+        # default changes; bump explicitly rather than relying on the wrapper default.
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
+          version: 'v0.72.0'
           image-ref: '${{ env.GHCR_REPO }}:main-mega-amd64'
           format: 'sarif'
           output: 'trivy-results.sarif'
@@ -86,6 +90,7 @@ jobs:
       - name: Run Trivy vulnerability scanner (JSON)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0 — see note above
         with:
+          version: 'v0.72.0'
           image-ref: '${{ env.GHCR_REPO }}:main-mega-amd64'
           format: 'json'
           output: 'trivy-results.json'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Build and push (amd64)
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.baseimage
@@ -192,7 +192,7 @@ jobs:
 
       - name: Build and push (arm64)
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.baseimage
@@ -293,7 +293,7 @@ jobs:
 
       - name: Build and push (amd64)
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.core
@@ -334,7 +334,7 @@ jobs:
 
       - name: Build and push (arm64)
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.core
@@ -438,7 +438,7 @@ jobs:
 
       - name: Build and push (amd64)
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.assemble
@@ -479,7 +479,7 @@ jobs:
 
       - name: Build and push (arm64)
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.assemble
@@ -583,7 +583,7 @@ jobs:
 
       - name: Build and push (amd64)
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.classify
@@ -624,7 +624,7 @@ jobs:
 
       - name: Build and push (arm64)
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.classify
@@ -728,7 +728,7 @@ jobs:
 
       - name: Build and push (amd64)
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.phylo
@@ -769,7 +769,7 @@ jobs:
 
       - name: Build and push (arm64)
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.phylo
@@ -873,7 +873,7 @@ jobs:
 
       - name: Build and push (amd64)
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.mega
@@ -914,7 +914,7 @@ jobs:
 
       - name: Build and push (arm64)
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.mega
@@ -1027,8 +1027,12 @@ jobs:
         # commits). This SHA is the vetted v0.36.0 release per broadinstitute/py3-bio#12;
         # do NOT blindly bump to whatever the upstream v0.36.0 tag currently points to —
         # the tag has been moved since. Verify any new SHA against multiple sources.
+        # `version:` pins the Trivy scanner binary itself (independent of the action
+        # wrapper's SHA above) so it doesn't silently drift if the action's own
+        # default changes; bump explicitly rather than relying on the wrapper default.
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
+          version: 'v0.72.0'
           image-ref: '${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-${{ matrix.flavor }}-amd64'
           format: 'sarif'
           output: 'trivy-results.sarif'
@@ -1044,6 +1048,7 @@ jobs:
       - name: Run Trivy vulnerability scanner (JSON)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0 — see note above
         with:
+          version: 'v0.72.0'
           image-ref: '${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-${{ matrix.flavor }}-amd64'
           format: 'json'
           output: 'trivy-results.json'
@@ -1112,6 +1117,7 @@ jobs:
       - name: Run Trivy secret scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0 — see vuln scanner note
         with:
+          version: 'v0.72.0'
           image-ref: '${{ env.GHCR_REPO }}:${{ needs.get-version.outputs.image-tag-prefix }}-mega-${{ matrix.arch }}'
           format: 'sarif'
           output: 'trivy-secrets.sarif'


### PR DESCRIPTION
## Summary

This PR bundles three related CI-hygiene fixes discovered/requested while
triaging this morning's scheduled scan failure, all in
`.github/workflows/{container-scan,docker}.yml`:

### 1. Fix CVE-triage pipeline (Sonnet 5 / Vertex incompatibility)

- The daily **Scheduled Container Vulnerability Scan** failed this morning
  ([run 29819786103](https://github.com/broadinstitute/viral-ngs/actions/runs/29819786103))
  at the "Claude analysis on Vertex AI" step with:
  ```
  API Error: 400 invalid_request_error:
  "thinking.type.enabled" is not supported for this model.
  Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
  ```
- Root cause: yesterday's model bump (#1100, `3ee81c94`) switched the triage
  pipeline from `claude-sonnet-4-6` to `claude-sonnet-5`, but
  `anthropics/claude-code-action` was still pinned to commit `567fe954` (tag
  `v1`, 2026-04-27), which bundles agent-SDK `^0.2.119` — predating Sonnet 5's
  adaptive-thinking request format. Sonnet 5 requires the SDK to send
  `thinking.type.adaptive` / `output_config.effort`; the old SDK only knew the
  legacy `thinking.type.enabled` shape, which Vertex now rejects for this model.
- This is why prior scheduled runs stayed green after the model bump: they
  simply found no *new* fixable CVEs and skipped the Claude step entirely.
  Today's run found two (CVE-2026-54058, CVE-2026-59197) and hit the
  incompatibility. No issues were filed, so both CVEs remain undetected/"new"
  and will be re-picked-up automatically once this pipeline is healthy again.
- **Fix:** bump the `claude-code-action` pin at both call sites (scan job's
  triage step, and the cve-fix-pr job's auto-fix-assessment step) from
  `567fe954` (v1) to `b76a0776ae74036e77cd11018083743453d7ad35` (tag
  `v1.0.179`, published 2026-07-20), which ships agent-SDK `^0.3.216`. Keeps
  `--model claude-sonnet-5` unchanged. Verified `v1.0.179` -> `b76a0776...`
  independently via the GitHub API and `git ls-remote`; the target commit's
  own message ("chore: bump Claude Code to 2.1.216 and Agent SDK to 0.3.216")
  corroborates this is the right fix.

### 2. Bump docker/build-push-action from Node 20 to Node 24

- GitHub Actions is deprecating the Node 20 runtime for actions.
  `docker/build-push-action@v6` still declares `using: node20`; `@v7`
  declares `using: node24`.
- Bumped all 12 call sites in `docker.yml` (baseimage/core/assemble/classify/
  phylo/mega, amd64+arm64 each) from `@v6` to `@v7`.
- Checked the full v7.0.0-v7.3.0 changelog: the only behavior-relevant change
  is removal of two already-deprecated env vars
  (`DOCKER_BUILD_NO_SUMMARY`, `DOCKER_BUILD_EXPORT_RETENTION_DAYS`) that this
  repo does not use. No config changes needed beyond the version bump.
- Also audited every other third-party action used across all 5 workflow
  files (`actions/checkout`, `create-github-app-token`, `download-artifact`,
  `setup-python`, `upload-artifact`, `codecov-action`, `docker/login-action`,
  `dorny/paths-filter`, `gacts/gitleaks`, `codeql-action/upload-sarif`,
  `google-github-actions/auth`, `imjasonh/setup-crane`, `trivy-action`,
  `claude-code-action`): all are already on `node24` or a composite
  (non-Node) runtime, so `build-push-action` was the only one needing a bump.
  The repo's own local composite actions (`.github/actions/*`) are also
  composite, not Node-based.

### 3. Pin Trivy scanner version to v0.72.0

- `aquasecurity/trivy-action` is (intentionally) pinned by commit SHA rather
  than a floating tag, per the existing supply-chain note (the action was
  compromised in March 2026). That SHA pin controls the *wrapper action*
  version, but none of the 5 invocations set the wrapper's own `version:`
  input (Trivy scanner binary version) — so all 5 silently rode the wrapper's
  baked-in default of `v0.70.0`.
- Added an explicit `version: 'v0.72.0'` input to all 5 `trivy-action`
  invocations (2 in `container-scan.yml`, 3 in `docker.yml`), confirmed
  `v0.72.0` is a real upstream Trivy release. The `trivy-action` wrapper
  itself stays pinned to the same commit SHA as before — only the scanner
  binary version changed, and it is now explicit rather than implicit.

## Test plan

- [ ] Static checks done locally: `git grep` confirms both `claude-code-action`
      call sites on `b76a0776...`, both `--model claude-sonnet-5` unchanged,
      all 12 `build-push-action` call sites on `@v7`, all 5 `trivy-action`
      blocks carry `version: 'v0.72.0'`.
- [ ] Dry-run dispatch of the CVE-triage fix from this branch (proves the 400
      is gone, files no issues):
      ```
      gh workflow run "Scheduled Container Vulnerability Scan" \
        --ref fix/cve-triage-sonnet5-action-bump \
        -f test_cve_id=CVE-2026-54058 \
        -f dry_run=true
      ```
      Success: the "Claude analysis on Vertex AI" step completes without the
      `thinking.type.enabled` 400, and the `claude-cve-analysis` artifact
      contains `CVE-2026-54058.md`.
- [ ] Docker/Trivy changes will exercise on the next full `docker.yml` build
      (e.g. push to this branch or merge to main) — confirm all
      baseimage/core/assemble/classify/phylo/mega build-and-push steps
      succeed on `build-push-action@v7`, and that both vuln + secret Trivy
      scans run cleanly against `v0.72.0`.
- [ ] After merge: either wait for the next 09:00 UTC scheduled scan, or
      dispatch with `-f force_fix_pr=true` to also exercise the cve-fix-pr
      job's Claude step end-to-end.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
