### PR TITLE
Pin rpds-py 2026.6.3 to fix PyO3 vulnerability

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -42,34 +42,6 @@
 CVE-2020-25649
 
 # -----------------------------------------------------------------------------
-# GHSA-36hh-v3qg-5jq4 — pyo3 Out-of-bounds Read in PyList/PyTuple iterators
-# Severity: HIGH (CVSS 4.0: 8.7, AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N)
-# Package: pyo3 0.28.3 compiled into rpds-py 2026.5.1
-# Location: opt/conda/lib/python3.12/site-packages/rpds/rpds.cpython-312-x86_64-linux-gnu.so
-#
-# JUSTIFICATION:
-#   The vulnerable code path is BoundListIterator::nth and
-#   BoundTupleIterator::nth_back, invoked when Python code calls .nth(n)
-#   or .nth_back(n) on a PyList or PyTuple iterator with a large enough n
-#   to overflow unchecked usize arithmetic, producing an out-of-bounds read.
-#
-#   rpds-py is used internally by jsonschema and referencing to manage
-#   immutable persistent data structures (schema registries, validation
-#   state). These libraries iterate over internally-constructed objects
-#   (JSON schema documents, WDL task graphs) using standard sequential
-#   traversal — not via .nth() with externally-controlled step indices.
-#   Pipeline inputs (FASTQ, BAM, VCF, reference FASTA) are processed by
-#   bioinformatics tools; no code path maps raw file content to a PyList
-#   or PyTuple iterator step argument. The vulnerable arithmetic is never
-#   reachable with an attacker-controlled index in this deployment model.
-#
-# RESOLUTION: Upgrade rpds-py to a conda-forge build that bundles pyo3>=0.29.0.
-# ADDED: 2026-06-13
-# REVIEW: Remove once rpds-py on conda-forge ships pyo3>=0.29.0
-# -----------------------------------------------------------------------------
-GHSA-36hh-v3qg-5jq4
-
-# -----------------------------------------------------------------------------
 # CVE-2026-54512 — jackson-databind PolymorphicTypeValidator bypass via
 #                  generic type parameters allows arbitrary class instantiation
 # Severity: HIGH (AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H)

--- a/docker/requirements/baseimage.txt
+++ b/docker/requirements/baseimage.txt
@@ -16,12 +16,14 @@ google-cloud-storage>=2.14.0
 # Note: firecloud is installed via pip in Dockerfile.baseimage because the
 # bioconda noarch package has an overly restrictive python<3.12 constraint
 
-# Python security libraries (pinned to address CVEs in transitive deps of firecloud)
+# Python libraries pinned to address vulnerabilities in transitive dependencies
 cryptography>=46.0.5
 pyopenssl>=26.0.0
 pyasn1>=0.6.3
 tornado>=6.5.4
 urllib3>=2.7.0
+# Versions >=2026.6.3 bundle pyo3>=0.29.0, fixing GHSA-36hh-v3qg-5jq4
+rpds-py>=2026.6.3
 
 # setuptools pinned to eliminate CVE-2026-23949 (jaraco.context path traversal)
 # Versions >=80.10.1 vendor jaraco.context>=6.1.0 with the fix


### PR DESCRIPTION
## Summary

- Pin `rpds-py>=2026.6.3` in the base image requirements so conda cannot resolve the vulnerable `2026.5.1` release.
- Remove the temporary `GHSA-36hh-v3qg-5jq4` Trivy exception now that a fixed conda-forge package is available.

## Upstream verification

- [GHSA-36hh-v3qg-5jq4](https://github.com/advisories/GHSA-36hh-v3qg-5jq4) identifies PyO3 `0.29.0` as the first patched version.
- The exact `rpds-py 2026.6.3` source archive used by the conda-forge recipe has the expected SHA-256 and locks PyO3 `0.29.0` in `Cargo.lock`.
- Conda-forge publishes Python 3.12 builds for both `linux-64` and `linux-aarch64`.

## Validation

- Built `docker/Dockerfile.baseimage` successfully for ARM64 and AMD64.
- Verified both images install and import `rpds-py 2026.6.3` under Python 3.12.
- Scanned both images with Trivy 0.72.0 using the CI HIGH/CRITICAL settings and the reduced `.trivyignore`; both scans reported zero findings.
- `git diff --check` passed.

## Closes

Closes #1092