### PR TITLE
Unblock the CVE auto-fix bot: verify conda availability before triage

### DIFF
--- a/.agents/skills/container-vulns/SKILL.md
+++ b/.agents/skills/container-vulns/SKILL.md
@@ -22,6 +22,10 @@ Container images are scanned for vulnerabilities using [Trivy](https://aquasecur
 - When new fixable HIGH/CRITICAL CVEs are detected (i.e. CVE IDs not already present in any open or closed GH issue title), the workflow invokes Claude Sonnet 5 on Vertex AI to triage each one and files a GitHub issue per CVE (labels: `security`, `cve`)
 - **Auto-fix PR (`cve-fix-pr` job)**: after new issues are filed, Claude assesses *all* currently-open `cve` issues and either opens a single `cve-fix` + `security` PR — only if every open issue meets the moderate confidence bar (version-floor bump, precedent-mirroring Dockerfile mitigation, or precedent-mirroring `.trivyignore` entry; all-or-nothing) — or uploads a `SKIPPED.md` decision-log artifact. The PR is authored with a GitHub App token so it triggers the required CI checks.
 - **Recovery / manual re-run**: the auto-fix job only fires when the scan finds a *new* CVE, so once an issue is filed the CVE is no longer "new" and a failed or skipped fix run will not retry on its own. To re-run it on demand against all currently-open `cve` issues, dispatch manually: `gh workflow run container-scan.yml -f force_fix_pr=true`
+- **Conda availability probe**: both Claude steps are preceded by `.github/scripts/probe-conda-availability.py`, which queries the conda-forge and bioconda APIs and writes `.cve-fix-context/conda-availability.json`. Per affected package it reports whether the Trivy `FixedVersion` exists on a channel, whether it is built for **both** `linux-64` and `linux-aarch64` (or is `noarch`), whether a requirements pin can fix the finding at all (`fix_shape` — an Ubuntu `os-package` or a `bundled-jar` cannot), and which other pinned packages carry a constraint that would exclude the fix version (`constrained_by`, e.g. `pyopenssl<50` capping `cryptography`). Uploaded as a workflow artifact. Before this existed the agents had no network tool at all and skipped *every* version-floor bump as unverifiable — the primary category the pipeline was built for.
+- **CI verifies ARM64, so the agent does not have to**: `docker.yml` builds all six tiers for both amd64 and native arm64 on every PR and re-scans each with Trivy, so a solver conflict from a floor bump fails required checks before merge. The auto-fix prompt says so explicitly and instructs the agent to reserve SKIP for "I cannot determine *what* the fix is", not "I cannot prove the fix works". Unproven solvability used to be the standard reason for skipping.
+- **Steering the bot via issue comments**: maintainer comments on a `cve` issue are passed to the auto-fix agent and outrank the machine-generated issue body — use them to specify or amend a fix. Comments are hard-filtered to `OWNER`/`MEMBER`/`COLLABORATOR` in the workflow's `jq`, not in the prompt: this is a public repo, so an unfiltered comments array would be an untrusted-instruction channel into an agent that edits files and opens PRs.
+- **Agent guardrails**: the auto-fix agent has domain-scoped `WebFetch` (no `WebSearch`, since its output is committed); the staged diff is checked against a path allowlist (`docker/requirements/*.txt`, `docker/Dockerfile.*`, `.trivyignore`) before commit; and the GitHub App token is kept out of `.git/config` while the agent runs (`persist-credentials: false`, push remote attached afterwards). The triage agent gets `WebSearch` too — it cannot edit or push.
 - The Vertex/WIF infra used here is documented in `.agents/skills/claude-on-vertex-ci/SKILL.md`
 
 **Key difference**: The scheduled scan's JSON output includes MEDIUM severity and non-fixable vulnerabilities to provide full visibility for risk assessment and debugging, while the control flow (issue filing, CI gates) still filters to fixable HIGH/CRITICAL only.
@@ -69,8 +73,12 @@ When triaging a CVE:
 
 1. **Check the CVSS vector** -- does the Rego policy already filter it?
 2. **Identify the source package** -- use Trivy JSON output (`PkgName`, `PkgPath`, `InstalledVersion`)
-3. **Check if a fix version exists on conda-forge/bioconda** -- not just on PyPI
-4. **Test on ARM64** -- solver conflicts are the most common failure mode
+3. **Check if a fix version exists on conda-forge/bioconda** -- not just on PyPI. Run
+   `.github/scripts/probe-conda-availability.py --trivy-json trivy-results.json --cve-ids "<CVE-ID>" --out /tmp/avail.json`
+   (works locally against a downloaded scan artifact) rather than checking by hand; it also
+   reports which other pinned packages constrain the version you want.
+4. **Test on ARM64** -- solver conflicts are the most common failure mode. Opening a PR is
+   a legitimate way to test this: `docker.yml` builds native arm64 for every tier.
 5. **If the fix version conflicts**: consider whether the CVE is exploitable in your deployment model. Document the risk assessment in `.trivyignore` or `vulnerability-mitigation-status.md`.
 6. **If the vulnerable code is unused**: delete the binary/file inline in the Dockerfile (same RUN layer as install to avoid bloating images)
 
@@ -80,6 +88,7 @@ When triaging a CVE:
 |------|---------|
 | `.trivy-ignore-policy.rego` | Rego policy for class-level CVE filtering |
 | `.trivyignore` | Per-CVE exceptions with justifications |
-| `.github/workflows/docker.yml` | Build-time scanning (SARIF + JSON) |
-| `.github/workflows/container-scan.yml` | Weekly scheduled scanning |
+| `.github/workflows/docker.yml` | Build-time scanning (SARIF + JSON), amd64 + native arm64 |
+| `.github/workflows/container-scan.yml` | Daily scheduled scanning, Claude triage, auto-fix PR |
+| `.github/scripts/probe-conda-availability.py` | Pre-agent conda-forge/bioconda availability + reverse-constraint probe |
 | `vulnerability-mitigation-status.md` | Local-only tracking doc (not committed) |

--- a/.github/scripts/probe-conda-availability.py
+++ b/.github/scripts/probe-conda-availability.py
@@ -1,0 +1,776 @@
+#!/usr/bin/env python3
+"""Probe conda channels for the availability of CVE fix versions.
+
+Written for the Claude triage / auto-fix pipeline in `.github/workflows/container-scan.yml`.
+Those agents are asked whether a version-floor bump in `docker/requirements/*.txt` can
+close a CVE, which requires knowing:
+
+  (a) whether the fixed version exists on conda-forge or bioconda at all (conda-forge
+      often lags PyPI, so a Trivy `FixedVersion` is not proof of availability), and
+  (b) whether it is built for every architecture we publish -- `linux-64` AND
+      `linux-aarch64`, or `noarch`.
+
+Historically the agents had no tool that could answer either question, so they skipped
+every floor bump as "unverifiable" -- see the SKIPPED.md decision logs from runs
+29883237168 (Pillow) and 30898278357 (cryptography). This script answers both questions
+deterministically, before the agent runs, and writes the result to a JSON file the agent
+reads. Keeping the lookup here rather than leaving it to the agent's own web access means
+the answer is identical run-to-run, costs the agent no turns, and is archived as a
+workflow artifact for audit.
+
+It also reports the reverse direction: which *other* packages pinned in
+`docker/requirements/*.txt` carry a dependency constraint that would exclude the fix
+version. That is the trap CVE-2026-69247 hit -- `pyopenssl` 26.3.0 pins
+`cryptography >=49.0.0,<50`, so bumping `cryptography` alone requires `pyopenssl` 26.4.0
+(which widened the cap to `<51`) to come along.
+
+Usage:
+    probe-conda-availability.py \
+        --trivy-json trivy-results.json \
+        --cve-ids "CVE-2026-69247 CVE-2025-47273" \
+        --requirements-dir docker/requirements \
+        --out .cve-fix-context/conda-availability.json
+
+Exit status is 0 even when lookups fail: partial data plus a populated `probe_errors`
+list is more useful to the agent than a failed workflow step. The agent is instructed to
+treat a package with no usable data as unverified -- i.e. SKIP -- which is the safe
+direction.
+"""
+
+import argparse
+import concurrent.futures
+import glob
+import json
+import os
+import re
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+
+ANACONDA_API = "https://api.anaconda.org/package/{channel}/{name}"
+CHANNELS = ("conda-forge", "bioconda")
+
+# Architectures the published images are built for; see the build matrix in docker.yml.
+REQUIRED_SUBDIRS = ("linux-64", "linux-aarch64")
+# The conda env in the images is Python 3.12 (see docker/Dockerfile.baseimage).
+PYTHON_TAG = "py312"
+
+# How many versions of a constraining package to walk when looking for the oldest one
+# that admits the fix version. Bounded so a package with a decade of releases doesn't
+# turn into a pathological loop.
+MAX_VERSIONS_SCANNED = 60
+
+# The reverse scan is a bonus, not the critical path, and some payloads are large
+# (google-cloud-sdk is ~7 MB). Fetch candidates concurrently and give the whole scan a
+# wall-clock budget; if it runs out we report what we have plus a probe_error saying the
+# scan was truncated, rather than silently returning partial data.
+REVERSE_SCAN_WORKERS = 8
+REVERSE_SCAN_BUDGET_SECONDS = 90
+# Reverse-scan fetches get one shot with a short timeout: a package whose payload is too
+# big to read in time (awscli lists thousands of releases) will time out again on retry,
+# and burning the budget on it starves the rest of the scan. Unread packages are reported
+# in `probe_errors` rather than silently dropped.
+REVERSE_SCAN_TIMEOUT = 12
+
+USER_AGENT = "viral-ngs-container-scan/1.0 (+https://github.com/broadinstitute/viral-ngs)"
+
+
+# --------------------------------------------------------------------------------------
+# Version handling
+#
+# Prefer `packaging` when the runner has it; fall back to a local comparator otherwise so
+# this script has no dependencies outside the stdlib. Conda-style versions such as
+# `2026.6.3` (rpds-py) must parse under either path.
+# --------------------------------------------------------------------------------------
+
+try:
+    from packaging.version import InvalidVersion, Version
+
+    def version_key(raw):
+        try:
+            return (0, Version(raw))
+        except InvalidVersion:
+            return (1, _fallback_key(raw))
+
+except ImportError:  # pragma: no cover - depends on runner image
+
+    def version_key(raw):
+        return (1, _fallback_key(raw))
+
+
+def _fallback_key(raw):
+    """Split a version into comparable (kind, value) chunks.
+
+    Numeric chunks sort as integers so 10 > 9; alphabetic chunks sort after numeric ones
+    at the same position. Good enough for "is this release >= that release", which is all
+    we need -- we are not trying to model conda's full pre-release ordering.
+    """
+    key = []
+    for chunk in re.split(r"[._\-+]", str(raw)):
+        for match in re.finditer(r"\d+|[A-Za-z]+", chunk):
+            token = match.group()
+            key.append((0, int(token), "") if token.isdigit() else (1, 0, token.lower()))
+    return tuple(key)
+
+
+def version_ge(a, b):
+    return version_key(a) >= version_key(b)
+
+
+def version_gt(a, b):
+    return version_key(a) > version_key(b)
+
+
+def sorted_versions(versions):
+    return sorted(versions, key=version_key)
+
+
+# --------------------------------------------------------------------------------------
+# Conda constraint evaluation
+# --------------------------------------------------------------------------------------
+
+_OP_RE = re.compile(r"^(>=|<=|==|!=|>|<|=)?\s*(.+)$")
+
+
+def constraint_allows(constraint, target):
+    """Does a conda version constraint admit `target`?
+
+    Handles the comma-separated conjunctions and `|` disjunctions that appear in conda
+    `depends` strings (e.g. `>=49.0.0,<51`). Returns None when the constraint cannot be
+    parsed, so callers can report uncertainty instead of guessing.
+    """
+    if not constraint or constraint.strip() in ("*", ""):
+        return True
+
+    # `|` is a disjunction in conda match specs; any satisfied branch admits the target.
+    if "|" in constraint:
+        results = [constraint_allows(part, target) for part in constraint.split("|")]
+        if any(r is True for r in results):
+            return True
+        return None if any(r is None for r in results) else False
+
+    for clause in constraint.split(","):
+        clause = clause.strip()
+        if not clause:
+            continue
+        match = _OP_RE.match(clause)
+        if not match:
+            return None
+        op, bound = match.group(1) or "==", match.group(2).strip()
+
+        # Prefix wildcards: `1.2.*` means "starts with 1.2.".
+        if bound.endswith(".*") or bound.endswith("*"):
+            prefix = bound.rstrip("*").rstrip(".")
+            hit = str(target) == prefix or str(target).startswith(prefix + ".")
+            if op in ("==", "="):
+                if not hit:
+                    return False
+                continue
+            if op == "!=":
+                if hit:
+                    return False
+                continue
+            return None
+
+        try:
+            if op == ">=":
+                ok = version_ge(target, bound)
+            elif op == ">":
+                ok = version_gt(target, bound)
+            elif op == "<=":
+                ok = version_ge(bound, target)
+            elif op == "<":
+                ok = version_gt(bound, target)
+            elif op in ("==", "="):
+                ok = version_key(target) == version_key(bound)
+            elif op == "!=":
+                ok = version_key(target) != version_key(bound)
+            else:
+                return None
+        except Exception:
+            return None
+        if not ok:
+            return False
+    return True
+
+
+def constraint_floor(constraint):
+    """Lowest version a constraint admits, as far as we can tell from `>=`/`>`/`==`."""
+    if not constraint:
+        return None
+    best = None
+    for clause in constraint.split(","):
+        match = _OP_RE.match(clause.strip())
+        if not match:
+            continue
+        op, bound = match.group(1) or "==", match.group(2).strip()
+        if op in (">=", ">", "==", "=") and not bound.endswith("*"):
+            if best is None or version_gt(bound, best):
+                best = bound
+    return best
+
+
+# --------------------------------------------------------------------------------------
+# Requirements files
+# --------------------------------------------------------------------------------------
+
+_REQ_LINE_RE = re.compile(r"^([A-Za-z0-9_.\-]+)\s*(.*)$")
+
+
+def read_requirements(requirements_dir):
+    """Map conda package name -> {file, line, spec, constraint} from docker/requirements."""
+    pins = {}
+    for path in sorted(glob.glob(os.path.join(requirements_dir, "*.txt"))):
+        try:
+            with open(path, encoding="utf-8") as handle:
+                lines = handle.readlines()
+        except OSError:
+            continue
+        for lineno, raw in enumerate(lines, start=1):
+            line = raw.split("#", 1)[0].strip()
+            if not line:
+                continue
+            match = _REQ_LINE_RE.match(line)
+            if not match:
+                continue
+            name, constraint = match.group(1), match.group(2).strip()
+            pins.setdefault(
+                name.lower(),
+                {
+                    "package": name,
+                    "file": path,
+                    "line": lineno,
+                    "spec": line,
+                    "constraint": constraint or None,
+                },
+            )
+    return pins
+
+
+# --------------------------------------------------------------------------------------
+# anaconda.org lookups
+# --------------------------------------------------------------------------------------
+
+
+class ChannelClient:
+    """Tiny cached client for the anaconda.org package API."""
+
+    def __init__(self, errors, timeout=30, retries=3):
+        self._cache = {}
+        self._errors = errors
+        self._timeout = timeout
+        self._retries = retries
+        self._lock = threading.Lock()
+
+    def cached(self, channel, name):
+        with self._lock:
+            return self._cache.get((channel, name.lower()), False)
+
+    def fetch(self, channel, name, timeout=None, retries=None):
+        key = (channel, name.lower())
+        with self._lock:
+            if key in self._cache:
+                return self._cache[key]
+
+        timeout = self._timeout if timeout is None else timeout
+        retries = self._retries if retries is None else retries
+        url = ANACONDA_API.format(channel=channel, name=name)
+        result = None
+        for attempt in range(1, retries + 1):
+            try:
+                request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+                with urllib.request.urlopen(request, timeout=timeout) as response:
+                    result = json.load(response)
+                break
+            except urllib.error.HTTPError as exc:
+                if exc.code == 404:
+                    break  # Package simply isn't in this channel; not an error.
+                if exc.code in (429, 500, 502, 503, 504) and attempt < retries:
+                    time.sleep(2 * attempt)
+                    continue
+                self._errors.append(
+                    "HTTP %s fetching %s/%s" % (exc.code, channel, name)
+                )
+                break
+            except Exception as exc:  # network error, malformed JSON, ...
+                if attempt < retries:
+                    time.sleep(2 * attempt)
+                    continue
+                self._errors.append(
+                    "%s fetching %s/%s: %s -- this package was NOT checked; treat any "
+                    "claim about it as unverified"
+                    % (type(exc).__name__, channel, name, exc)
+                )
+                break
+
+        with self._lock:
+            self._cache[key] = result
+        return result
+
+
+def files_by_version(payload):
+    """Group a package payload's files by version -> list of {subdir, build, depends}."""
+    grouped = {}
+    for entry in payload.get("files") or []:
+        attrs = entry.get("attrs") or {}
+        version = entry.get("version")
+        if not version:
+            continue
+        grouped.setdefault(version, []).append(
+            {
+                "subdir": attrs.get("subdir") or entry.get("subdir"),
+                "build": attrs.get("build") or "",
+                "depends": attrs.get("depends") or [],
+                "upload_time": entry.get("upload_time"),
+            }
+        )
+    return grouped
+
+
+def describe_version(version, builds):
+    subdirs = sorted({b["subdir"] for b in builds if b["subdir"]})
+    noarch = "noarch" in subdirs
+    py_tagged = {
+        b["subdir"]
+        for b in builds
+        if b["subdir"] and b["build"].startswith(PYTHON_TAG)
+    }
+    uploads = sorted(b["upload_time"] for b in builds if b["upload_time"])
+    return {
+        "version": version,
+        "subdirs": subdirs,
+        "noarch": noarch,
+        "linux_64": noarch or "linux-64" in subdirs,
+        "linux_aarch64": noarch or "linux-aarch64" in subdirs,
+        "py312_linux_64": noarch or "linux-64" in py_tagged,
+        "py312_linux_aarch64": noarch or "linux-aarch64" in py_tagged,
+        "arch_ok": noarch or all(s in subdirs for s in REQUIRED_SUBDIRS),
+        "first_upload": uploads[0] if uploads else None,
+    }
+
+
+def probe_channel(client, channel, pkg_name, threshold):
+    """Availability of `pkg_name` at versions >= `threshold` in one channel."""
+    payload = client.fetch(channel, pkg_name)
+    name_lookup = "exact"
+    if payload is None and pkg_name != pkg_name.lower():
+        payload = client.fetch(channel, pkg_name.lower())
+        name_lookup = "lowercased"
+    if payload is None:
+        return {"name_lookup": "not_found"}
+
+    grouped = files_by_version(payload)
+    candidates = []
+    for version in sorted_versions(grouped):
+        if threshold and not version_ge(version, threshold):
+            continue
+        candidates.append(describe_version(version, grouped[version]))
+
+    usable = [c for c in candidates if c["arch_ok"]]
+    return {
+        "name_lookup": name_lookup,
+        "resolved_name": payload.get("name", pkg_name),
+        "latest_version": payload.get("latest_version"),
+        "candidates": candidates,
+        "recommended_floor": usable[0]["version"] if usable else None,
+        "arch_ok": bool(usable),
+    }
+
+
+def reverse_scan_candidates(pins, target_name):
+    """Which pinned packages are worth checking for a constraint on `target_name`.
+
+    Scanning all ~88 pinned packages costs a lot of large payloads for little return, so
+    prefer the requirements file that pins the target -- a cap on a Python security lib
+    lives alongside it in baseimage.txt, which is exactly where the `pyopenssl` cap on
+    `cryptography` lives. Fall back to everything when the target isn't pinned at all.
+    """
+    target_lower = target_name.lower()
+    pin = pins.get(target_lower)
+    if pin:
+        same_file = {
+            key: value
+            for key, value in pins.items()
+            if value["file"] == pin["file"] and key != target_lower
+        }
+        if same_file:
+            return same_file, pin["file"]
+    return {k: v for k, v in pins.items() if k != target_lower}, None
+
+
+def find_reverse_constraints(client, candidates, target_name, target_version, errors):
+    """Packages pinned in docker/requirements that constrain `target_name`.
+
+    This is the check that would have caught `pyopenssl <50` blocking `cryptography`
+    50.0.0 without a human noticing it.
+    """
+    findings = []
+    target_lower = target_name.lower()
+    deadline = time.monotonic() + REVERSE_SCAN_BUDGET_SECONDS
+
+    # Warm the cache concurrently: conda-forge first, then bioconda only for the misses.
+    for channel in CHANNELS:
+        pending = [
+            pin["package"]
+            for key, pin in sorted(candidates.items())
+            if client.cached(channel, pin["package"]) is False
+            and not any(
+                client.cached(prior, pin["package"]) for prior in CHANNELS[: CHANNELS.index(channel)]
+            )
+        ]
+        if not pending or time.monotonic() > deadline:
+            continue
+        with concurrent.futures.ThreadPoolExecutor(REVERSE_SCAN_WORKERS) as pool:
+            futures = {
+                pool.submit(
+                    client.fetch,
+                    channel,
+                    name,
+                    timeout=REVERSE_SCAN_TIMEOUT,
+                    retries=1,
+                ): name
+                for name in pending
+            }
+            for future in concurrent.futures.as_completed(
+                futures, timeout=max(1.0, deadline - time.monotonic())
+            ):
+                try:
+                    future.result()
+                except concurrent.futures.TimeoutError:
+                    break
+                except Exception:
+                    pass  # ChannelClient already recorded the error.
+
+    unscanned = []
+    for key, pin in sorted(candidates.items()):
+        for channel in CHANNELS:
+            payload = client.cached(channel, pin["package"])
+            if payload is False:
+                # Never fetched (budget ran out before this one).
+                if pin["package"] not in unscanned:
+                    unscanned.append(pin["package"])
+                continue
+            if payload is None:
+                continue
+
+            grouped = files_by_version(payload)
+            latest = payload.get("latest_version")
+
+            def constraint_for(version):
+                for build in grouped.get(version, []):
+                    for dep in build["depends"]:
+                        parts = dep.split(None, 1)
+                        if parts and parts[0].lower() == target_lower:
+                            return dep, (parts[1].strip() if len(parts) > 1 else "")
+                return None, None
+
+            latest_dep, latest_constraint = constraint_for(latest)
+            if latest_dep is None:
+                break  # This package doesn't depend on the target at all.
+
+            latest_allows = constraint_allows(latest_constraint, target_version)
+
+            # Walk newest-first to find the oldest version that still admits the target,
+            # so we can say "raise the floor to exactly this".
+            ordered = list(reversed(sorted_versions(grouped)))[:MAX_VERSIONS_SCANNED]
+            min_allowing = None
+            for version in ordered:
+                _, constraint = constraint_for(version)
+                if constraint is None:
+                    continue
+                if constraint_allows(constraint, target_version) is True:
+                    min_allowing = version
+                else:
+                    break
+
+            repo_floor = constraint_floor(pin["constraint"])
+            needs_raise = bool(
+                min_allowing and repo_floor and version_gt(min_allowing, repo_floor)
+            ) or bool(min_allowing and not repo_floor)
+
+            if latest_allows is None:
+                errors.append(
+                    "could not parse %s constraint %r on %s"
+                    % (pin["package"], latest_constraint, target_name)
+                )
+
+            findings.append(
+                {
+                    "package": pin["package"],
+                    "channel": channel,
+                    "latest_version": latest,
+                    "constraint_at_latest": latest_dep,
+                    "latest_allows_target": latest_allows,
+                    "min_version_allowing_target": min_allowing,
+                    "repo_file": pin["file"],
+                    "repo_line": pin["line"],
+                    "repo_spec": pin["spec"],
+                    "repo_floor": repo_floor,
+                    "floor_needs_raise": needs_raise,
+                }
+            )
+            break  # Found it in this channel; don't double-report from the other.
+
+    if unscanned:
+        errors.append(
+            "reverse dependency scan for %s was truncated after %ss; %d package(s) not "
+            "checked for a constraint on %s: %s"
+            % (
+                target_name,
+                REVERSE_SCAN_BUDGET_SECONDS,
+                len(unscanned),
+                target_name,
+                ", ".join(unscanned),
+            )
+        )
+
+    return findings
+
+
+# --------------------------------------------------------------------------------------
+# Trivy input
+# --------------------------------------------------------------------------------------
+
+
+def classify_fix_shape(trivy_class, trivy_type):
+    """What kind of fix a finding needs -- not every CVE is a conda floor bump.
+
+    Without this, an Ubuntu `curl` finding whose fix version is `8.14.1-2ubuntu1.4` would
+    be matched against conda-forge's `curl` 8.16.0 and reported as "floor bump verified",
+    which is wrong: an apt package is not fixed by pinning a conda package of the same
+    name. Probing conda for os-pkgs findings is therefore skipped entirely.
+    """
+    if trivy_class == "os-pkgs":
+        return "os-package"
+    if trivy_type == "jar":
+        return "bundled-jar"
+    if trivy_class == "lang-pkgs":
+        return "conda-requirements-pin"
+    return "unknown"
+
+
+def collect_targets(trivy_path, cve_ids, errors):
+    """Resolve each requested CVE ID to its package + fix version(s) from the Trivy JSON."""
+    try:
+        with open(trivy_path, encoding="utf-8") as handle:
+            report = json.load(handle)
+    except (OSError, ValueError) as exc:
+        errors.append("could not read %s: %s" % (trivy_path, exc))
+        return {}
+
+    wanted = {c.upper() for c in cve_ids}
+    targets = {}
+    for result in report.get("Results") or []:
+        for vuln in result.get("Vulnerabilities") or []:
+            cve = (vuln.get("VulnerabilityID") or "").upper()
+            if cve not in wanted:
+                continue
+            pkg = vuln.get("PkgName")
+            if not pkg:
+                continue
+            entry = targets.setdefault(
+                pkg,
+                {
+                    "trivy_pkg_name": pkg,
+                    "cve_ids": [],
+                    "installed_version": vuln.get("InstalledVersion"),
+                    "fixed_versions": [],
+                    "pkg_paths": [],
+                    "trivy_class": result.get("Class"),
+                    "trivy_type": result.get("Type"),
+                    "fix_shape": classify_fix_shape(result.get("Class"), result.get("Type")),
+                    "severities": [],
+                },
+            )
+            if cve not in entry["cve_ids"]:
+                entry["cve_ids"].append(cve)
+            if vuln.get("Severity") and vuln["Severity"] not in entry["severities"]:
+                entry["severities"].append(vuln["Severity"])
+            if vuln.get("PkgPath") and vuln["PkgPath"] not in entry["pkg_paths"]:
+                entry["pkg_paths"].append(vuln["PkgPath"])
+            # Trivy may list several fix branches, e.g. "2.18.8, 2.21.4, 3.1.4".
+            for candidate in (vuln.get("FixedVersion") or "").split(","):
+                candidate = candidate.strip()
+                if candidate and candidate not in entry["fixed_versions"]:
+                    entry["fixed_versions"].append(candidate)
+
+    missing = wanted - {c for e in targets.values() for c in e["cve_ids"]}
+    for cve in sorted(missing):
+        errors.append(
+            "%s not found in %s (test mode, or the scan target has diverged)"
+            % (cve, trivy_path)
+        )
+    return targets
+
+
+# --------------------------------------------------------------------------------------
+# Reporting
+# --------------------------------------------------------------------------------------
+
+
+def summarize(entry):
+    lines = []
+    name = entry["trivy_pkg_name"]
+    cves = ", ".join(entry["cve_ids"])
+    threshold = entry.get("fix_threshold")
+
+    if entry["fix_shape"] == "os-package":
+        return [
+            "%s (%s): Ubuntu OS package (%s -> %s). Fixed by a base-image / apt update, "
+            "NOT by a docker/requirements pin -- conda channels were not queried."
+            % (name, cves, entry.get("installed_version"), ", ".join(entry["fixed_versions"]))
+        ]
+
+    hit = None
+    for channel, data in entry["channels"].items():
+        if data.get("arch_ok") and data.get("recommended_floor"):
+            hit = (channel, data["recommended_floor"])
+            break
+
+    if hit:
+        lines.append(
+            "%s (%s): %s %s is available on %s for linux-64 + linux-aarch64 -> "
+            "floor bump VERIFIED as installable."
+            % (name, cves, name, hit[1], hit[0])
+        )
+    elif any(d.get("name_lookup") != "not_found" for d in entry["channels"].values()):
+        lines.append(
+            "%s (%s): no build >= %s satisfies both linux-64 and linux-aarch64 -> "
+            "treat availability as UNVERIFIED."
+            % (name, cves, threshold)
+        )
+    elif entry["fix_shape"] == "bundled-jar":
+        lines.append(
+            "%s (%s): a dependency bundled inside a fat JAR, not a conda package. Fixed "
+            "only when the upstream tool ships a newer JAR -- see the Java fat-JAR "
+            "section of the container-vulns skill." % (name, cves)
+        )
+    else:
+        lines.append(
+            "%s (%s): not packaged on conda-forge or bioconda under this name -> a "
+            "docker/requirements floor bump does not apply. Check whether it is a "
+            "vendored copy or bundled binary instead." % (name, cves)
+        )
+
+    for con in entry.get("constrained_by") or []:
+        if con["floor_needs_raise"]:
+            lines.append(
+                "  %s pins '%s'; the current pin '%s' (%s:%s) also admits versions that "
+                "exclude %s %s. Raise it to >=%s alongside the bump."
+                % (
+                    con["package"],
+                    con["constraint_at_latest"],
+                    con["repo_spec"],
+                    con["repo_file"],
+                    con["repo_line"],
+                    name,
+                    threshold,
+                    con["min_version_allowing_target"],
+                )
+            )
+        elif con["latest_allows_target"] is False:
+            lines.append(
+                "  %s pins '%s' and NO available version admits %s %s -- a bump would be "
+                "unsolvable until upstream widens the cap."
+                % (con["package"], con["constraint_at_latest"], name, threshold)
+            )
+    return lines
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--trivy-json", required=True)
+    parser.add_argument(
+        "--cve-ids", default="", help="space- and/or comma-separated CVE IDs"
+    )
+    parser.add_argument("--requirements-dir", default="docker/requirements")
+    parser.add_argument("--out", required=True)
+    parser.add_argument(
+        "--no-reverse-scan",
+        action="store_true",
+        help="skip the reverse dependency-constraint scan",
+    )
+    args = parser.parse_args()
+
+    cve_ids = [c for c in re.split(r"[\s,]+", args.cve_ids) if c]
+    errors = []
+    client = ChannelClient(errors)
+
+    targets = collect_targets(args.trivy_json, cve_ids, errors) if cve_ids else {}
+    pins = read_requirements(args.requirements_dir)
+
+    packages = []
+    for pkg_name in sorted(targets):
+        entry = targets[pkg_name]
+        fixes = sorted_versions(entry["fixed_versions"]) if entry["fixed_versions"] else []
+        # Lowest fix branch at or above what's installed is the floor we actually want.
+        installed = entry.get("installed_version")
+        usable_fixes = [
+            f for f in fixes if not installed or version_ge(f, installed)
+        ] or fixes
+        entry["fix_threshold"] = usable_fixes[0] if usable_fixes else None
+
+        pin = pins.get(pkg_name.lower())
+        entry["repo_requirement"] = pin
+
+        entry["channels"] = {}
+        if entry["fix_shape"] != "os-package":
+            for channel in CHANNELS:
+                entry["channels"][channel] = probe_channel(
+                    client, channel, pkg_name, entry["fix_threshold"]
+                )
+
+        entry["constrained_by"] = []
+        entry["reverse_scan_scope"] = None
+        if (
+            not args.no_reverse_scan
+            and entry["fix_threshold"]
+            and entry["fix_shape"] != "os-package"
+        ):
+            candidates, scoped_file = reverse_scan_candidates(pins, pkg_name)
+            entry["reverse_scan_scope"] = {
+                "requirements_file": scoped_file,
+                "packages_considered": len(candidates),
+            }
+            entry["constrained_by"] = find_reverse_constraints(
+                client, candidates, pkg_name, entry["fix_threshold"], errors
+            )
+
+        packages.append(entry)
+
+    summary = []
+    for entry in packages:
+        summary.extend(summarize(entry))
+    if not packages:
+        summary.append("No packages resolved from the requested CVE IDs.")
+
+    report = {
+        "trivy_json": args.trivy_json,
+        "requested_cve_ids": cve_ids,
+        "channels_queried": list(CHANNELS),
+        "required_subdirs": list(REQUIRED_SUBDIRS),
+        "python_build_tag": PYTHON_TAG,
+        "summary": summary,
+        "packages": packages,
+        "probe_errors": errors,
+    }
+
+    out_dir = os.path.dirname(args.out)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as handle:
+        json.dump(report, handle, indent=2, sort_keys=False)
+        handle.write("\n")
+
+    print("Wrote %s" % args.out)
+    for line in summary:
+        print("  " + line)
+    for err in errors:
+        print("  probe_error: %s" % err, file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/probe-conda-availability.py
+++ b/.github/scripts/probe-conda-availability.py
@@ -254,6 +254,20 @@ def read_requirements(requirements_dir):
 # --------------------------------------------------------------------------------------
 
 
+# Three distinct outcomes have to stay distinguishable, because conflating the last two
+# would make the probe assert something false:
+#   dict          -- the package exists in this channel
+#   None          -- HTTP 404: the package genuinely is not in this channel
+#   FETCH_FAILED  -- timeout / 5xx / malformed JSON: we do not know either way
+# Reporting a failed lookup as "not packaged on conda-forge" would tell the agent a floor
+# bump does not apply when in fact nothing was checked.
+FETCH_FAILED = object()
+
+# Sentinel for "this (channel, name) has never been fetched", distinct from all three
+# outcomes above so the reverse scan can tell "not looked up" from "looked up, absent".
+NOT_CACHED = object()
+
+
 class ChannelClient:
     """Tiny cached client for the anaconda.org package API."""
 
@@ -266,7 +280,7 @@ class ChannelClient:
 
     def cached(self, channel, name):
         with self._lock:
-            return self._cache.get((channel, name.lower()), False)
+            return self._cache.get((channel, name.lower()), NOT_CACHED)
 
     def fetch(self, channel, name, timeout=None, retries=None):
         key = (channel, name.lower())
@@ -290,18 +304,20 @@ class ChannelClient:
                 if exc.code in (429, 500, 502, 503, 504) and attempt < retries:
                     time.sleep(2 * attempt)
                     continue
+                result = FETCH_FAILED
                 self._errors.append(
-                    "HTTP %s fetching %s/%s" % (exc.code, channel, name)
+                    "HTTP %s fetching %s/%s -- NOT checked; nothing may be claimed "
+                    "about it" % (exc.code, channel, name)
                 )
                 break
             except Exception as exc:  # network error, malformed JSON, ...
                 if attempt < retries:
                     time.sleep(2 * attempt)
                     continue
+                result = FETCH_FAILED
                 self._errors.append(
-                    "%s fetching %s/%s: %s -- this package was NOT checked; treat any "
-                    "claim about it as unverified"
-                    % (type(exc).__name__, channel, name, exc)
+                    "%s fetching %s/%s: %s -- NOT checked; nothing may be claimed "
+                    "about it" % (type(exc).__name__, channel, name, exc)
                 )
                 break
 
@@ -358,6 +374,9 @@ def probe_channel(client, channel, pkg_name, threshold):
     if payload is None and pkg_name != pkg_name.lower():
         payload = client.fetch(channel, pkg_name.lower())
         name_lookup = "lowercased"
+    if payload is FETCH_FAILED:
+        # NOT the same as "not in this channel" -- we learned nothing. See probe_errors.
+        return {"name_lookup": "probe_failed", "arch_ok": None}
     if payload is None:
         return {"name_lookup": "not_found"}
 
@@ -415,9 +434,11 @@ def find_reverse_constraints(client, candidates, target_name, target_version, er
         pending = [
             pin["package"]
             for key, pin in sorted(candidates.items())
-            if client.cached(channel, pin["package"]) is False
+            if client.cached(channel, pin["package"]) is NOT_CACHED
+            # Skip if an earlier channel already resolved it to a real payload.
             and not any(
-                client.cached(prior, pin["package"]) for prior in CHANNELS[: CHANNELS.index(channel)]
+                isinstance(client.cached(prior, pin["package"]), dict)
+                for prior in CHANNELS[: CHANNELS.index(channel)]
             )
         ]
         if not pending or time.monotonic() > deadline:
@@ -447,8 +468,9 @@ def find_reverse_constraints(client, candidates, target_name, target_version, er
     for key, pin in sorted(candidates.items()):
         for channel in CHANNELS:
             payload = client.cached(channel, pin["package"])
-            if payload is False:
-                # Never fetched (budget ran out before this one).
+            if payload is NOT_CACHED or payload is FETCH_FAILED:
+                # Budget ran out before this one, or the lookup failed. Either way we
+                # cannot say whether it constrains the target -- report, don't assume.
                 if pin["package"] not in unscanned:
                     unscanned.append(pin["package"])
                 continue
@@ -515,8 +537,8 @@ def find_reverse_constraints(client, candidates, target_name, target_version, er
 
     if unscanned:
         errors.append(
-            "reverse dependency scan for %s was truncated after %ss; %d package(s) not "
-            "checked for a constraint on %s: %s"
+            "reverse dependency scan for %s is INCOMPLETE (budget %ss); %d package(s) "
+            "were not checked for a constraint on %s: %s"
             % (
                 target_name,
                 REVERSE_SCAN_BUDGET_SECONDS,
@@ -635,7 +657,15 @@ def summarize(entry):
             "floor bump VERIFIED as installable."
             % (name, cves, name, hit[1], hit[0])
         )
-    elif any(d.get("name_lookup") != "not_found" for d in entry["channels"].values()):
+    elif any(
+        d.get("name_lookup") == "probe_failed" for d in entry["channels"].values()
+    ):
+        lines.append(
+            "%s (%s): the channel lookup FAILED (see probe_errors) -- nothing was "
+            "checked. Do NOT conclude anything about availability from this entry; "
+            "verify it yourself before acting." % (name, cves)
+        )
+    elif any(d.get("name_lookup") not in ("not_found", "probe_failed") for d in entry["channels"].values()):
         lines.append(
             "%s (%s): no build >= %s satisfies both linux-64 and linux-aarch64 -> "
             "treat availability as UNVERIFIED."
@@ -715,19 +745,27 @@ def main():
         pin = pins.get(pkg_name.lower())
         entry["repo_requirement"] = pin
 
+        # Don't query conda for findings a conda package could never match: an Ubuntu apt
+        # package, or a Maven coordinate bundled in a fat JAR
+        # (`com.fasterxml.jackson.core:jackson-databind` is not a conda package name).
         entry["channels"] = {}
-        if entry["fix_shape"] != "os-package":
+        if entry["fix_shape"] not in ("os-package", "bundled-jar"):
             for channel in CHANNELS:
                 entry["channels"][channel] = probe_channel(
                     client, channel, pkg_name, entry["fix_threshold"]
                 )
 
+        # The reverse scan is the expensive half (up to ~88 package payloads), so it is
+        # restricted to findings a requirements floor bump can actually fix. Without this,
+        # a single fat-JAR CVE would fetch every pinned package to look for a dependency
+        # on a Maven coordinate that no conda package declares -- burning the budget and
+        # manufacturing timeout errors.
         entry["constrained_by"] = []
         entry["reverse_scan_scope"] = None
         if (
             not args.no_reverse_scan
             and entry["fix_threshold"]
-            and entry["fix_shape"] != "os-package"
+            and entry["fix_shape"] == "conda-requirements-pin"
         ):
             candidates, scoped_file = reverse_scan_candidates(pins, pkg_name)
             entry["reverse_scan_scope"] = {

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -599,16 +599,22 @@ jobs:
           # anyone can comment — filter to maintainers HERE, not in the prompt. An
           # unfiltered comments array is a direct untrusted-instruction channel into an
           # agent that edits files and opens PRs; a prompt instruction is not a control.
+          # `// []` guards against a null/absent comments field (gh returns [] today, but
+          # `.comments[]` on null would abort this step under `set -e`).
           gh issue list --repo "$GITHUB_REPOSITORY" \
             --label cve --state open \
             --json number,title,body,labels,comments --limit 100 \
           | jq '[ .[]
-                  | .comments = [ .comments[]
+                  | .comments = [ (.comments // [])[]
                       | select(.authorAssociation == "OWNER"
                                or .authorAssociation == "MEMBER"
                                or .authorAssociation == "COLLABORATOR")
                       | {author: .author.login, authorAssociation, createdAt, body} ] ]' \
             > .cve-fix-context/open-issues.json
+          # Log what the filter kept vs dropped. Maintainer comments now steer the fix, so
+          # silently losing them would be worse than the crash the guard above prevents.
+          kept=$(jq '[.[].comments | length] | add // 0' .cve-fix-context/open-issues.json)
+          echo "::notice::Retained $kept maintainer comment(s) across open cve issues"
           gh pr list --repo "$GITHUB_REPOSITORY" \
             --label cve-fix --state open \
             --json number,title,headRefName,body --limit 50 \
@@ -802,9 +808,10 @@ jobs:
             `recommended_floor`, availability is **VERIFIED** — do not treat it
             as an open question, and do not skip on the grounds that you cannot
             reach the network yourself. Availability is unverified only when the
-            probe reports `name_lookup: not_found` or lists the package in
-            `probe_errors`. Remember to apply any `constrained_by` floor raise in
-            the same commit.
+            probe reports `name_lookup: not_found`, `name_lookup: probe_failed`
+            (the lookup itself errored — nothing was checked), or lists the
+            package in `probe_errors`. Remember to apply any `constrained_by`
+            floor raise in the same commit.
 
             **(b) Inline Dockerfile mitigation that mirrors an exact precedent
             commit.** You must cite the precedent SHA in your PR body. The

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -194,6 +194,27 @@ jobs:
           echo "cve_ids=$new_list" >> "$GITHUB_OUTPUT"
           echo "test_mode=false" >> "$GITHUB_OUTPUT"
 
+      # Answer "is the fix version actually installable?" deterministically, before
+      # Claude runs. Claude has web access below and could look this up itself, but doing
+      # it here makes the answer identical run-to-run, costs the agent no turns, and
+      # archives it as an artifact for audit.
+      - name: Probe conda channel availability for fix versions
+        if: steps.triage.outputs.cve_ids != ''
+        env:
+          CVE_IDS: ${{ steps.triage.outputs.cve_ids }}
+        run: |
+          set -uo pipefail
+          # Fail soft: a broken probe should be loudly visible but must not stop CVE
+          # issues from being filed. The prompt tells Claude to fall back to its own
+          # lookups when the file is missing or incomplete.
+          if ! python3 .github/scripts/probe-conda-availability.py \
+              --trivy-json trivy-results.json \
+              --cve-ids "$CVE_IDS" \
+              --requirements-dir docker/requirements \
+              --out .cve-fix-context/conda-availability.json; then
+            echo "::error::conda availability probe failed — triage will proceed without it"
+          fi
+
       - name: Authenticate to GCP via Workload Identity Federation
         if: steps.triage.outputs.cve_ids != ''
         uses: google-github-actions/auth@v3
@@ -229,12 +250,28 @@ jobs:
           use_vertex: 'true'
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: '--model claude-sonnet-5 --max-turns 30'
+          # WebSearch + WebFetch are allowed here: this agent has no Edit permission, its
+          # only output is .md files that a later step files as issues for humans to read,
+          # and it cannot push. Being able to read the actual GHSA/NVD advisory is what
+          # keeps reports from hedging on facts it could simply look up.
           settings: |
             {
               "permissions": {
                 "allow": [
                   "Read",
                   "Write",
+                  "WebSearch",
+                  "WebFetch(domain:github.com)",
+                  "WebFetch(domain:raw.githubusercontent.com)",
+                  "WebFetch(domain:api.anaconda.org)",
+                  "WebFetch(domain:anaconda.org)",
+                  "WebFetch(domain:nvd.nist.gov)",
+                  "WebFetch(domain:avd.aquasec.com)",
+                  "WebFetch(domain:cve.org)",
+                  "WebFetch(domain:www.cve.org)",
+                  "WebFetch(domain:pypi.org)",
+                  "WebFetch(domain:bioconda.github.io)",
+                  "WebFetch(domain:conda-forge.org)",
                   "Bash(mkdir:*)",
                   "Bash(git log:*)",
                   "Bash(git show:*)",
@@ -285,20 +322,33 @@ jobs:
                own knowledge if the CVE is present in the JSON. If the CVE is NOT in the
                JSON (test mode, or scan-target divergence), explicitly say so in the report
                and use your training knowledge as a clearly-labeled fallback.
-            2. `.agents/skills/container-vulns/SKILL.md` — read fully. This is the repo's
+            2. `.cve-fix-context/conda-availability.json` — **the authoritative answer to
+               "is the fix version installable?"** Pre-computed against the conda-forge and
+               bioconda APIs before you started. Read its `summary` array first, then the
+               per-package detail. It tells you, per affected package: whether the fixed
+               version exists on a conda channel, whether it is built for BOTH `linux-64`
+               and `linux-aarch64` (or is `noarch`), whether the finding is even the shape
+               a requirements pin can fix (`fix_shape`: an Ubuntu `os-package` or a
+               `bundled-jar` is not), and which other pinned packages carry a constraint
+               that would exclude the fix version (`constrained_by` — e.g. `pyopenssl`
+               capping `cryptography`). Cite it rather than hedging about availability. If
+               a package appears in `probe_errors`, or the file is absent entirely (the
+               probe failed — the workflow logs an error), say so explicitly and use your
+               web tools to check it yourself.
+            3. `.agents/skills/container-vulns/SKILL.md` — read fully. This is the repo's
                container-vulnerability playbook and tells you what the maintainers consider
                actionable vs. accepted risk.
-            3. `.trivyignore` — existing per-CVE exceptions with their justifications. Mirror
+            4. `.trivyignore` — existing per-CVE exceptions with their justifications. Mirror
                the writing style and depth of justification when you recommend `.trivyignore`
                additions.
-            4. `.trivy-ignore-policy.rego` — Rego policy for class-level CVE filtering.
+            5. `.trivy-ignore-policy.rego` — Rego policy for class-level CVE filtering.
                Understand what it filters and why.
-            5. `docker/Dockerfile.*` — container build files showing dep installs and inline
+            6. `docker/Dockerfile.*` — container build files showing dep installs and inline
                mitigations. Look for prior fixups (`find ... -exec rm`, `gem install`, etc.)
                applied to similar packages.
-            6. `docker/requirements/*.txt` — conda dependency lists. Use `grep` to find
+            7. `docker/requirements/*.txt` — conda dependency lists. Use `grep` to find
                which file pulls in the affected package.
-            7. Recent git history — full history is available (the workflow checks out
+            8. Recent git history — full history is available (the workflow checks out
                with `fetch-depth: 0`). Use:
                  - `git log --all --oneline --grep <package>` to find prior commits
                    touching the affected package
@@ -415,6 +465,15 @@ jobs:
           if-no-files-found: warn
           include-hidden-files: true
 
+      - name: Upload conda availability probe as artifact
+        if: steps.triage.outputs.cve_ids != '' && always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: conda-availability-scan
+          path: .cve-fix-context/conda-availability.json
+          if-no-files-found: warn
+          include-hidden-files: true
+
       - name: Summarize CVE discovery
         # Notice-level only — we do NOT exit 1 here. New CVE discovery is the
         # expected outcome of a useful scan, not a workflow failure: notifications
@@ -481,11 +540,10 @@ jobs:
       #   AUTOFIX_APP_ID          — numeric App ID
       #   AUTOFIX_APP_PRIVATE_KEY — full .pem contents (BEGIN/END lines included)
       #
-      # This step runs BEFORE checkout so the App token can be passed to
-      # actions/checkout via `token:`, which persists it in the local git
-      # config for the subsequent `git push`. (Without that, git push would
-      # silently fall back to the cached default GITHUB_TOKEN, defeating the
-      # whole point of using the App.)
+      # NOTE: the token is deliberately NOT persisted into .git/config by the
+      # checkout below — see the `persist-credentials: false` comment there. The
+      # authenticated push remote is configured in "Open auto-fix PR" instead,
+      # after the Claude step has finished running.
       - name: Mint GitHub App installation token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
@@ -509,9 +567,14 @@ jobs:
           # CVE-fix commits — required to satisfy the moderate confidence bar
           # (mirror an exact precedent or skip).
           fetch-depth: 0
-          # Persist the App token in .git/config so `git push` later in the
-          # job authenticates as the App, not the default GITHUB_TOKEN.
           token: ${{ steps.app-token.outputs.token }}
+          # Do NOT write the App installation token into .git/config. The Claude
+          # step below can Read any file in the workspace and has WebFetch, so an
+          # on-disk token (contents:write + pull-requests:write, 1h lifetime)
+          # would be both readable and exfiltratable via a crafted URL. The
+          # "Open auto-fix PR" step sets an authenticated push remote instead,
+          # after the agent has finished.
+          persist-credentials: false
 
       - name: Configure git author
         run: |
@@ -531,9 +594,20 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p .cve-fix-context
+          # Include issue comments so maintainers can steer the bot by commenting on the
+          # issue (e.g. "also raise the pyopenssl floor"). viral-ngs is a PUBLIC repo, so
+          # anyone can comment — filter to maintainers HERE, not in the prompt. An
+          # unfiltered comments array is a direct untrusted-instruction channel into an
+          # agent that edits files and opens PRs; a prompt instruction is not a control.
           gh issue list --repo "$GITHUB_REPOSITORY" \
             --label cve --state open \
-            --json number,title,body,labels --limit 100 \
+            --json number,title,body,labels,comments --limit 100 \
+          | jq '[ .[]
+                  | .comments = [ .comments[]
+                      | select(.authorAssociation == "OWNER"
+                               or .authorAssociation == "MEMBER"
+                               or .authorAssociation == "COLLABORATOR")
+                      | {author: .author.login, authorAssociation, createdAt, body} ] ]' \
             > .cve-fix-context/open-issues.json
           gh pr list --repo "$GITHUB_REPOSITORY" \
             --label cve-fix --state open \
@@ -547,6 +621,26 @@ jobs:
         if: steps.context.outputs.issue_count == '0'
         run: |
           echo "::notice::No open cve issues — nothing for the auto-fix pipeline to do."
+
+      # Pre-compute conda channel/arch availability for every CVE under consideration.
+      # Before this existed the agent had no way to check it and skipped every
+      # version-floor bump as unverifiable — see the SKIPPED.md decision logs from runs
+      # 29883237168 and 30898278357.
+      - name: Probe conda channel availability for fix versions
+        if: steps.context.outputs.issue_count != '0'
+        run: |
+          set -uo pipefail
+          cve_ids=$(jq -r '[.[].title | scan("CVE-[0-9]{4}-[0-9]+")] | unique | join(" ")' \
+            .cve-fix-context/open-issues.json)
+          echo "::notice::Probing conda availability for: ${cve_ids:-<none>}"
+          # Fail soft, loudly — see the matching step in the scan job.
+          if ! python3 .github/scripts/probe-conda-availability.py \
+              --trivy-json trivy-results.json \
+              --cve-ids "$cve_ids" \
+              --requirements-dir docker/requirements \
+              --out .cve-fix-context/conda-availability.json; then
+            echo "::error::conda availability probe failed — the assessment will proceed without it"
+          fi
 
       - name: Authenticate to GCP via Workload Identity Federation
         if: steps.context.outputs.issue_count != '0'
@@ -567,7 +661,15 @@ jobs:
         with:
           use_vertex: 'true'
           github_token: ${{ steps.app-token.outputs.token }}
-          claude_args: '--model claude-sonnet-5 --max-turns 30'
+          # 40 turns, not 30: web lookups cost turns, and an agent that exhausts its
+          # budget writes neither PROCEED.md nor SKIPPED.md, which hard-fails the
+          # "Validate Claude output" step below.
+          claude_args: '--model claude-sonnet-5 --max-turns 40'
+          # Domain-scoped WebFetch only — no WebSearch. Unlike the triage agent, this one
+          # has Edit and its output is committed and pushed, so the one channel whose
+          # content an attacker can steer (search results) stays closed. Its actual
+          # questions are already answered by conda-availability.json, trivy-results.json
+          # and git history; WebFetch covers the advisory lookups those don't.
           settings: |
             {
               "permissions": {
@@ -575,6 +677,13 @@ jobs:
                   "Read",
                   "Write",
                   "Edit",
+                  "WebFetch(domain:github.com)",
+                  "WebFetch(domain:raw.githubusercontent.com)",
+                  "WebFetch(domain:api.anaconda.org)",
+                  "WebFetch(domain:anaconda.org)",
+                  "WebFetch(domain:nvd.nist.gov)",
+                  "WebFetch(domain:avd.aquasec.com)",
+                  "WebFetch(domain:pypi.org)",
                   "Bash(mkdir:*)",
                   "Bash(git log:*)",
                   "Bash(git show:*)",
@@ -613,14 +722,46 @@ jobs:
             ## Inputs
 
             1. `.cve-fix-context/open-issues.json` — every open issue with the
-               `cve` label. Each entry has `number`, `title`, `body`, `labels`.
-               The `body` contains the original triage report (CVSS, dependency
-               chain, recommended fix, etc.).
+               `cve` label. Each entry has `number`, `title`, `body`, `labels`,
+               `comments`. The `body` contains the original triage report (CVSS,
+               dependency chain, recommended fix, etc.).
             2. `.cve-fix-context/open-fix-prs.json` — every open PR with the
                `cve-fix` label (prior auto-fix runs whose PRs haven't merged yet).
             3. `trivy-results.json` — the most recent scan output containing ALL
                vulnerabilities (CRITICAL/HIGH/MEDIUM, fixable and non-fixable). Use `jq`
                to cross-reference CVSS data or confirm a CVE is still flagged.
+            4. `.cve-fix-context/conda-availability.json` — **the authoritative
+               answer to "is this fix version installable?"**, pre-computed
+               against the conda-forge and bioconda APIs before you started.
+               Read its `summary` array first, then the per-package detail:
+                 - `channels.*.recommended_floor` / `arch_ok` — the lowest fixed
+                   version built for BOTH `linux-64` and `linux-aarch64` (or
+                   `noarch`). This is the floor to pin.
+                 - `fix_shape` — whether a requirements pin can fix this finding
+                   at all. `os-package` (Ubuntu/apt) and `bundled-jar` cannot.
+                 - `constrained_by` — other packages pinned in
+                   `docker/requirements/*.txt` whose own dependency constraints
+                   would exclude the fix version. Where `floor_needs_raise` is
+                   true you MUST raise that package's floor to
+                   `min_version_allowing_target` in the same commit, or the
+                   environment will not solve.
+                 - `probe_errors` — anything the probe could not check. Only
+                   these are genuinely unverified; use WebFetch on
+                   `api.anaconda.org` to check them yourself.
+               If this file is absent entirely the probe failed (the workflow logs
+               an error): fall back to WebFetch on
+               `https://api.anaconda.org/package/conda-forge/<pkg>` and say in the
+               PR body that you verified availability yourself.
+
+            ## Maintainer guidance in issue comments
+
+            The `comments` array on each issue has already been filtered to repo
+            maintainers (OWNER / MEMBER / COLLABORATOR). Those comments are
+            **authoritative and outrank the issue body** — the body was generated
+            by an earlier automated triage pass, the comments are human review.
+            If a maintainer comment specifies, amends or narrows the fix,
+            implement it as specified and cite the comment in the per-CVE
+            rationale of your PR body.
 
             ## Required reading
 
@@ -656,8 +797,14 @@ jobs:
             **(a) Version-floor bump in `docker/requirements/*.txt`.** Direct
             edit to a requirements file pinning the affected package to a
             patched minimum. Verify the fix version against `trivy-results.json`
-            (the `FixedVersion` field) and ensure the package is available on
-            conda-forge (it often lags PyPI — flag this if unsure).
+            (the `FixedVersion` field) and its installability against
+            `conda-availability.json`. Where that file reports `arch_ok` with a
+            `recommended_floor`, availability is **VERIFIED** — do not treat it
+            as an open question, and do not skip on the grounds that you cannot
+            reach the network yourself. Availability is unverified only when the
+            probe reports `name_lookup: not_found` or lists the package in
+            `probe_errors`. Remember to apply any `constrained_by` floor raise in
+            the same commit.
 
             **(b) Inline Dockerfile mitigation that mirrors an exact precedent
             commit.** You must cite the precedent SHA in your PR body. The
@@ -673,13 +820,32 @@ jobs:
             **If ANY open CVE issue requires:**
             - a novel mitigation pattern with no precedent,
             - a `.trivyignore` justification not mirrored by existing entries,
-            - an ARM64 solver-conflict workaround,
+            - a workaround for a *known* ARM64 solver conflict (pinning around
+              the icu / openjdk / htslib / libdeflate chains described in the
+              skill's ARM64 section),
             - a Java fat-JAR version bump,
             - any judgment call where you're uncertain,
 
             **→ then SKIP the entire PR.** Partial PRs are not allowed: it is
             all-of-them-cleanly or none. The SKIPPED.md log will tell humans
             exactly what needs their attention.
+
+            ## What CI verifies for you — do NOT skip for these reasons
+
+            The PR you open is built and tested by `docker.yml` before any human
+            can merge it: all six image tiers (baseimage, core, assemble,
+            classify, phylo, mega) are built for **both `linux/amd64` and native
+            `linux/arm64`** (`ubuntu-24.04-arm` runners), and each is re-scanned
+            by Trivy with the CI gate enabled. A conda solver conflict introduced
+            by a version-floor bump therefore turns into a red required check on
+            an unmerged PR — it cannot reach `main`.
+
+            So: unproven-but-plausible solvability is **not** grounds for SKIP.
+            Do not pre-verify what CI verifies. **Reserve SKIP for cases where
+            you cannot determine _what_ the fix should be — not cases where you
+            cannot prove the fix works.** The cost of a wrong guess here is one
+            red check that a human reads; the cost of a reflexive skip is that
+            nothing ever gets fixed automatically.
 
             ## Dedup against in-flight auto-fix PRs
 
@@ -714,6 +880,10 @@ jobs:
             - **Fix:** <one-line description: e.g. "pin urllib3>=2.7.0 in baseimage.txt">
             - **Precedent:** <commit SHA + one-line description, verified with git show>
             - **Confidence:** <one of: version-bump | dockerfile-precedent | trivyignore-precedent>
+            - **Availability:** <from conda-availability.json: channel, version, subdirs —
+              e.g. "conda-forge 50.0.0, linux-64 + linux-aarch64 (py312)">
+            - **Coupled bumps:** <any `constrained_by` floor raises applied, or "none">
+            - **Maintainer guidance:** <cite any maintainer comment you followed, or "none">
 
             <repeat per CVE>
 
@@ -777,8 +947,12 @@ jobs:
               `.cve-fix-context/`.
             - Verify every commit SHA you cite with `git show <sha>`.
             - Verify every `FixedVersion` you cite against `trivy-results.json`.
-            - When uncertain, choose SKIP. The cost of a skip is a small
-              artifact upload; the cost of a bad PR is reviewer trust.
+            - Your edits must stay within `docker/requirements/*.txt`,
+              `docker/Dockerfile.*` and `.trivyignore`. This is enforced by the
+              workflow, which aborts if the staged diff touches anything else.
+            - When uncertain about *what the fix is*, choose SKIP. Do NOT skip
+              merely because you could not prove a fix works — see "What CI
+              verifies for you" above.
             - If you finish with budget remaining, do NOT pad — stop.
 
       - name: Validate Claude output and decide next step
@@ -831,6 +1005,18 @@ jobs:
           # pathspec matches a gitignored path, which kills this step under `set -e`.
           # trivy-results.json is NOT gitignored, so it still needs the explicit exclude.
           git add -A -- ':!trivy-results.json'
+          # Enforce the change surface. The prompt asks the agent to stay out of
+          # .github/workflows/ etc., but `git add -A` would commit whatever it wrote —
+          # a prompt instruction is a request, not a control. Anything outside the
+          # requirements files, the Dockerfiles and .trivyignore is a hard stop.
+          disallowed=$(git diff --cached --name-only \
+            | grep -vE '^(docker/requirements/[A-Za-z0-9_.-]+\.txt|docker/Dockerfile\.[A-Za-z0-9_.-]+|\.trivyignore)$' \
+            || true)
+          if [ -n "$disallowed" ]; then
+            echo "::error::Auto-fix diff touches files outside the allowed change surface — refusing to open a PR"
+            echo "$disallowed" | sed 's/^/  /'
+            exit 1
+          fi
           # Scan staged diff for secrets before committing (defence-in-depth).
           # gitleaks is installed by the "Install gitleaks" step above (it is NOT
           # pre-installed on GitHub-hosted ubuntu-latest runners).
@@ -840,6 +1026,12 @@ jobs:
             exit 1
           fi
           git commit -m "Auto-fix: address open CVE issues (run ${GITHUB_RUN_ID})"
+          # Checkout ran with persist-credentials:false so the App token was never on
+          # disk while the agent ran. Attach it now, after the agent is done, so the
+          # push is authored by the App (which is what makes downstream required checks
+          # fire on the PR — the default GITHUB_TOKEN would not trigger them).
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push -u origin "$branch"
           gh pr create \
             --repo "$GITHUB_REPOSITORY" \
@@ -848,6 +1040,15 @@ jobs:
             --title "Auto-fix: address open CVE issues ($(date -u +%Y-%m-%d))" \
             --body-file .claude-fix-pr/PROCEED.md \
             --label cve-fix --label security
+
+      - name: Upload conda availability probe as artifact
+        if: always() && steps.context.outputs.issue_count != '0'
+        uses: actions/upload-artifact@v6
+        with:
+          name: conda-availability-fix
+          path: .cve-fix-context/conda-availability.json
+          if-no-files-found: warn
+          include-hidden-files: true
 
       - name: Upload decision log (skip case)
         if: always() && steps.decide.outputs.decision == 'skip'


### PR DESCRIPTION
## Why

This morning's scheduled scan filed #1107 (`CVE-2026-69247`, `cryptography` 49.0.0 → 50.0.0) and then the `cve-fix-pr` job **skipped** it. The skip wasn't a judgment call about the CVE — it was structural, and recurring:

- The confidence bar for category (a), the version-floor bump, requires the agent to check conda-forge availability and ARM64 resolution.
- The agent's permission allow-list contained **no network tool at all** — no `WebFetch`, no `WebSearch`, no `curl`.
- Combined with *"when uncertain, choose SKIP"*, every floor bump was unverifiable and therefore auto-skipped. Category (a) — the pipeline's primary use case — was effectively dead code.

Same root cause on 2026-07-22 (run `29883237168`, the Pillow CVEs: *"no way to verify resolution ... in this environment"*). The last bot-authored PR was #1099 on 2026-06-24; #1105 and #1106 were both fixed by hand.

Two facts the agent was never told, both of which make its caution unnecessary:

1. `cryptography` 50.0.0 **is** on conda-forge for `linux-64` and `linux-aarch64` with py312 builds (published 2026-08-02). Nothing was blocked; it just couldn't look.
2. `docker.yml` builds **native arm64** for all six tiers on every PR and re-scans each with Trivy. A solver conflict from a floor bump fails required checks *before* merge — the agent was pre-verifying something CI already verifies, at the cost of never shipping.

## What changed

**`.github/scripts/probe-conda-availability.py`** (new) — runs before both Claude steps and writes `.cve-fix-context/conda-availability.json`. Per affected package:

- does the Trivy `FixedVersion` exist on conda-forge / bioconda, and is it built for **both** `linux-64` and `linux-aarch64` (or `noarch`)?
- `fix_shape`: can a requirements pin fix this finding at all? An Ubuntu `os-package` and a `bundled-jar` dependency cannot. Without this the probe would have matched an Ubuntu `curl` finding (`8.14.1-2ubuntu1.4`) against conda-forge's `curl` 8.16.0 and reported "verified".
- `constrained_by`: which other pinned packages carry a constraint that would exclude the fix version.

Uploaded as an artifact; fails soft but logs an `::error::`.

**Prompt / bar fixes** — the availability file is authoritative, `docker.yml`'s arm64 coverage is stated explicitly, and: *reserve SKIP for cases where you cannot determine **what** the fix should be, not cases where you cannot prove the fix works.*

**Web access** — `WebSearch` + domain-scoped `WebFetch` for the triage agent (no `Edit`, cannot push); domain-scoped `WebFetch` only for the auto-fix agent, whose output is committed and pushed.

**Maintainer comments reach the bot** — the context step dropped `comments`, so a maintainer note on an issue was invisible (#1092 already carries exactly such a note). Now included and **hard-filtered to `OWNER`/`MEMBER`/`COLLABORATOR` in the `jq`** — this is a public repo, so an unfiltered comments array is an untrusted-instruction channel into an agent that edits files and opens PRs. A prompt instruction is not a control.

**Guardrails**

- Path allowlist on the staged diff (`docker/requirements/*.txt`, `docker/Dockerfile.*`, `.trivyignore`). The prompt already asked the agent to stay out of `.github/workflows/`; `git add -A` would have committed it anyway.
- App token no longer sits in `.git/config` while the agent runs (`persist-credentials: false`; push remote attached afterwards). `Read` is allowed, so with `WebFetch` an on-disk token would be readable *and* exfiltratable.
- `--max-turns` 30 → 40: an exhausted agent writes neither `PROCEED.md` nor `SKIPPED.md`, which hard-fails the validation step.

## Verification

Probe run locally against the real `trivy-results.json` from run `30898278357`:

```
cryptography (CVE-2026-69247): cryptography 50.0.0 is available on conda-forge
  for linux-64 + linux-aarch64 -> floor bump VERIFIED as installable.
  pyopenssl pins 'cryptography >=49.0.0,<51'; the current pin 'pyopenssl>=26.0.0'
  (docker/requirements/baseimage.txt:21) also admits versions that exclude
  cryptography 50.0.0. Raise it to >=26.4.0 alongside the bump.
```

It independently found the `pyopenssl 26.3.0 → cryptography <50` cap — the coupling that a naive one-line bump would have tripped over. Also exercised: Java fat-JAR coordinates, Ubuntu OS packages, a CVE absent from the JSON (test mode), and the jq filters + allowlist gate against real API data. 16 s wall clock.

**Deliberately does not include the `cryptography` fix itself.** After this merges, `gh workflow run container-scan.yml -f force_fix_pr=true` should have the bot produce that PR on its own — which is the real end-to-end test.

## Blocked by two pre-existing CVE findings (neither from this PR)

`scan-containers (mega)` is a **required** check and it currently has two gating findings, so this PR cannot go green on its own:

| CVE | Package | Tier | Note |
|---|---|---|---|
| CVE-2026-69247 | `cryptography` 49.0.0 → 50.0.0 | all six | This is #1107 — the CVE this PR exists to let the bot fix. Present because the `baseimage` conda layer was served from registry cache (`ImageCreated: 2026-07-23`), so 49.0.0 is still baked in. This PR touches no requirements file, so the layer hash is unchanged. |
| CVE-2025-47273 | `setuptools` 70.3.0 → 78.1.1 | `assemble` + `mega` only | Source not yet identified. |

Any PR that doesn't touch `docker/requirements/` will hit the first one, so this is a repo-wide gate issue rather than something specific to this branch.

**Correction to an earlier version of this description:** I attributed the `setuptools` finding to the unpinned isolated FreeBayes env. That is wrong. A dry-run solve of `python=3.12` + `freebayes>=1.3.6` against conda-forge/bioconda picks **setuptools 83.0.0**, and a reverse-constraint scan of all 14 packages in `assemble.txt` / `assemble-x86.txt` / `freebayes.txt` found *no* package declaring any constraint on `setuptools`. So nothing is pinning it down.

What is known:

- It is confined to `assemble` and `mega`; `baseimage`, `core`, `classify` and `phylo` were all built fresh today (2026-08-04) and show only the `cryptography` finding.
- `baseimage.txt` pins `setuptools>=80.10.1` and `install-conda-deps.sh` resolves all requirements files in a single solver call, so the main env cannot hold 70.3.0 — it would surface as a solver conflict instead.
- Trivy reports it with `PkgPath: null` and `PURL pkg:pypi/setuptools@70.3.0`, which fits the "vendored copies" category in the container-vulns skill (a `setuptools-70.3.0.dist-info` shipped inside some tool's own directory) rather than an environment package.
- The published 2026-07-23 `mega` image does *not* have it, and today's build of the same commit does — so it arrived via a conda-forge repodata change in the last ~12 days.

If that reading is right the fix is an inline Dockerfile removal (the documented precedent pattern), not a version pin — which is precisely the kind of judgment call the auto-fix bot should SKIP on. Confirming it needs a look inside the built `assemble` image. Tracking separately; not in scope here.
